### PR TITLE
[AAP-6245] Filled rule names so they are not empty

### DIFF
--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -1,3 +1,13 @@
 class ShutdownException(Exception):
 
     pass
+
+
+class RulenameEmptyException(Exception):
+
+    pass
+
+
+class RulenameDuplicateException(Exception):
+
+    pass

--- a/ansible_rulebook/rule_generator.py
+++ b/ansible_rulebook/rule_generator.py
@@ -238,13 +238,7 @@ else:
                 name=ansible_ruleset.name,
                 serialized_ruleset=json.dumps(ruleset_ast["RuleSet"]),
             )
-            index = 0
             for ansible_rule in ansible_ruleset.rules:
-                if ansible_rule.name:
-                    rule_name = ansible_rule.name
-                else:
-                    rule_name = f"r_{index}"
-                index += 1
                 if ansible_rule.enabled:
                     fn = make_fn(
                         ansible_ruleset.name,
@@ -256,7 +250,7 @@ else:
                         plan,
                     )
                     drools_ruleset.add_rule(
-                        DroolsRule(name=rule_name, callback=fn)
+                        DroolsRule(name=ansible_rule.name, callback=fn)
                     )
 
             rulesets.append(

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -5,6 +5,8 @@ from ansible_rulebook.condition_parser import (
     parse_condition as parse_condition_value,
 )
 
+from .exception import RulenameDuplicateException, RulenameEmptyException
+
 
 def parse_hosts(hosts):
     if isinstance(hosts, str):
@@ -64,8 +66,21 @@ def parse_source_filter(source_filter: Dict) -> rt.EventSourceFilter:
 
 def parse_rules(rules: Dict) -> List[rt.Rule]:
     rule_list = []
+    rule_names = []
     for rule in rules:
         name = rule.get("name")
+        if name is None:
+            raise RulenameEmptyException("Rule name not provided")
+
+        if name == "":
+            raise RulenameEmptyException("Rule name cannot be an empty string")
+
+        if name in rule_names:
+            raise RulenameDuplicateException(
+                f"Rule with name {name} defined multiple times"
+            )
+
+        rule_names.append(name)
         rule_list.append(
             rt.Rule(
                 name=name,

--- a/tests/asts/test_assert_facts.yml
+++ b/tests/asts/test_assert_facts.yml
@@ -22,7 +22,7 @@
               rhs:
                 Integer: 1
         enabled: true
-        name: null
+        name: r1
     - Rule:
         action:
           Action:
@@ -43,7 +43,7 @@
               rhs:
                 String: hello world
         enabled: true
-        name: null
+        name: r2
     sources:
     - EventSource:
         name: range

--- a/tests/asts/test_filters.yml
+++ b/tests/asts/test_filters.yml
@@ -18,7 +18,7 @@
               rhs:
                 Integer: 0
         enabled: true
-        name: null
+        name: r1
     - Rule:
         action:
           Action:
@@ -32,7 +32,7 @@
               rhs:
                 Integer: 1
         enabled: true
-        name: null
+        name: r2
     - Rule:
         action:
           Action:
@@ -49,7 +49,7 @@
               rhs:
                 Integer: 2
         enabled: true
-        name: null
+        name: r3
     - Rule:
         action:
           Action:
@@ -60,7 +60,7 @@
           - IsDefinedExpression:
               Event: msg
         enabled: true
-        name: null
+        name: r4
     sources:
     - EventSource:
         name: range

--- a/tests/asts/test_host_rules.yml
+++ b/tests/asts/test_host_rules.yml
@@ -19,7 +19,7 @@
               rhs:
                 Integer: 1
         enabled: true
-        name: null
+        name: r1
     - Rule:
         action:
           Action:
@@ -34,7 +34,7 @@
               rhs:
                 Integer: 2
         enabled: true
-        name: null
+        name: r2
     - Rule:
         action:
           Action:
@@ -51,7 +51,7 @@
               rhs:
                 Integer: 3
         enabled: true
-        name: null
+        name: r3
     - Rule:
         action:
           Action:
@@ -68,7 +68,7 @@
               rhs:
                 Integer: 4
         enabled: true
-        name: null
+        name: r4
     - Rule:
         action:
           Action:
@@ -79,7 +79,7 @@
           - IsDefinedExpression:
               Event: j
         enabled: true
-        name: null
+        name: r5
     sources:
     - EventSource:
         name: hosts

--- a/tests/asts/test_rules.yml
+++ b/tests/asts/test_rules.yml
@@ -19,7 +19,7 @@
               rhs:
                 Integer: 1
         enabled: true
-        name: null
+        name: r1
     - Rule:
         action:
           Action:
@@ -34,7 +34,7 @@
               rhs:
                 Integer: 2
         enabled: true
-        name: null
+        name: r2
     - Rule:
         action:
           Action:
@@ -51,7 +51,7 @@
               rhs:
                 Integer: 3
         enabled: true
-        name: null
+        name: r3
     - Rule:
         action:
           Action:
@@ -68,7 +68,7 @@
               rhs:
                 Integer: 4
         enabled: true
-        name: null
+        name: r4
     - Rule:
         action:
           Action:
@@ -79,7 +79,7 @@
           - IsDefinedExpression:
               Event: j
         enabled: true
-        name: null
+        name: r5
     sources:
     - EventSource:
         name: range

--- a/tests/asts/test_rules_multiple_hosts.yml
+++ b/tests/asts/test_rules_multiple_hosts.yml
@@ -19,7 +19,7 @@
               rhs:
                 Integer: 1
         enabled: true
-        name: null
+        name: r1
     - Rule:
         action:
           Action:
@@ -34,7 +34,7 @@
               rhs:
                 Integer: 2
         enabled: true
-        name: null
+        name: r2
     - Rule:
         action:
           Action:
@@ -51,7 +51,7 @@
               rhs:
                 Integer: 3
         enabled: true
-        name: null
+        name: r3
     - Rule:
         action:
           Action:
@@ -68,7 +68,7 @@
               rhs:
                 Integer: 4
         enabled: true
-        name: null
+        name: r4
     - Rule:
         action:
           Action:
@@ -79,7 +79,7 @@
           - IsDefinedExpression:
               Event: j
         enabled: true
-        name: null
+        name: r5
     sources:
     - EventSource:
         name: range

--- a/tests/asts/test_rules_multiple_hosts2.yml
+++ b/tests/asts/test_rules_multiple_hosts2.yml
@@ -16,7 +16,7 @@
               rhs:
                 Integer: 1
         enabled: true
-        name: null
+        name: r1
     sources:
     - EventSource:
         name: range

--- a/tests/asts/test_rules_multiple_hosts3.yml
+++ b/tests/asts/test_rules_multiple_hosts3.yml
@@ -16,7 +16,7 @@
               rhs:
                 Integer: 1
         enabled: true
-        name: null
+        name: r1
     sources:
     - EventSource:
         name: range

--- a/tests/asts/test_simple.yml
+++ b/tests/asts/test_simple.yml
@@ -18,7 +18,7 @@
               rhs:
                 Integer: 0
         enabled: true
-        name: null
+        name: r1
     - Rule:
         action:
           Action:
@@ -32,7 +32,7 @@
               rhs:
                 Integer: 1
         enabled: true
-        name: null
+        name: r2
     - Rule:
         action:
           Action:
@@ -49,7 +49,7 @@
               rhs:
                 Integer: 2
         enabled: true
-        name: null
+        name: r3
     - Rule:
         action:
           Action:
@@ -60,7 +60,7 @@
           - IsDefinedExpression:
               Event: msg
         enabled: true
-        name: null
+        name: r4
     sources:
     - EventSource:
         name: range

--- a/tests/examples/01_noop.yml
+++ b/tests/examples/01_noop.yml
@@ -6,7 +6,7 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         none:

--- a/tests/examples/02_debug.yml
+++ b/tests/examples/02_debug.yml
@@ -6,7 +6,7 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         debug:

--- a/tests/examples/03_print_event.yml
+++ b/tests/examples/03_print_event.yml
@@ -6,7 +6,7 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         print_event:

--- a/tests/examples/04_assert_fact.yml
+++ b/tests/examples/04_assert_fact.yml
@@ -6,13 +6,13 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
           fact:
             msg: hello world
-    - name:
+    - name: r2
       condition: event.msg == "hello world"
       action:
         print_event:

--- a/tests/examples/05_post_event.yml
+++ b/tests/examples/05_post_event.yml
@@ -6,13 +6,13 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         post_event:
           event:
             msg: hello world
-    - name:
+    - name: r2
       condition: event.msg == "hello world"
       action:
         print_event:

--- a/tests/examples/06_retract_fact.yml
+++ b/tests/examples/06_retract_fact.yml
@@ -6,19 +6,19 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
           fact:
             msg: hello world
-    - name:
+    - name: r2
       condition: event.msg == "hello world"
       action:
         retract_fact:
           fact:
             msg: hello world
-    - name:
+    - name: r3
       condition: event.msg is not defined
       action:
         debug:

--- a/tests/examples/07_and.yml
+++ b/tests/examples/07_and.yml
@@ -6,7 +6,7 @@
         i_limit: 5
         j_limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.nested.i == 1 and event.nested.j == 1
       action:
         debug:

--- a/tests/examples/08_or.yml
+++ b/tests/examples/08_or.yml
@@ -6,7 +6,7 @@
         i_limit: 5
         j_limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.nested.i == 1 or event.nested.j == 1
       action:
         debug:

--- a/tests/examples/09_gt.yml
+++ b/tests/examples/09_gt.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i > 2
       action:
         debug:

--- a/tests/examples/10_lt.yml
+++ b/tests/examples/10_lt.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i < 2
       action:
         debug:

--- a/tests/examples/11_le.yml
+++ b/tests/examples/11_le.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i <= 2
       action:
         debug:

--- a/tests/examples/12_ge.yml
+++ b/tests/examples/12_ge.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i >= 2
       action:
         debug:

--- a/tests/examples/13_add.yml
+++ b/tests/examples/13_add.yml
@@ -6,7 +6,7 @@
         i_limit: 5
         j_limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.nested.i == event.nested.j + 1
       action:
         debug:

--- a/tests/examples/14_sub.yml
+++ b/tests/examples/14_sub.yml
@@ -6,7 +6,7 @@
         i_limit: 5
         j_limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.nested.i == event.nested.j - 1
       action:
         debug:

--- a/tests/examples/15_multiple_events_all.yml
+++ b/tests/examples/15_multiple_events_all.yml
@@ -6,7 +6,7 @@
         i_limit: 5
         j_limit: 5
   rules:
-    - name:
+    - name: r1
       condition:
         all:
           - event.nested.i == 1

--- a/tests/examples/16_multiple_events_any.yml
+++ b/tests/examples/16_multiple_events_any.yml
@@ -6,7 +6,7 @@
         i_limit: 5
         j_limit: 5
   rules:
-    - name:
+    - name: r1
       condition:
         any:
           - event.nested.i == 1

--- a/tests/examples/17_multiple_sources_any.yml
+++ b/tests/examples/17_multiple_sources_any.yml
@@ -7,7 +7,7 @@
     - range2:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition:
         any:
           - event.i == 1

--- a/tests/examples/18_multiple_sources_all.yml
+++ b/tests/examples/18_multiple_sources_all.yml
@@ -7,7 +7,7 @@
     - range2:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition:
         all:
           - event.i == 1

--- a/tests/examples/19_is_defined.yml
+++ b/tests/examples/19_is_defined.yml
@@ -5,13 +5,13 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
           fact:
             msg: hello
-    - name:
+    - name: r2
       condition: event.msg is defined
       action:
         debug:

--- a/tests/examples/20_is_not_defined.yml
+++ b/tests/examples/20_is_not_defined.yml
@@ -5,19 +5,19 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
           fact:
             msg: hello
-    - name:
+    - name: r2
       condition: event.msg is defined
       action:
         retract_fact:
           fact:
             msg: hello
-    - name:
+    - name: r3
       condition: event.msg is not defined
       action:
         debug:

--- a/tests/examples/21_run_playbook.yml
+++ b/tests/examples/21_run_playbook.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         run_playbook:

--- a/tests/examples/23_nested_data.yml
+++ b/tests/examples/23_nested_data.yml
@@ -5,7 +5,7 @@
     - replay:
         directory: examples/replays/23_nested_data
   rules:
-    - name:
+    - name: r1
       condition: event.root.nested.i == 1
       action:
         debug:

--- a/tests/examples/24_max_attributes.yml
+++ b/tests/examples/24_max_attributes.yml
@@ -5,7 +5,7 @@
     - replay:
         directory: examples/replays/24_max_attributes
   rules:
-    - name:
+    - name: r1
       condition: event.attr_1 == 1
       action:
         debug:

--- a/tests/examples/25_max_attributes_nested.yml
+++ b/tests/examples/25_max_attributes_nested.yml
@@ -5,7 +5,7 @@
     - replay:
         directory: examples/replays/25_max_attributes_nested
   rules:
-    - name:
+    - name: r1
       condition: event.branch_0.branch_0.branch_0.leaf_1 == 1
       action:
         debug:

--- a/tests/examples/26_print_events.yml
+++ b/tests/examples/26_print_events.yml
@@ -6,7 +6,7 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: 
         all:
           - event.i == 1

--- a/tests/examples/27_var_root.yml
+++ b/tests/examples/27_var_root.yml
@@ -4,9 +4,9 @@
   sources:
     - non_existent:
   rules:
-    - name:
+    - name: r1
       condition:
-        all:
+        all: 
           - events.webhook << event.webhook.payload.url == "http://www.example.com"
           - events.kafka << event.kafka.message.channel == "red"
       action:

--- a/tests/examples/28_right_side_condition_template.yml
+++ b/tests/examples/28_right_side_condition_template.yml
@@ -6,7 +6,7 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == "{{ custom.expected_index }}"
       action:
         debug:

--- a/tests/examples/29_run_module.yml
+++ b/tests/examples/29_run_module.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         run_module:

--- a/tests/examples/30_run_module_missing.yml
+++ b/tests/examples/30_run_module_missing.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         run_module:

--- a/tests/examples/31_run_module_missing_args.yml
+++ b/tests/examples/31_run_module_missing_args.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         run_module:

--- a/tests/examples/32_run_module_fail.yml
+++ b/tests/examples/32_run_module_fail.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         run_module:

--- a/tests/examples/33_run_playbook_retry.yml
+++ b/tests/examples/33_run_playbook_retry.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         run_playbook:

--- a/tests/examples/34_run_playbook_retries.yml
+++ b/tests/examples/34_run_playbook_retries.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         run_playbook:

--- a/tests/examples/35_multiple_rulesets_1_fired.yml
+++ b/tests/examples/35_multiple_rulesets_1_fired.yml
@@ -5,14 +5,14 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
           fact:
             do_not_fire_rule: True
           ruleset: 35 multiple rulesets 1
-    - name:
+    - name: r2
       condition: event.do_not_fire_rule == True
       action:
         none:
@@ -22,7 +22,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.do_not_fire_rule == True
       action:
         debug:

--- a/tests/examples/36_multiple_rulesets_both_fired.yml
+++ b/tests/examples/36_multiple_rulesets_both_fired.yml
@@ -5,7 +5,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
@@ -22,7 +22,7 @@
     - range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.fire_rule == True
       action:
         debug:

--- a/tests/rules/test_assert_facts.yml
+++ b/tests/rules/test_assert_facts.yml
@@ -6,7 +6,7 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
@@ -16,7 +16,7 @@
             beta: 
                name: R2D2
                location: Naboo
-    - name:
+    - name: r2
       condition: event.msg == "hello world"
       action:
         run_playbook:

--- a/tests/rules/test_duplicate_rule_names.yml
+++ b/tests/rules/test_duplicate_rule_names.yml
@@ -1,12 +1,16 @@
 ---
-- name: Test rules multiple hosts 3
+- name: Test ruleset with duplicate rule names
   hosts: all
   sources:
     - name: range
       range:
         limit: 5
   rules:
-    - name: r1
+    - name: rule1
       condition: event.i == 1
+      action:
+        debug:
+    - name: rule1
+      condition: event.i == 2
       action:
         debug:

--- a/tests/rules/test_filters.yml
+++ b/tests/rules/test_filters.yml
@@ -8,24 +8,24 @@
       filters:
         - noop:
   rules:
-    - name:
+    - name: r1
       condition: event.i == 0
       action:
         print_event:
           pretty: true
           var_root: i
-    - name:
+    - name: r2
       condition: event.i == 1
       action:
         print_event:
-    - name:
+    - name: r3
       condition: event.i == 2
       action:
         run_playbook:
           name: playbooks/hello_world_set_fact.yml
           var_root: i
           post_events: true
-    - name:
+    - name: r4
       condition: event.msg is defined
       action:
         print_event:

--- a/tests/rules/test_host_rules.yml
+++ b/tests/rules/test_host_rules.yml
@@ -6,33 +6,33 @@
       hosts:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
           ruleset: Test host rules
           fact:
             j: 1
-    - name:
+    - name: r2
       condition: event.i == 2
       action:
         run_playbook:
           name: playbooks/hello_events.yml
-    - name:
+    - name: r3
       condition: event.i == 3
       action:
         retract_fact:
           ruleset: Test host rules
           fact:
             j: 3
-    - name:
+    - name: r4
       condition: event.i == 4
       action:
         post_event:
           ruleset: Test host rules
           event:
             j: 4
-    - name:
+    - name: r5
       condition: event.j is defined
       action:
         none:

--- a/tests/rules/test_rules.yml
+++ b/tests/rules/test_rules.yml
@@ -6,33 +6,33 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
           ruleset: Test rules4
           fact:
             j: 1
-    - name:
+    - name: r2
       condition: event.i == 2
       action:
         run_playbook:
           name: playbooks/hello_world_set_fact.yml
-    - name:
+    - name: r3
       condition: event.i == 3
       action:
         retract_fact:
           ruleset: Test rules4
           fact:
             j: 3
-    - name:
+    - name: r4
       condition: event.i == 4
       action:
         post_event:
           ruleset: Test rules4
           event:
             j: 4
-    - name:
+    - name: r5
       condition: event.j is defined
       action:
         none:

--- a/tests/rules/test_rules_multiple_hosts.yml
+++ b/tests/rules/test_rules_multiple_hosts.yml
@@ -6,33 +6,33 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         assert_fact:
           ruleset: Test rules multiple hosts
           fact:
             j: 1
-    - name:
+    - name: r2
       condition: event.i == 2
       action:
         run_playbook:
           name: playbooks/hello_events.yml
-    - name:
+    - name: r3
       condition: event.i == 3
       action:
         retract_fact:
           ruleset: Test rules multiple hosts
           fact:
             j: 3
-    - name:
+    - name: r4
       condition: event.i == 4
       action:
         post_event:
           ruleset: Test rules multiple hosts
           event:
             j: 4
-    - name:
+    - name: r5
       condition: event.j is defined
       action:
         none:

--- a/tests/rules/test_rules_multiple_hosts2.yml
+++ b/tests/rules/test_rules_multiple_hosts2.yml
@@ -6,7 +6,7 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 1
       action:
         debug:

--- a/tests/rules/test_simple.yml
+++ b/tests/rules/test_simple.yml
@@ -6,24 +6,24 @@
       range:
         limit: 5
   rules:
-    - name:
+    - name: r1
       condition: event.i == 0
       action:
         print_event:
           pretty: true
           var_root: i
-    - name:
+    - name: r2
       condition: event.i == 1
       action:
         print_event:
-    - name:
+    - name: r3
       condition: event.i == 2
       action:
         run_playbook:
           name: playbooks/hello_world_set_fact.yml
           var_root: i
           post_events: true
-    - name:
+    - name: r4
       condition: event.msg is defined
       action:
         print_event:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from ansible_rulebook.engine import run_rulesets, start_source
+from ansible_rulebook.exception import RulenameDuplicateException
 from ansible_rulebook.messages import Shutdown
 from ansible_rulebook.rule_types import EventSource, EventSourceFilter
 from ansible_rulebook.rules_parser import parse_rule_sets
@@ -401,3 +402,9 @@ async def test_run_assert_facts():
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "3"
     assert event_log.get_nowait()["type"] == "Shutdown", "4"
     assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_rule_names():
+    with pytest.raises(RulenameDuplicateException):
+        load_rules("rules/test_duplicate_rule_names.yml")


### PR DESCRIPTION
Enforces that every rule in a rule set has a name and there are no duplicate names.

https://issues.redhat.com/browse/AAP-6245

Replacement for #174