### PR TITLE
Add job details for eda-server usage

### DIFF
--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -41,6 +41,8 @@ async def none(
     variables: Dict,
     facts: Dict,
     project_data_file: str,
+    source_ruleset_name: str,
+    source_rule_name: str,
     ruleset: str,
 ):
     await event_log.put(
@@ -81,6 +83,8 @@ async def print_event(
     variables: Dict,
     facts: Dict,
     project_data_file: str,
+    source_ruleset_name: str,
+    source_rule_name: str,
     ruleset: str,
     name: Optional[str] = None,
     var_root: Union[str, Dict, None] = None,
@@ -118,6 +122,8 @@ async def set_fact(
     facts: Dict,
     project_data_file: str,
     ruleset: str,
+    source_ruleset_name: str,
+    source_rule_name: str,
     fact: Dict,
     name: Optional[str] = None,
 ):
@@ -142,6 +148,8 @@ async def retract_fact(
     facts: Dict,
     project_data_file: str,
     ruleset: str,
+    source_ruleset_name: str,
+    source_rule_name: str,
     fact: Dict,
     name: Optional[str] = None,
 ):
@@ -164,6 +172,8 @@ async def post_event(
     variables: Dict,
     project_data_file: str,
     facts: Dict,
+    source_ruleset_name: str,
+    source_rule_name: str,
     ruleset: str,
     event: Dict,
 ):
@@ -187,6 +197,8 @@ async def run_playbook(
     facts: Dict,
     project_data_file: str,
     ruleset: str,
+    source_ruleset_name: str,
+    source_rule_name: str,
     name: str,
     set_facts: Optional[bool] = None,
     post_events: Optional[bool] = None,
@@ -206,7 +218,6 @@ async def run_playbook(
         inventory,
         variables,
         facts,
-        ruleset,
         name,
         "run_playbook",
         var_root,
@@ -224,10 +235,10 @@ async def run_playbook(
             job_id=job_id,
             ansible_events_id=settings.identifier,
             name=playbook_name,
-            ruleset=ruleset,
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
             hosts=",".join(hosts),
             action="run_playbook",
-            inventory=yaml.dump(inventory),
         )
     )
 
@@ -276,6 +287,8 @@ async def run_module(
     variables: Dict,
     facts: Dict,
     ruleset: str,
+    source_ruleset_name: str,
+    source_rule_name: str,
     name: str,
     set_facts: Optional[bool] = None,
     post_events: Optional[bool] = None,
@@ -295,7 +308,6 @@ async def run_module(
         inventory,
         variables,
         facts,
-        ruleset,
         name,
         "run_module",
         var_root,
@@ -311,10 +323,10 @@ async def run_module(
             job_id=job_id,
             ansible_events_id=settings.identifier,
             name=module_name,
-            ruleset=ruleset,
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
             hosts=",".join(hosts),
             action="run_module",
-            inventory=yaml.dump(inventory),
         )
     )
 
@@ -451,7 +463,6 @@ async def pre_process_runner(
     inventory: Dict,
     variables: Dict,
     facts: Dict,
-    ruleset: str,
     name: str,
     action: str,
     var_root: Union[str, Dict, None] = None,
@@ -479,13 +490,13 @@ async def pre_process_runner(
 
     playbook_name = name
 
-    os.mkdir(os.path.join(private_data_dir, "env"))
-    with open(os.path.join(private_data_dir, "env", "extravars"), "w") as f:
+    os.mkdir(env_dir)
+    with open(os.path.join(env_dir, "extravars"), "w") as f:
         f.write(yaml.dump(variables))
-    os.mkdir(os.path.join(private_data_dir, "inventory"))
-    with open(os.path.join(private_data_dir, "inventory", "hosts"), "w") as f:
+    os.mkdir(inventory_dir)
+    with open(os.path.join(inventory_dir, "hosts"), "w") as f:
         f.write(yaml.dump(inventory))
-    os.mkdir(os.path.join(private_data_dir, "project"))
+    os.mkdir(project_dir)
 
     logger.debug("project_data_file: %s", project_data_file)
     if project_data_file:
@@ -573,6 +584,9 @@ async def shutdown(
     variables: Dict,
     facts: Dict,
     ruleset: str,
+    source_ruleset_name: str,
+    source_rule_name: str,
+    project_data_file: str,
 ):
     await event_log.put(
         dict(

--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -49,6 +49,8 @@ async def none(
         dict(
             type="Action",
             action="noop",
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
             activation_id=settings.identifier,
             run_at=str(datetime.utcnow()),
         )
@@ -70,6 +72,8 @@ async def debug(event_log, **kwargs):
             type="Action",
             action="debug",
             playbook_name=kwargs.get("name"),
+            ruleset=kwargs.get("source_ruleset_name"),
+            rule=kwargs.get("source_rule_name"),
             activation_id=settings.identifier,
             run_at=str(datetime.utcnow()),
         )
@@ -108,6 +112,8 @@ async def print_event(
             type="Action",
             action="print_event",
             activation_id=settings.identifier,
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
             playbook_name=name,
             run_at=str(datetime.utcnow()),
         )
@@ -121,9 +127,9 @@ async def set_fact(
     variables: Dict,
     facts: Dict,
     project_data_file: str,
-    ruleset: str,
     source_ruleset_name: str,
     source_rule_name: str,
+    ruleset: str,
     fact: Dict,
     name: Optional[str] = None,
 ):
@@ -134,6 +140,8 @@ async def set_fact(
             type="Action",
             action="set_fact",
             activation_id=settings.identifier,
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
             playbook_name=name,
             run_at=str(datetime.utcnow()),
         )
@@ -147,9 +155,9 @@ async def retract_fact(
     variables: Dict,
     facts: Dict,
     project_data_file: str,
-    ruleset: str,
     source_ruleset_name: str,
     source_rule_name: str,
+    ruleset: str,
     fact: Dict,
     name: Optional[str] = None,
 ):
@@ -158,6 +166,8 @@ async def retract_fact(
         dict(
             type="Action",
             action="retract_fact",
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
             activation_id=settings.identifier,
             playbook_name=name,
             run_at=str(datetime.utcnow()),
@@ -170,8 +180,8 @@ async def post_event(
     inventory: Dict,
     hosts: List,
     variables: Dict,
-    project_data_file: str,
     facts: Dict,
+    project_data_file: str,
     source_ruleset_name: str,
     source_rule_name: str,
     ruleset: str,
@@ -183,6 +193,8 @@ async def post_event(
         dict(
             type="Action",
             action="post_event",
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
             activation_id=settings.identifier,
             run_at=str(datetime.utcnow()),
         )
@@ -196,9 +208,9 @@ async def run_playbook(
     variables: Dict,
     facts: Dict,
     project_data_file: str,
-    ruleset: str,
     source_ruleset_name: str,
     source_rule_name: str,
+    ruleset: str,
     name: str,
     set_facts: Optional[bool] = None,
     post_events: Optional[bool] = None,
@@ -229,6 +241,7 @@ async def run_playbook(
 
     job_id = str(uuid.uuid4())
 
+    logger.info(f"ruleset: {source_ruleset_name}, rule: {source_rule_name}")
     await event_log.put(
         dict(
             type="Job",
@@ -286,9 +299,9 @@ async def run_module(
     hosts: List,
     variables: Dict,
     facts: Dict,
-    ruleset: str,
     source_ruleset_name: str,
     source_rule_name: str,
+    ruleset: str,
     name: str,
     set_facts: Optional[bool] = None,
     post_events: Optional[bool] = None,
@@ -583,16 +596,18 @@ async def shutdown(
     hosts: List,
     variables: Dict,
     facts: Dict,
-    ruleset: str,
+    project_data_file: str,
     source_ruleset_name: str,
     source_rule_name: str,
-    project_data_file: str,
+    ruleset: str,
 ):
     await event_log.put(
         dict(
             type="Action",
             action="shutdown",
             activation_id=settings.identifier,
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
             run_at=str(datetime.utcnow()),
         )
     )

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -161,6 +161,7 @@ async def start_source(
 
 async def call_action(
     ruleset: str,
+    rule: str,
     action: str,
     action_args: Dict,
     variables: Dict,
@@ -232,6 +233,8 @@ async def call_action(
                 variables=variables_copy,
                 facts=facts,
                 project_data_file=project_data_file,
+                source_ruleset_name=ruleset,
+                source_rule_name=rule,
                 **action_args,
             )
         except KeyError as e:

--- a/ansible_rulebook/rule_generator.py
+++ b/ansible_rulebook/rule_generator.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 def add_to_plan(
     ruleset: str,
+    rule: str,
     action: str,
     action_args: Dict,
     variables: Dict,
@@ -46,7 +47,15 @@ def add_to_plan(
 ) -> None:
     plan.put_nowait(
         ActionContext(
-            ruleset, action, action_args, variables, inventory, hosts, facts, c
+            ruleset,
+            rule,
+            action,
+            action_args,
+            variables,
+            inventory,
+            hosts,
+            facts,
+            c,
         )
     )
 
@@ -174,6 +183,7 @@ def make_fn(
         logger.info("calling %s", ansible_rule.name)
         add_to_plan(
             ruleset,
+            ansible_rule.name,
             ansible_rule.action.action,
             ansible_rule.action.action_args,
             variables,

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -52,6 +52,7 @@ class RuleSet(NamedTuple):
 
 class ActionContext(NamedTuple):
     ruleset: str
+    rule: str
     action: str
     actions_args: Dict
     variables: Dict

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -931,7 +931,10 @@ async def test_35_multiple_rulesets_1_fired():
         "max_events": 5,
         "processed_events": 2,
         "shutdown_events": 1,
-        "actions": ["set_fact", "noop"],
+        "actions": [
+            "35 multiple rulesets 1::r1::set_fact",
+            "35 multiple rulesets 1::r2::noop",
+        ],
     }
     validate_events(event_log, **checks)
 
@@ -961,7 +964,10 @@ async def test_36_multiple_rulesets_both_fired():
         "max_events": 6,
         "processed_events": 3,
         "shutdown_events": 1,
-        "actions": ["set_fact", "debug"],
+        "actions": [
+            "36 multiple rulesets 1::r1::set_fact",
+            "36 multiple rulesets 2::r1::debug",
+        ],
     }
     validate_events(event_log, **checks)
 
@@ -977,7 +983,9 @@ def validate_events(event_log, **kwargs):
         if event["type"] == "ProcessedEvent":
             processed_events += 1
         elif event["type"] == "Action":
-            actions.append(event["action"])
+            actions.append(
+                f"{event['ruleset']}::{event['rule']}::{event['action']}"
+            )
         elif event["type"] == "Shutdown":
             shutdown_events += 1
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -188,9 +188,9 @@ async def test_generate_rules():
     print(durable_rulesets[0][0].define())
     set_fact("Demo rules", {"payload": {"text": "hello"}})
 
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "slack"
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "set_fact"
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "log"
+    assert ruleset_queue_plans[0][2].get_nowait().action == "slack"
+    assert ruleset_queue_plans[0][2].get_nowait().rule == "assert fact"
+    assert ruleset_queue_plans[0][2].get_nowait().ruleset == "Demo rules"
 
 
 @pytest.mark.asyncio
@@ -213,9 +213,9 @@ async def test_generate_rules_multiple_conditions_any():
     print(durable_rulesets[0][0].define())
 
     post("Demo rules multiple conditions any", {"i": 0})
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert ruleset_queue_plans[0][2].get_nowait().action == "debug"
     post("Demo rules multiple conditions any", {"i": 1})
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert ruleset_queue_plans[0][2].get_nowait().action == "debug"
 
 
 @pytest.mark.asyncio
@@ -241,7 +241,7 @@ async def test_generate_rules_multiple_conditions_all():
     assert ruleset_queue_plans[0][2].qsize() == 0
     post("Demo rules multiple conditions all", {"i": 1})
     assert ruleset_queue_plans[0][2].qsize() == 1
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert ruleset_queue_plans[0][2].get_nowait().action == "debug"
 
 
 @pytest.mark.asyncio
@@ -269,4 +269,4 @@ async def test_generate_rules_multiple_conditions_all_3():
     assert ruleset_queue_plans[0][2].qsize() == 0
     post("Demo rules multiple conditions reference assignment", {"i": 2})
     assert ruleset_queue_plans[0][2].qsize() == 1
-    assert ruleset_queue_plans[0][2].get_nowait()[1] == "debug"
+    assert ruleset_queue_plans[0][2].get_nowait().action == "debug"


### PR DESCRIPTION
Add more job related details to the event queue, so EDA server side can save them for either debug or job rerun.


Resolves: [AAP-5081](https://issues.redhat.com/browse/AAP-5081)