### PR TITLE
Limit to one artifacts folder for each playbook run

### DIFF
--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -388,6 +388,7 @@ async def call_runner(
                 verbosity=verbosity,
                 event_handler=event_callback,
                 json_mode=json_mode,
+                rotate_artifacts=1,
                 **runner_args,
             ),
         )
@@ -600,7 +601,6 @@ def get_status(private_data_dir: str):
     status_files = glob.glob(
         os.path.join(private_data_dir, "artifacts", "*", "status")
     )
-    status_files.sort(key=os.path.getmtime, reverse=True)
     with open(status_files[0], "r") as f:
         status = f.read()
     return status


### PR DESCRIPTION
Set ansible-runner option rotate_artifacts=1. This will keep only one artifacts folder under the ansible runner working folder. Since we create one temporary working folder for each firing of playbook action, adding this option has no side effect to normal situation. It is useful when retries option is configured for the action. It will automatically remove the artifacts folder for previous failed running and only preserve the latest artifacts.

Replaces #177