### PR TITLE
[AAP-4440] Support storing facts per host

### DIFF
--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -47,6 +47,7 @@ class RuleSet(NamedTuple):
     hosts: Union[str, List[str]]
     sources: List[EventSource]
     rules: List[Rule]
+    gather_facts: bool
 
 
 class ActionContext(NamedTuple):

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -24,6 +24,7 @@ def parse_rule_sets(rule_sets: Dict) -> List[rt.RuleSet]:
                 hosts=parse_hosts(rule_set["hosts"]),
                 sources=parse_event_sources(rule_set["sources"]),
                 rules=parse_rules(rule_set.get("rules", {})),
+                gather_facts=rule_set.get("gather_facts", False),
             )
         )
     return rule_set_list

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -1,7 +1,11 @@
+import glob
+import json
 import os
+import tempfile
 from pprint import pprint
 from typing import Any, Dict, List, Union
 
+import ansible_runner
 import jinja2
 import yaml
 
@@ -71,3 +75,38 @@ def json_count(data):
                 )
             for i in o.values():
                 q.append(i)
+
+
+def collect_ansible_facts(inventory: Dict) -> List[Dict]:
+    hosts_facts = []
+    with tempfile.TemporaryDirectory(
+        prefix="gather_facts"
+    ) as private_data_dir:
+        os.mkdir(os.path.join(private_data_dir, "inventory"))
+        with open(
+            os.path.join(private_data_dir, "inventory", "hosts"), "w"
+        ) as f:
+            f.write(yaml.dump(inventory))
+
+        r = ansible_runner.run(
+            private_data_dir=private_data_dir,
+            module="ansible.builtin.setup",
+            host_pattern="*",
+        )
+        if r.rc != 0:
+            raise Exception(
+                "Error collecting facts in ansible_runner.run "
+                f"rc={r.rc}, status={r.status}"
+            )
+
+        host_path = os.path.join(
+            private_data_dir, "artifacts", "*", "fact_cache", "*"
+        )
+        for host_file in glob.glob(host_path):
+            hostname = os.path.basename(host_file)
+            with open(host_file) as f:
+                data = json.load(f)
+            data["meta"] = dict(hosts=hostname)
+            hosts_facts.append(data)
+
+    return hosts_facts

--- a/schema/ruleset_schema.json
+++ b/schema/ruleset_schema.json
@@ -10,6 +10,10 @@
                 "hosts": {
                     "type": "string"
                 },
+                "gather_facts": {
+                    "type": "boolean",
+                    "default": false
+                },
                 "name": {
                     "type": "string"
                 },

--- a/tests/examples/37_hosts_facts.yml
+++ b/tests/examples/37_hosts_facts.yml
@@ -1,0 +1,22 @@
+---
+- name: Host facts
+  hosts: all
+  gather_facts: true
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name: "Host 1 rule"
+      condition:
+        all:
+          - fact.meta.hosts == "localhost"
+          - event.i == 1
+      action:
+        debug:
+    - name: "Host 2 rule"
+      condition:
+        all:
+          - fact.os == "linux"
+          - event.i == 4 
+      action:
+        debug:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,6 +5,7 @@ import pytest
 
 from ansible_rulebook.engine import run_rulesets
 from ansible_rulebook.messages import Shutdown
+from ansible_rulebook.util import load_inventory
 
 from .test_engine import load_rules
 
@@ -985,3 +986,33 @@ def validate_events(event_log, **kwargs):
         assert kwargs["processed_events"] == processed_events
     if "shutdown_events" in kwargs:
         assert kwargs["shutdown_events"] == shutdown_events
+
+
+@pytest.mark.skipif(
+    os.environ.get("RULES_ENGINE", "durable_rules") == "durable_rules",
+    reason="durable rules does not support more than 255 keys in facts",
+)
+@pytest.mark.asyncio
+async def test_37_hosts_facts():
+    ruleset_queues, event_log = load_rules("examples/37_hosts_facts.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(i=1))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "debug", "2"
+
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "7"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "8"
+    assert event_log.empty()


### PR DESCRIPTION
A ruleset can have an optional gather_facts flag which enables collection of ansible facts per host in the inventory list. These ansible facts are stored in the rules engine per host. When a rule matches the corresponding host fact and the event are returned from the rules engine.

You can refer to the facts per host using the fact prefix. e.g.

fact.meta.hosts == 'localhost'

When the fact is returned from the rules engine it allows us to limit the hosts that the playbook would run on by using the meta.hosts key.

https://issues.redhat.com/browse/AAP-4440