### PR TITLE
CLI requires inventory if rules are set

### DIFF
--- a/ansible_events/cli.py
+++ b/ansible_events/cli.py
@@ -118,6 +118,10 @@ def main(args: List[str] = None) -> int:
     if args.version:
         show_version()
 
+    if args.rules and not args.inventory:
+        print("Error: inventory is required")
+        return 1
+
     if args.id:
         settings.identifier = args.id
 


### PR DESCRIPTION
The command line requires inventory argument if rules argument is set

Resolves AAP-5405: The arg '--inventory' is not mandatory when running ansible-events