### PR TITLE
Log every run_playbook or run_module retry

### DIFF
--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -215,6 +215,9 @@ async def run_playbook(
     for i in range(retries + 1):
         if i > 0 and delay > 0:
             await asyncio.sleep(delay)
+            logger.info(
+                "Previous run_playbook failed. Retry %d of %d", i, retries
+            )
 
         run_at = str(datetime.utcnow())
         await call_runner(
@@ -290,7 +293,9 @@ async def run_module(
     for i in range(retries + 1):
         if i > 0 and delay > 0:
             await asyncio.sleep(delay)
-
+            logger.info(
+                "Previous run_module failed. Retry %d of %d", i, retries
+            )
         run_at = str(datetime.utcnow())
         await call_runner(
             event_log,


### PR DESCRIPTION
See also AAP-5126: Add retry option to run_playbook action that will rerun a playbook on failure

This is followup of #147 per QE's suggestion.