### PR TITLE
[AAP-5919] Refactor logging

### DIFF
--- a/ansible_events/app.py
+++ b/ansible_events/app.py
@@ -20,7 +20,7 @@ from ansible_events.websocket import (
     send_event_log_to_websocket,
 )
 
-logger = logging.getLogger("ansible_events")
+logger = logging.getLogger(__name__)
 
 
 # FIXME(cutwater): Replace parsed_args with clear interface
@@ -105,11 +105,13 @@ def load_rules(parsed_args) -> List[RuleSet]:
         logger.debug("Loading no rules")
         return []
     elif os.path.exists(parsed_args.rules):
-        logger.debug(f"Loading rules from the file system {parsed_args.rules}")
+        logger.debug(
+            "Loading rules from the file system %s", parsed_args.rules
+        )
         with open(parsed_args.rules) as f:
             return rules_parser.parse_rule_sets(yaml.safe_load(f.read()))
     elif has_rules(*split_collection_name(parsed_args.rules)):
-        logger.debug(f"Loading rules from a collection {parsed_args.rules}")
+        logger.debug("Loading rules from a collection %s", parsed_args.rules)
         return rules_parser.parse_rule_sets(
             collection_load_rules(*split_collection_name(parsed_args.rules))
         )
@@ -122,7 +124,6 @@ def spawn_sources(
     variables: Dict[str, Any],
     source_dirs: List[str],
 ) -> Tuple[List[asyncio.Task], List[RuleSetQueue]]:
-    logger.info("Starting sources")
     tasks = []
     ruleset_queues = []
     for ruleset in rulesets:

