### PR TITLE
Fix type hint

### DIFF
--- a/ansible_events/engine.py
+++ b/ansible_events/engine.py
@@ -201,7 +201,7 @@ async def call_action(
 
 
 async def run_rulesets(
-    event_log: Queue,
+    event_log: asyncio.Queue,
     ruleset_queues: List[RuleSetQueue],
     variables: Dict,
     inventory: Dict,


### PR DESCRIPTION
The `run_rulesets` function expects that the `event_log` parameter
is an asynchronous queue instance. But `queue.Queue` is used as
a type hint.