### PR TITLE
[AAP-4440] Support storing facts per host

### DIFF
--- a/ansible_events/engine.py
+++ b/ansible_events/engine.py
@@ -40,7 +40,11 @@ from ansible_events.rule_types import (
     RuleSetQueuePlan,
 )
 from ansible_events.rules_parser import parse_hosts
-from ansible_events.util import json_count, substitute_variables
+from ansible_events.util import (
+    collect_ansible_facts,
+    json_count,
+    substitute_variables,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -190,10 +194,10 @@ async def call_action(
                 variables_copy["events"] = multi_match
                 variables_copy["facts"] = multi_match
                 new_hosts = []
-                for event in variables_copy["events"]:
+                for event in variables_copy["events"].values():
                     if "meta" in event:
                         if "hosts" in event["meta"]:
-                            new_hosts.append(
+                            new_hosts.extend(
                                 parse_hosts(event["meta"]["hosts"])
                             )
                 if new_hosts:
@@ -284,13 +288,20 @@ async def run_rulesets(
     if not rulesets_queue_plans:
         return
 
+    hosts_facts = []
+    for ruleset, _ in ruleset_queues:
+        if ruleset.gather_facts and not hosts_facts:
+            hosts_facts = collect_ansible_facts(inventory)
+
     for ruleset_queue_plan in rulesets_queue_plans:
         logger.info("ruleset define: %s", ruleset_queue_plan.ruleset.define())
 
     ruleset_tasks = []
     for ruleset_queue_plan in rulesets_queue_plans:
         ruleset_task = asyncio.create_task(
-            run_ruleset(event_log, ruleset_queue_plan, project_data_file)
+            run_ruleset(
+                event_log, ruleset_queue_plan, hosts_facts, project_data_file
+            )
         )
         ruleset_tasks.append(ruleset_task)
 
@@ -303,10 +314,14 @@ async def run_rulesets(
 async def run_ruleset(
     event_log: asyncio.Queue,
     ruleset_queue_plan: EngineRuleSetQueuePlan,
+    hosts_facts: List[Dict],
     project_data_file: Optional[str] = None,
 ):
 
     name = ruleset_queue_plan.ruleset.name
+    for data in hosts_facts:
+        lang.assert_fact(name, data)
+
     logger.info("Waiting for event from %s", name)
     while True:
         data = await ruleset_queue_plan.queue.get()

--- a/ansible_events/rule_types.py
+++ b/ansible_events/rule_types.py
@@ -47,6 +47,7 @@ class RuleSet(NamedTuple):
     hosts: Union[str, List[str]]
     sources: List[EventSource]
     rules: List[Rule]
+    gather_facts: bool
 
 
 class ActionContext(NamedTuple):

--- a/ansible_events/rules_parser.py
+++ b/ansible_events/rules_parser.py
@@ -24,6 +24,7 @@ def parse_rule_sets(rule_sets: Dict) -> List[rt.RuleSet]:
                 hosts=parse_hosts(rule_set["hosts"]),
                 sources=parse_event_sources(rule_set["sources"]),
                 rules=parse_rules(rule_set.get("rules", {})),
+                gather_facts=rule_set.get("gather_facts", False),
             )
         )
     return rule_set_list

--- a/ansible_events/util.py
+++ b/ansible_events/util.py
@@ -1,7 +1,11 @@
+import glob
+import json
 import os
+import tempfile
 from pprint import pprint
 from typing import Any, Dict, List, Union
 
+import ansible_runner
 import jinja2
 import yaml
 
@@ -71,3 +75,38 @@ def json_count(data):
                 )
             for i in o.values():
                 q.append(i)
+
+
+def collect_ansible_facts(inventory: Dict) -> List[Dict]:
+    hosts_facts = []
+    with tempfile.TemporaryDirectory(
+        prefix="gather_facts"
+    ) as private_data_dir:
+        os.mkdir(os.path.join(private_data_dir, "inventory"))
+        with open(
+            os.path.join(private_data_dir, "inventory", "hosts"), "w"
+        ) as f:
+            f.write(yaml.dump(inventory))
+
+        r = ansible_runner.run(
+            private_data_dir=private_data_dir,
+            module="ansible.builtin.setup",
+            host_pattern="*",
+        )
+        if r.rc != 0:
+            raise Exception(
+                "Error collecting facts in ansible_runner.run "
+                f"rc={r.rc}, status={r.status}"
+            )
+
+        host_path = os.path.join(
+            private_data_dir, "artifacts", "*", "fact_cache", "*"
+        )
+        for host_file in glob.glob(host_path):
+            hostname = os.path.basename(host_file)
+            with open(host_file) as f:
+                data = json.load(f)
+            data["meta"] = dict(hosts=hostname)
+            hosts_facts.append(data)
+
+    return hosts_facts

--- a/schema/ruleset_schema.json
+++ b/schema/ruleset_schema.json
@@ -10,6 +10,10 @@
                 "hosts": {
                     "type": "string"
                 },
+                "gather_facts": {
+                    "type": "boolean",
+                    "default": false
+                },
                 "name": {
                     "type": "string"
                 },

--- a/tests/examples/37_hosts_facts.yml
+++ b/tests/examples/37_hosts_facts.yml
@@ -1,0 +1,22 @@
+---
+- name: Host facts
+  hosts: all
+  gather_facts: true
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name: "Host 1 rule"
+      condition:
+        all:
+          - fact.meta.hosts == "localhost"
+          - event.i == 1
+      action:
+        debug:
+    - name: "Host 2 rule"
+      condition:
+        all:
+          - fact.os == "linux"
+          - event.i == 4 
+      action:
+        debug:


### PR DESCRIPTION
A ruleset can have an optional gather_facts flag which enables collection of ansible facts per host in the inventory list. These ansible facts are stored in the rules engine per host. When a rule matches the corresponding host fact and the event are returned from the rules engine.

You can refer to the facts per host using the fact prefix. e.g.

fact.meta.hosts == 'localhost'

When the fact is returned from the rules engine it allows us to limit the hosts that the playbook would run on by using the meta.hosts key.

https://issues.redhat.com/browse/AAP-4440