--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -29,7 +29,7 @@ from .conf import settings
 from .exception import ShutdownException
 from .util import get_horizontal_rule
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 async def none(
@@ -118,7 +118,7 @@ async def assert_fact(
     fact: Dict,
     name: Optional[str] = None,
 ):
-    logger.debug(f"assert_fact {ruleset} {fact}")
+    logger.debug("assert_fact %s %s", ruleset, fact)
     lang.assert_fact(ruleset, fact)
     await event_log.put(
         dict(
@@ -194,7 +194,7 @@ async def run_playbook(
     **kwargs,
 ):
 
-    logger.info(f"running Ansible playbook: {name}")
+    logger.info("running Ansible playbook: %s", name)
     temp, playbook_name, job_id = await pre_process_runner(
         event_log,
         inventory,
@@ -401,9 +401,9 @@ async def pre_process_runner(
 ):
 
     private_data_dir = tempfile.mkdtemp(prefix=action)
-    logger.debug(f"private data dir {private_data_dir}")
-    logger.debug(f"variables {variables}")
-    logger.debug(f"facts {facts}")
+    logger.debug("private data dir %s", private_data_dir)
+    logger.debug("variables %s", variables)
+    logger.debug("facts %s", facts)
 
     variables["facts"] = facts
     for k, v in kwargs.items():
@@ -446,7 +446,7 @@ async def pre_process_runner(
             )
         else:
             logger.error(
-                f"Could not find a playbook for {name} from {os.getcwd()}"
+                "Could not find a playbook for %s from %s", name, os.getcwd()
             )
 
     job_id = str(uuid.uuid4())
@@ -498,7 +498,7 @@ async def post_process_runner(
         ):
             with open(host_facts) as f:
                 fact = json.loads(f.read())
-            logger.debug(f"fact {fact}")
+            logger.debug("fact %s", fact)
             if assert_facts:
                 lang.assert_fact(ruleset, fact)
             if post_events:

--- a/ansible_events/cli.py
+++ b/ansible_events/cli.py
@@ -30,7 +30,7 @@ import ansible_events
 from ansible_events import app
 from ansible_events.conf import settings
 
-logger = logging.getLogger("ansible_events")
+logger = logging.getLogger(__name__)
 
 
 def get_parser() -> argparse.ArgumentParser:

--- a/ansible_events/durability.py
+++ b/ansible_events/durability.py
@@ -3,7 +3,7 @@ import logging
 
 import redis
 
-logger = logging.getLogger("durability")
+logger = logging.getLogger(__name__)
 
 
 def unix_time(dt):
@@ -49,8 +49,8 @@ def provide_durability(host, redis_host_name="localhost", port=6379):
                 mid,
                 format_message(action_type, content),
             )
-        except BaseException as e:
-            logger.error(e)
+        except BaseException:
+            logger.exception("BaseException encountered")
             return 601
 
         return 0
@@ -58,8 +58,8 @@ def provide_durability(host, redis_host_name="localhost", port=6379):
     def delete_message_callback(ruleset, sid, mid):
         try:
             r.hdel(get_hset_name(ruleset, sid), mid)
-        except BaseException as e:
-            logger.error(e)
+        except BaseException:
+            logger.exception("BaseException encountered")
             return 602
 
         return 0
@@ -77,8 +77,8 @@ def provide_durability(host, redis_host_name="localhost", port=6379):
                 get_list_name(ruleset, sid),
                 format_message(action_type, content),
             )
-        except BaseException as e:
-            logger.error(e)
+        except BaseException:
+            logger.exception("BaseException encountered")
             return 603
 
         return 0
@@ -95,8 +95,8 @@ def provide_durability(host, redis_host_name="localhost", port=6379):
                 host.complete_get_queued_messages(
                     ruleset, sid, format_messages(messages)
                 )
-        except BaseException as e:
-            logger.error(e)
+        except BaseException:
+            logger.exception("BaseException encountered")
             return 604
 
         return 0
@@ -112,8 +112,8 @@ def provide_durability(host, redis_host_name="localhost", port=6379):
                 host.complete_get_idle_state(
                     ruleset, sid, format_messages(messages)
                 )
-        except BaseException as e:
-            logger.error(e)
+        except BaseException:
+            logger.exception("BaseException encountered")
             return 606
 
         return 0

--- a/ansible_events/key.py
+++ b/ansible_events/key.py
@@ -5,7 +5,7 @@ import shutil
 import stat
 import tempfile
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 ssh_add = shutil.which("ssh-add")
 

--- a/ansible_events/rule_generator.py
+++ b/ansible_events/rule_generator.py
@@ -26,6 +26,8 @@ from ansible_events.rule_types import (
 )
 from ansible_events.util import substitute_variables
 
+logger = logging.getLogger(__name__)
+
 
 def add_to_plan(
     ruleset: str,
@@ -147,10 +149,9 @@ def visit_condition(parsed_condition: ConditionTypes, variables: Dict):
 
 def generate_condition(ansible_condition: RuleCondition, variables: Dict):
     condition = visit_condition(ansible_condition.value, variables)
-    logger = logging.getLogger()
     for i in condition:
         if i:
-            logger.debug(f"{i.define()}")
+            logger.debug("%s", i.define())
         else:
             logger.debug("None")
     return condition
@@ -166,8 +167,7 @@ def make_fn(
     plan: asyncio.Queue,
 ) -> Callable:
     def fn(c):
-        logger = logging.getLogger()
-        logger.info(f"calling {ansible_rule.name}")
+        logger.info("calling %s", ansible_rule.name)
         add_to_plan(
             ruleset,
             ansible_rule.action.action,
@@ -189,7 +189,6 @@ def generate_rulesets(
     inventory: Dict,
 ):
 
-    logger = logging.getLogger()
     rulesets = []
 
     for ansible_ruleset, queue, plan in ansible_ruleset_queue_plans:

--- a/ansible_events/websocket.py
+++ b/ansible_events/websocket.py
@@ -9,7 +9,7 @@ import yaml
 from ansible_events import rules_parser as rules_parser
 from ansible_events.key import install_private_key
 
-logger = logging.getLogger("ansible_events.websocket")
+logger = logging.getLogger(__name__)
 
 
 async def request_workload(activation_id, websocket_address):
@@ -74,5 +74,5 @@ async def send_event_log_to_websocket(event_log, websocket_address):
         except CancelledError:
             logger.info("closing websocket due to task cancelled")
             return
-        except BaseException as e:
-            logger.error(f"websocket error {type(e)} {e} on {event}")
+        except BaseException:
+            logger.exception("websocket error on %s", event)

--- a/performance_test/generate_inventory.py
+++ b/performance_test/generate_inventory.py
@@ -19,7 +19,7 @@ import sys
 import yaml
 from docopt import docopt
 
-logger = logging.getLogger("generate_inventory")
+logger = logging.getLogger(__name__)
 
 
 def main(args=None):

--- a/performance_test/perf_test.py
+++ b/performance_test/perf_test.py
@@ -20,7 +20,7 @@ import time
 
 from docopt import docopt
 
-logger = logging.getLogger("perf_test")
+logger = logging.getLogger(__name__)
 
 
 def main(args=None):

--- a/tests/event_filters/dashes_to_underscores.py
+++ b/tests/event_filters/dashes_to_underscores.py
@@ -12,7 +12,7 @@ import logging
 
 
 def main(event, overwrite=True):
-    logger = logging.getLogger()
+    logger = logging.getLogger(__name__)
     logger.info("dashes_to_underscores")
     q = []
     q.append(event)
@@ -27,9 +27,9 @@ def main(event, overwrite=True):
                     del o[key]
                     if new_key in o and overwrite:
                         o[new_key] = value
-                        logger.info(f"Replacing {key} with {new_key}")
+                        logger.info("Replacing %s with %s", key, new_key)
                     elif new_key not in o:
                         o[new_key] = value
-                        logger.info(f"Replacing {key} with {new_key}")
+                        logger.info("Replacing %s with %s", key, new_key)
 
     return event

--- a/tests/sources/replay.py
+++ b/tests/sources/replay.py
@@ -5,7 +5,7 @@ import logging
 import os
 from typing import Any, Dict
 
-logger = logging.getLogger("replay")
+logger = logging.getLogger(__name__)
 
 
 async def main(queue: asyncio.Queue, args: Dict[str, Any]):
@@ -15,13 +15,13 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
         logger.error("No replay directory")
         return
     if not os.path.exists(directory):
-        logger.error(f"Could not find replay directory {directory}")
+        logger.error("Could not find replay directory %s", directory)
         return
 
     replays = sorted(glob.glob(os.path.join(directory, "*.json")))
 
     if not replays:
-        logger.error(f"Could not find any replays in directory {directory}")
+        logger.error("Could not find any replays in directory %s", directory)
         return
 
     for replay_file in replays:


### PR DESCRIPTION
1. Avoid using global logger. Get logger using name _name_
2. Avoid f-string format. Use logger's own formatting
3. Use logger.exception() to log stack trace.

Resolves AAP-5919

The issues were originally brought up in #150. I decide to go overall all source code and apply the same principles. 
@cutwater please review