### PR TITLE
[AAP-4436] Combine the same playbook on multiple hosts

### DIFF
--- a/ansible_events/engine.py
+++ b/ansible_events/engine.py
@@ -3,6 +3,7 @@ import logging
 import os
 import runpy
 import traceback
+from collections import OrderedDict
 from datetime import datetime
 from pprint import pformat
 from typing import Any, Dict, List, Optional, cast
@@ -13,7 +14,7 @@ else:
     from durable import engine, lang
 
 import ansible_events.rule_generator as rule_generator
-from ansible_events.builtin import actions as builtin_actions
+from ansible_events.builtin import actions as builtin_actions, run_playbook
 from ansible_events.collection import (
     find_source,
     find_source_filter,
@@ -141,105 +142,6 @@ async def start_source(
         await queue.put(Shutdown())
 
 
-async def call_action(
-    ruleset: str,
-    action: str,
-    action_args: Dict,
-    variables: Dict,
-    inventory: Dict,
-    hosts: List,
-    facts: Dict,
-    c,
-    event_log,
-) -> Dict:
-
-    logger.info(f"call_action {action}")
-
-    if action in builtin_actions:
-        try:
-            variables_copy = variables.copy()
-            if c.m is not None:
-                variables_copy[
-                    "event"
-                ] = c.m._d  # event data is stored in c.m._d
-                variables_copy[
-                    "fact"
-                ] = c.m._d  # event data is stored in c.m._d
-                event = c.m._d  # event data is stored in c.m._d
-                if "meta" in event:
-                    if "hosts" in event["meta"]:
-                        hosts = parse_hosts(event["meta"]["hosts"])
-            else:
-                variables_copy["events"] = c._m
-                variables_copy["facts"] = c._m
-                new_hosts = []
-                for event in variables_copy["events"]:
-                    if "meta" in event:
-                        if "hosts" in event["meta"]:
-                            new_hosts.append(
-                                parse_hosts(event["meta"]["hosts"])
-                            )
-                if new_hosts:
-                    hosts = new_hosts
-
-            logger.info(
-                f"substitute_variables [{action_args}] [{variables_copy}]"
-            )
-            action_args = {
-                k: substitute_variables(v, variables_copy)
-                for k, v in action_args.items()
-            }
-            logger.info(f"action args: {action_args}")
-
-            if facts is None:
-                facts = lang.get_facts(ruleset)
-                logger.info(f"facts: {facts}")
-
-            if "ruleset" not in action_args:
-                action_args["ruleset"] = ruleset
-
-            return await builtin_actions[action](
-                event_log=event_log,
-                inventory=inventory,
-                hosts=hosts,
-                variables=variables_copy,
-                facts=facts,
-                **action_args,
-            )
-        except KeyError as e:
-            logger.error(f"KeyError: {e}\n{pformat(variables_copy)}")
-            result = dict(error=e)
-        except engine.MessageNotHandledException as e:
-            logger.error(f"MessageNotHandledException: {action_args}")
-            result = dict(error=e)
-        except engine.MessageObservedException as e:
-            logger.info(f"MessageObservedException: {action_args}")
-            result = dict(error=e)
-        except ShutdownException:
-            raise
-        except Exception as e:
-            logger.error(
-                f"Error calling {action}: {e}\n {traceback.format_exc()}"
-            )
-            result = dict(error=e)
-    else:
-        logger.error(f"Action {action} not supported")
-        result = dict(error=f"Action {action} not supported")
-
-    await event_log.put(
-        dict(
-            type="Action",
-            action=action,
-            activation_id=settings.identifier,
-            playbook_name=action_args.get("name"),
-            status="failed",
-            run_at=str(datetime.utcnow()),
-        )
-    )
-
-    return result
-
-
 async def run_rulesets(
     event_log: asyncio.Queue,
     ruleset_queues: List[RuleSetQueue],
@@ -265,34 +167,56 @@ async def run_rulesets(
 
     ruleset_tasks = []
     for ruleset_queue_plan in rulesets_queue_plans:
-        ruleset_task = asyncio.create_task(
-            run_ruleset(event_log, ruleset_queue_plan)
-        )
+        ruleset_runner = RuleSetRunner(event_log, ruleset_queue_plan)
+        ruleset_task = asyncio.create_task(ruleset_runner.run_ruleset())
         ruleset_tasks.append(ruleset_task)
 
     await asyncio.wait(ruleset_tasks, return_when=asyncio.FIRST_COMPLETED)
 
 
-async def run_ruleset(
-    event_log: asyncio.Queue, ruleset_queue_plan: EngineRuleSetQueuePlan
-):
+class RuleSetRunner:
+    def __init__(
+        self,
+        event_log: asyncio.Queue,
+        ruleset_queue_plan: EngineRuleSetQueuePlan,
+    ):
+        self.pa_runner = PlaybookActionRunner()
+        self.playbook_actions_task = None
+        self.action_tasks = []
+        self.event_log = event_log
+        self.ruleset_queue_plan = ruleset_queue_plan
 
-    name = ruleset_queue_plan.ruleset.name
-    logger.info(f"Waiting for event from {name}")
-    while True:
-        data = await ruleset_queue_plan.queue.get()
-        json_count(data)
-        if isinstance(data, Shutdown):
-            await event_log.put(dict(type="Shutdown"))
-            return
-        if not data:
-            await event_log.put(dict(type="EmptyEvent"))
-            continue
+    async def run_ruleset(self):
+        name = self.ruleset_queue_plan.ruleset.name
+        self.playbook_actions_task = asyncio.create_task(
+            self.pa_runner.start(name), name=name
+        )
+        logger.info(f"Waiting for event from {name}")
+        while True:
+            data = await self.ruleset_queue_plan.queue.get()
+            self.ruleset_queue_plan.plan.queue = asyncio.Queue()
+            json_count(data)
+            if isinstance(data, Shutdown):
+                await asyncio.wait(self.action_tasks)
+                self.pa_runner.stop()
+                await self.playbook_actions_task
+                await self.event_log.put(dict(type="Shutdown"))
+                return
+            if not data:
+                await self.event_log.put(dict(type="EmptyEvent"))
+                continue
 
-        logger.debug(str(data))
-        ruleset_queue_plan.plan.queue = asyncio.Queue()
+            logger.debug(str(data))
+            self.action_tasks.append(
+                asyncio.create_task(
+                    self.run_actions(data, self.ruleset_queue_plan.plan.queue)
+                )
+            )
+
+    async def run_actions(self, data: Dict, plan_queue: asyncio.Queue):
         results = []
         try:
+            name = self.ruleset_queue_plan.ruleset.name
             try:
                 lang.post(name, data)
             except engine.MessageObservedException:
@@ -302,21 +226,188 @@ async def run_ruleset(
             finally:
                 logger.debug(lang.get_pending_events(name))
 
-            while not ruleset_queue_plan.plan.queue.empty():
-                item = cast(
-                    ActionContext, await ruleset_queue_plan.plan.queue.get()
-                )
-                result = await call_action(*item, event_log=event_log)
+            while not plan_queue.empty():
+                item = cast(ActionContext, await plan_queue.get())
+                result = await self.call_action(*item)
                 results.append(result)
 
-            await event_log.put(dict(type="ProcessedEvent", results=results))
+            await self.event_log.put(
+                dict(type="ProcessedEvent", results=results)
+            )
         except engine.MessageNotHandledException:
             logger.info(f"MessageNotHandledException: {data}")
-            await event_log.put(dict(type="MessageNotHandled"))
+            await self.event_log.put(dict(type="MessageNotHandled"))
         except ShutdownException:
-            await event_log.put(dict(type="Shutdown"))
-            return
+            await self.ruleset_queue_plan.queue.put(Shutdown())
         except Exception as e:
             logger.error(
                 f"Error calling {data}: {e}\n {traceback.format_exc()}"
             )
+
+    async def call_action(
+        self,
+        ruleset: str,
+        action: str,
+        action_args: Dict,
+        variables: Dict,
+        inventory: Dict,
+        hosts: List,
+        facts: Dict,
+        c,
+    ) -> Dict:
+
+        logger.info(f"call_action {action}")
+
+        if action in builtin_actions:
+            try:
+                variables_copy = variables.copy()
+                if c.m is not None:
+                    variables_copy[
+                        "event"
+                    ] = c.m._d  # event data is stored in c.m._d
+                    variables_copy[
+                        "fact"
+                    ] = c.m._d  # event data is stored in c.m._d
+                    event = c.m._d  # event data is stored in c.m._d
+                    if "meta" in event:
+                        if "hosts" in event["meta"]:
+                            hosts = parse_hosts(event["meta"]["hosts"])
+                else:
+                    variables_copy["events"] = c._m
+                    variables_copy["facts"] = c._m
+                    new_hosts = []
+                    for event in variables_copy["events"]:
+                        if "meta" in event:
+                            if "hosts" in event["meta"]:
+                                new_hosts.append(
+                                    parse_hosts(event["meta"]["hosts"])
+                                )
+                    if new_hosts:
+                        hosts = new_hosts
+
+                logger.info(
+                    f"substitute_variables [{action_args}] [{variables_copy}]"
+                )
+                action_args = {
+                    k: substitute_variables(v, variables_copy)
+                    for k, v in action_args.items()
+                }
+                logger.info(action_args)
+
+                if facts is None:
+                    facts = lang.get_facts(ruleset)
+                    logger.info(f"facts: {facts}")
+
+                if "ruleset" not in action_args:
+                    action_args["ruleset"] = ruleset
+
+                if action == "run_playbook":
+                    action_args["event_log"] = self.event_log
+                    action_args["inventory"] = inventory
+                    action_args["hosts"] = hosts
+                    action_args["variables"] = variables_copy
+                    action_args["facts"] = facts
+                    return await self.pa_runner.wait_for_playbook(action_args)
+                else:
+                    return await builtin_actions[action](
+                        event_log=self.event_log,
+                        inventory=inventory,
+                        hosts=hosts,
+                        variables=variables_copy,
+                        facts=facts,
+                        **action_args,
+                    )
+            except KeyError as e:
+                logger.error(f"{e}\n{pformat(variables_copy)}")
+                result = dict(error=e)
+            except engine.MessageNotHandledException as e:
+                logger.error(f"MessageNotHandledException: {action_args}")
+                result = dict(error=e)
+            except engine.MessageObservedException as e:
+                logger.info(f"MessageObservedException: {action_args}")
+                result = dict(error=e)
+            except ShutdownException:
+                raise
+            except Exception as e:
+                logger.error(
+                    f"Error calling {action}: {e}\n {traceback.format_exc()}"
+                )
+                result = dict(error=e)
+        else:
+            logger.error(f"Action {action} not supported")
+            result = dict(error=f"Action {action} not supported")
+
+        await self.event_log.put(
+            dict(
+                type="Action",
+                action=action,
+                activation_id=settings.identifier,
+                playbook_name=action_args.get("name"),
+                status="failed",
+                run_at=str(datetime.utcnow()),
+            )
+        )
+
+        return result
+
+
+class PlaybookActionRunner:
+    def __init__(self):
+        self.actions = OrderedDict()
+        self.result = None
+        self.stopped = True
+        self.delay = int(os.environ.get("RUN_PLAYBOOK_DELAY", 0))
+
+    async def start(self, name: str):
+        if not self.stopped:
+            return
+
+        logger.info(f"Start a playbook action runner for {name}")
+        self.stopped = False
+        while not self.stopped:
+            await asyncio.sleep(self.delay)
+            await self.execute()
+        logger.info(f"Playbook action runner {name} exists")
+
+    def stop(self):
+        self.stopped = True
+
+    async def execute(self):
+        for key in list(self.actions.keys()):
+            action_args = self.actions[key]
+            del self.actions[key]
+            async_condition = action_args.pop("async_condition")
+
+            try:
+                result = await run_playbook(**action_args)
+            except Exception as e:
+                action = "run_playbook"
+                logger.error(
+                    f"Error calling {action}: {e}\n {traceback.format_exc()}"
+                )
+                result = dict(error=e)
+
+            async with async_condition:
+                self.result = result
+                async_condition.notify_all()
+
+    async def wait_for_playbook(self, action_args: Dict):
+        name = action_args["name"]
+        logger.info(f"Queue playbook {name} for running later")
+
+        if name in self.actions:
+            for host in action_args["hosts"]:
+                logger.info(f"Combine host {host} to playbook {name}")
+                self.actions[name]["hosts"].add(host)
+            async_condition = self.actions[name]["async_condition"]
+        else:
+            async_condition = asyncio.Condition()
+            action_args["async_condition"] = async_condition
+            action_args["hosts"] = set(action_args["hosts"])
+            self.actions[name] = action_args
+
+        result = None
+        async with async_condition:
+            await async_condition.wait()
+            result = self.result
+        return result

--- a/ansible_events/rule_generator.py
+++ b/ansible_events/rule_generator.py
@@ -21,6 +21,7 @@ from ansible_events.condition_types import (
 from ansible_events.rule_types import (
     ActionContext,
     Condition as RuleCondition,
+    EngineRuleSetQueuePlan,
     RuleSetQueuePlan,
 )
 from ansible_events.util import substitute_variables
@@ -211,6 +212,6 @@ def generate_rulesets(
                         *generate_condition(ansible_rule.condition, variables),
                     )(fn)
                     logger.info(r.define())
-        rulesets.append((a_ruleset, [], queue, plan))
+        rulesets.append(EngineRuleSetQueuePlan(a_ruleset, queue, plan))
 
     return rulesets

--- a/ansible_events/rule_types.py
+++ b/ansible_events/rule_types.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from queue import Queue
+import os
 from typing import Any, Dict, List, NamedTuple, Union
 
 import ansible_events.condition_types as ct
+
+if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+    from drools.vendor.lang import ruleset as EngineRuleSet
+else:
+    from durable.lang import ruleset as EngineRuleSet
 
 
 class EventSourceFilter(NamedTuple):
@@ -55,17 +60,18 @@ class ActionContext(NamedTuple):
     c: Any
 
 
-class RuleSetPlan(NamedTuple):
-    ruleset: RuleSet
-    plan: asyncio.Queue
-
-
 class RuleSetQueue(NamedTuple):
     ruleset: RuleSet
-    queue: Queue
+    queue: asyncio.Queue
 
 
 class RuleSetQueuePlan(NamedTuple):
     ruleset: RuleSet
-    queue: Queue
+    queue: asyncio.Queue
+    plan: asyncio.Queue
+
+
+class EngineRuleSetQueuePlan(NamedTuple):
+    ruleset: EngineRuleSet
+    queue: asyncio.Queue
     plan: asyncio.Queue

--- a/ansible_events/rule_types.py
+++ b/ansible_events/rule_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List, NamedTuple, Union
 
 import ansible_events.condition_types as ct
@@ -65,13 +66,12 @@ class RuleSetQueue(NamedTuple):
     queue: asyncio.Queue
 
 
-class RuleSetQueuePlan(NamedTuple):
-    ruleset: RuleSet
+@dataclass
+class Plan:
     queue: asyncio.Queue
-    plan: asyncio.Queue
 
 
 class EngineRuleSetQueuePlan(NamedTuple):
     ruleset: EngineRuleSet
     queue: asyncio.Queue
-    plan: asyncio.Queue
+    plan: Plan

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -159,20 +159,17 @@ async def test_generate_rules():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queue_plans = [
-        (ruleset, Queue(), asyncio.Queue()) for ruleset in rulesets
-    ]
-    durable_rulesets = generate_rulesets(
-        ruleset_queue_plans, dict(), inventory
-    )
+    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
-    print(durable_rulesets[0][0].define())
+    durable_rulesets[0].plan.queue = asyncio.Queue()
+    print(durable_rulesets[0].ruleset.define())
 
     assert_fact("Demo rules", {"payload": {"text": "hello"}})
 
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "slack"
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "assert_fact"
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "log"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "slack"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "assert_fact"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "log"
 
 
 @pytest.mark.asyncio
@@ -185,19 +182,16 @@ async def test_generate_rules_multiple_conditions_any():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queue_plans = [
-        (ruleset, Queue(), asyncio.Queue()) for ruleset in rulesets
-    ]
-    durable_rulesets = generate_rulesets(
-        ruleset_queue_plans, dict(), inventory
-    )
+    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
-    print(durable_rulesets[0][0].define())
+    durable_rulesets[0].plan.queue = asyncio.Queue()
+    print(durable_rulesets[0].ruleset.define())
 
     post("Demo rules multiple conditions any", {"i": 0})
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "debug"
     post("Demo rules multiple conditions any", {"i": 1})
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "debug"
 
 
 @pytest.mark.asyncio
@@ -210,20 +204,17 @@ async def test_generate_rules_multiple_conditions_all():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queue_plans = [
-        (ruleset, Queue(), asyncio.Queue()) for ruleset in rulesets
-    ]
-    durable_rulesets = generate_rulesets(
-        ruleset_queue_plans, dict(), inventory
-    )
+    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
-    print(durable_rulesets[0][0].define())
+    durable_rulesets[0].plan.queue = asyncio.Queue()
+    print(durable_rulesets[0].ruleset.define())
 
     post("Demo rules multiple conditions all", {"i": 0})
-    assert ruleset_queue_plans[0][2].qsize() == 0
+    assert durable_rulesets[0].plan.queue.qsize() == 0
     post("Demo rules multiple conditions all", {"i": 1})
-    assert ruleset_queue_plans[0][2].qsize() == 1
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert durable_rulesets[0].plan.queue.qsize() == 1
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "debug"
 
 
 @pytest.mark.asyncio
@@ -236,19 +227,16 @@ async def test_generate_rules_multiple_conditions_all_3():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queue_plans = [
-        (ruleset, Queue(), asyncio.Queue()) for ruleset in rulesets
-    ]
-    durable_rulesets = generate_rulesets(
-        ruleset_queue_plans, dict(), inventory
-    )
+    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
-    print(durable_rulesets[0][0].define())
+    durable_rulesets[0].plan.queue = asyncio.Queue()
+    print(durable_rulesets[0].ruleset.define())
 
     post("Demo rules multiple conditions reference assignment", {"i": 0})
-    assert ruleset_queue_plans[0][2].qsize() == 0
+    assert durable_rulesets[0].plan.queue.qsize() == 0
     post("Demo rules multiple conditions reference assignment", {"i": 1})
-    assert ruleset_queue_plans[0][2].qsize() == 0
+    assert durable_rulesets[0].plan.queue.qsize() == 0
     post("Demo rules multiple conditions reference assignment", {"i": 2})
-    assert ruleset_queue_plans[0][2].qsize() == 1
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert durable_rulesets[0].plan.queue.qsize() == 1
+    assert durable_rulesets[0].plan.queue.get_nowait()[1] == "debug"


### PR DESCRIPTION
    Run the same playbook only once based on multiple events in a
    configurable time window through environmental variable
    RUN_PLAYBOOK_DELAY (seconds). Combine hosts collected from all
    related events.
    
    Resolves AAP-4436: Combine the same action together on multiple hosts
    based on multiple events in a certain period of time

This work only places run_playbook actions into the combinable queue. Technically all other actions can be treated the same way, but I feel there is no need since they are all quick actions. The only exception is the run_module action which can be easily handled the same way after the review.

Many unit tests are failing because the execution sequence changed. They will be fixed after reviewers approve the solution.

Depends on #158