### PR TITLE
[AAP-6010] add GH action to build container image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,33 @@
+name: Build container image
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    env:
+      EDA_TOKEN: ${{ secrets.EDA_SERVER_TOKEN }}
+      QUAY_PASSWORD: ${{ secrets.EDA_AIZQUIERDO_QUAY_PW }}
+      QUAY_USERNAME: "aizquier+edaci"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build image
+        run: |
+          export GITHUB_TOKEN=$EDA_TOKEN
+          docker build -t ansible-rulebook:latest . \
+          --no-cache --build-arg GITHUB_TOKEN=$GITHUB_TOKEN
+
+      - name: Tag image
+        run: >
+          docker image tag ansible-rulebook:latest
+          quay.io/aizquier/ansible-rulebook:latest
+
+      - name: Push image
+        run: |
+          docker login -u=$QUAY_USERNAME -p=$QUAY_PASSWORD quay.io
+          docker image push quay.io/aizquier/ansible-rulebook:latest


### PR DESCRIPTION
Add GH action to build automatically the container image from the main branch on: quay.io/aizquier/ansible-rulebook:latest
Depends on https://github.com/ansible/ansible-rulebook/pull/165
Closes https://issues.redhat.com/browse/AAP-6010

Note that the image is public. Create a private repository in quay.io requires a developer plan (I'm trying to acquire it) 
Also quay.io supports the automatic build from the repository without need any GH action, but doesn't support `build-args` required to inject the token for the private repos, that's why using an action. When the repository becomes public, can be changed. 