### PR TITLE
Switch the default rules engine to Drools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: ansible-galaxy collection install benthomasson.eda
       - name: Run tests via Durable rules
         run: pytest
+        env:
+          RULES_ENGINE: durable_rules
       - name: Run tests via Drools
         run: pytest
-        env:
-          RULES_ENGINE: drools

--- a/ansible_events/builtin.py
+++ b/ansible_events/builtin.py
@@ -19,7 +19,7 @@ import dpath.util
 import janus
 import yaml
 
-if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+if os.environ.get("RULES_ENGINE", "drools") == "drools":
     from drools import ruleset as lang
 else:
     from durable import lang

--- a/ansible_events/engine.py
+++ b/ansible_events/engine.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pprint import pformat
 from typing import Any, Dict, List, Optional, cast
 
-if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+if os.environ.get("RULES_ENGINE", "drools") == "drools":
     from drools import ruleset as lang
     from drools.exceptions import (
         MessageNotHandledException,
@@ -167,7 +167,7 @@ async def call_action(
     if action in builtin_actions:
         try:
             single_match = None
-            if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+            if os.environ.get("RULES_ENGINE", "drools") == "drools":
                 keys = list(rules_engine_result.data.keys())
                 if len(keys) == 1:
                     single_match = rules_engine_result.data[keys[0]]
@@ -313,7 +313,7 @@ async def run_ruleset(
         json_count(data)
         if isinstance(data, Shutdown):
             await event_log.put(dict(type="Shutdown"))
-            if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+            if os.environ.get("RULES_ENGINE", "drools") == "drools":
                 lang.end_session(name)
             return
         if not data:
@@ -345,7 +345,7 @@ async def run_ruleset(
             await event_log.put(dict(type="MessageNotHandled"))
         except ShutdownException:
             await event_log.put(dict(type="Shutdown"))
-            if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+            if os.environ.get("RULES_ENGINE", "drools") == "drools":
                 lang.end_session(name)
             return
         except Exception:

--- a/ansible_events/rule_generator.py
+++ b/ansible_events/rule_generator.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Callable, Dict, List
 
-if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+if os.environ.get("RULES_ENGINE", "drools") == "drools":
     from drools.rule import Rule as DroolsRule
     from drools.ruleset import Ruleset as DroolsRuleset
 
@@ -187,7 +187,7 @@ def make_fn(
     return fn
 
 
-if os.environ.get("RULES_ENGINE", "durable_rules") == "durable_rules":
+if os.environ.get("RULES_ENGINE", "drools") == "durable_rules":
 
     def generate_rulesets(
         ansible_ruleset_queue_plans: List[RuleSetQueuePlan],

--- a/ansible_events/rule_types.py
+++ b/ansible_events/rule_types.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, NamedTuple, Union
 
 import ansible_events.condition_types as ct
 
-if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+if os.environ.get("RULES_ENGINE", "drools") == "drools":
     from drools.ruleset import Ruleset as EngineRuleSet
 else:
     from durable.lang import ruleset as EngineRuleSet

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-if os.environ.get("RULES_ENGINE", "durable_rules") == "durable_rules":
+if os.environ.get("RULES_ENGINE", "drools") == "durable_rules":
     from durable.lang import c, m, none
 
     from ansible_events.condition_parser import condition, parse_condition
@@ -10,7 +10,7 @@ if os.environ.get("RULES_ENGINE", "durable_rules") == "durable_rules":
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test",
 )
 def test_infix():
@@ -36,7 +36,7 @@ def test_infix():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test",
 )
 def test_m():
@@ -80,7 +80,7 @@ def test_m():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test",
 )
 def test_parse_condition():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -735,7 +735,7 @@ async def test_27_var_root():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test, issues with jinja substitution",
 )
 @pytest.mark.asyncio

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 from queue import Queue
 
-if os.environ.get("RULES_ENGINE", "durable_rules") == "drools":
+if os.environ.get("RULES_ENGINE", "drools") == "drools":
     from drools.ruleset import assert_fact, post
 else:
     from durable import lang
@@ -18,7 +18,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test",
 )
 def test_m():
@@ -71,7 +71,7 @@ def test_m():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test",
 )
 def test_ruleset():
@@ -93,7 +93,7 @@ def test_ruleset():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test",
 )
 def test_rules():
@@ -125,7 +125,7 @@ def test_rules():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test",
 )
 def test_assert_facts():
@@ -149,7 +149,7 @@ def test_assert_facts():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "durable_rules") == "drools",
+    os.environ.get("RULES_ENGINE", "drools") == "drools",
     reason="durable rules only test",
 )
 def test_parse_rules():


### PR DESCRIPTION
We support 2 rules engines
* Drools
* Durable Rules

Till now the default rules engine was durable_rules now we are changing the default to Drools.

To run ansible_events with durable rules engine use

RULES_ENGINE=durable_rules ansible_events ....

or to run pytests with durable rules engine use

RULES_ENGINE=durable_rules pytest