### PR TITLE
Cancel ruleset tasks

### DIFF
--- a/ansible_events/engine.py
+++ b/ansible_events/engine.py
@@ -277,6 +277,9 @@ async def run_rulesets(
         ruleset_tasks.append(ruleset_task)
 
     await asyncio.wait(ruleset_tasks, return_when=asyncio.FIRST_COMPLETED)
+    logger.info("Canceling all ruleset tasks")
+    for task in ruleset_tasks:
+        task.cancel()
 
 
 async def run_ruleset(


### PR DESCRIPTION
Cancel all ruleset tasks when any running ruleset task completes. This way when the main task exist there is no unmonitored ruleset task still running in background.

See also AAP-5471

A followup work of #150