### PR TITLE
Testing difference between Drools and durable rules

### DIFF
--- a/tests/examples/38_multiple_matches_with_single_event.yml
+++ b/tests/examples/38_multiple_matches_with_single_event.yml
@@ -1,0 +1,14 @@
+---
+- name: single event multi condition
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name: "Rule1"
+      condition:
+        all:
+          - event.target_os == "linux"
+          - event.tracking_id == 345
+      action:
+        debug:

--- a/tests/examples/39_multiple_matches_with_multiple_events.yml
+++ b/tests/examples/39_multiple_matches_with_multiple_events.yml
@@ -1,0 +1,14 @@
+---
+- name: multiple event multi condition
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name: "Rule1"
+      condition:
+        all:
+          - event.target_os == "linux"
+          - event.tracking_id == 345
+      action:
+        debug:


### PR DESCRIPTION
When matching multiple expressions in a condition with durable rules we have to create 2 separate events to get a match With Drools we can have either a
- single event or
- multiple events

It works with both.

Durable rules only works with multiple events, is this ok