### PR TITLE
Start a new plan queue for each event

### DIFF
--- a/ansible_events/engine.py
+++ b/ansible_events/engine.py
@@ -37,7 +37,6 @@ from ansible_events.rule_types import (
     EngineRuleSetQueuePlan,
     EventSource,
     RuleSetQueue,
-    RuleSetQueuePlan,
 )
 from ansible_events.rules_parser import parse_hosts
 from ansible_events.util import json_count, substitute_variables
@@ -272,13 +271,8 @@ async def run_rulesets(
     if redis_host_name and redis_port:
         provide_durability(lang.get_host(), redis_host_name, redis_port)
 
-    ansible_ruleset_queue_plans = [
-        RuleSetQueuePlan(ruleset, queue, asyncio.Queue())
-        for ruleset, queue in ruleset_queues
-    ]
-
     rulesets_queue_plans = rule_generator.generate_rulesets(
-        ansible_ruleset_queue_plans, variables, inventory
+        ruleset_queues, variables, inventory
     )
 
     if not rulesets_queue_plans:
@@ -319,8 +313,22 @@ async def run_ruleset(
         if not data:
             await event_log.put(dict(type="EmptyEvent"))
             continue
+
+        logger.debug(str(data))
+
         results = []
         try:
+            # Asset added by other ruleset, not related to current event
+            while not ruleset_queue_plan.plan.queue.empty():
+                item = cast(
+                    ActionContext, await ruleset_queue_plan.plan.queue.get()
+                )
+                result = await call_action(*item, event_log=event_log)
+
+            # create a new plan queue for current event so that results
+            # can be concanated
+            ruleset_queue_plan.plan.queue = asyncio.Queue()
+
             try:
                 lang.post(name, data)
             except MessageObservedException:
@@ -330,8 +338,10 @@ async def run_ruleset(
             finally:
                 logger.debug(lang.get_pending_events(name))
 
-            while not ruleset_queue_plan.plan.empty():
-                item = cast(ActionContext, await ruleset_queue_plan.plan.get())
+            while not ruleset_queue_plan.plan.queue.empty():
+                item = cast(
+                    ActionContext, await ruleset_queue_plan.plan.queue.get()
+                )
                 result = await call_action(
                     *item,
                     event_log=event_log,

--- a/ansible_events/rule_types.py
+++ b/ansible_events/rule_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List, NamedTuple, Union
 
 import ansible_events.condition_types as ct
@@ -65,13 +66,12 @@ class RuleSetQueue(NamedTuple):
     queue: asyncio.Queue
 
 
-class RuleSetQueuePlan(NamedTuple):
-    ruleset: RuleSet
+@dataclass
+class Plan:
     queue: asyncio.Queue
-    plan: asyncio.Queue
 
 
 class EngineRuleSetQueuePlan(NamedTuple):
     ruleset: EngineRuleSet
     queue: asyncio.Queue
-    plan: asyncio.Queue
+    plan: Plan

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -170,19 +170,17 @@ async def test_generate_rules():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queue_plans = [
-        (ruleset, Queue(), asyncio.Queue()) for ruleset in rulesets
-    ]
-    durable_rulesets = generate_rulesets(
-        ruleset_queue_plans, dict(), inventory
-    )
+    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
-    print(durable_rulesets[0][0].define())
+    durable_rulesets[0].plan.queue = asyncio.Queue()
+    print(durable_rulesets[0].ruleset.define())
+
     assert_fact("Demo rules", {"payload": {"text": "hello"}})
 
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "slack"
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "assert_fact"
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "log"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "slack"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "assert_fact"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "log"
 
 
 @pytest.mark.asyncio
@@ -195,19 +193,16 @@ async def test_generate_rules_multiple_conditions_any():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queue_plans = [
-        (ruleset, Queue(), asyncio.Queue()) for ruleset in rulesets
-    ]
-    durable_rulesets = generate_rulesets(
-        ruleset_queue_plans, dict(), inventory
-    )
+    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
-    print(durable_rulesets[0][0].define())
+    durable_rulesets[0].plan.queue = asyncio.Queue()
+    print(durable_rulesets[0].ruleset.define())
 
     post("Demo rules multiple conditions any", {"i": 0})
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "debug"
     post("Demo rules multiple conditions any", {"i": 1})
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "debug"
 
 
 @pytest.mark.asyncio
@@ -220,20 +215,17 @@ async def test_generate_rules_multiple_conditions_all():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queue_plans = [
-        (ruleset, Queue(), asyncio.Queue()) for ruleset in rulesets
-    ]
-    durable_rulesets = generate_rulesets(
-        ruleset_queue_plans, dict(), inventory
-    )
+    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
-    print(durable_rulesets[0][0].define())
+    durable_rulesets[0].plan.queue = asyncio.Queue()
+    print(durable_rulesets[0].ruleset.define())
 
     post("Demo rules multiple conditions all", {"i": 0})
-    assert ruleset_queue_plans[0][2].qsize() == 0
+    assert durable_rulesets[0].plan.queue.qsize() == 0
     post("Demo rules multiple conditions all", {"i": 1})
-    assert ruleset_queue_plans[0][2].qsize() == 1
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert durable_rulesets[0].plan.queue.qsize() == 1
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "debug"
 
 
 @pytest.mark.asyncio
@@ -246,19 +238,16 @@ async def test_generate_rules_multiple_conditions_all_3():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queue_plans = [
-        (ruleset, Queue(), asyncio.Queue()) for ruleset in rulesets
-    ]
-    durable_rulesets = generate_rulesets(
-        ruleset_queue_plans, dict(), inventory
-    )
+    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
-    print(durable_rulesets[0][0].define())
+    durable_rulesets[0].plan.queue = asyncio.Queue()
+    print(durable_rulesets[0].ruleset.define())
 
     post("Demo rules multiple conditions reference assignment", {"i": 0})
-    assert ruleset_queue_plans[0][2].qsize() == 0
+    assert durable_rulesets[0].plan.queue.qsize() == 0
     post("Demo rules multiple conditions reference assignment", {"i": 1})
-    assert ruleset_queue_plans[0][2].qsize() == 0
+    assert durable_rulesets[0].plan.queue.qsize() == 0
     post("Demo rules multiple conditions reference assignment", {"i": 2})
-    assert ruleset_queue_plans[0][2].qsize() == 1
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert durable_rulesets[0].plan.queue.qsize() == 1
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "debug"


### PR DESCRIPTION
    This is a preparation for running events in parallel whenever possible.
    Before all actions resulting from events are placed in one queue (plan).
    It is not a problem when events are processed sequentially.
    
    Now each event will use a dedicated queue to store resulting actions.
    It helps to collect and concatenate results from these actions while
    allow events to be processed in parallel.
    
    This work also eliminates the use of data type RuleSetQueuePlan because
    we can directly convert a RuleSetQueue to EngineRuleSetQueuePlan without
    using RuleSetQueuePlan as a middle carrier.
    
    See Also: AAP-4436