### PR TITLE
require pyparsing >= 3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python_requires = >=3.6
 install_requires = 
 	asyncio
 	durable_rules
-	pyparsing
+	pyparsing >= 3.0
 	jsonschema
 	jinja2
 	redis


### PR DESCRIPTION
This PR:
- ensures `pyparsing >= 3.0` is installed as a requirement, see https://github.com/pyparsing/pyparsing/blob/master/docs/whats_new_in_3_0_0.rst#2api-changes 
- closes #179 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>