### PR TITLE
Fixed rule names in performance rulebooks

### DIFF
--- a/performance_test/100k_event_rules.yml
+++ b/performance_test/100k_event_rules.yml
@@ -6,7 +6,7 @@
       range:
         limit: 100000
   rules:
-    - name:
+    - name: r1
       condition: event.i is defined
       action:
         none:

--- a/performance_test/10k_event_rules.yml
+++ b/performance_test/10k_event_rules.yml
@@ -6,7 +6,7 @@
       range:
         limit: 10000
   rules:
-    - name:
+    - name: r1
       condition: event.i is defined
       action:
         none:

--- a/performance_test/1k_event_rules.yml
+++ b/performance_test/1k_event_rules.yml
@@ -6,7 +6,7 @@
       range:
         limit: 1000
   rules:
-    - name:
+    - name: r1
       condition: event.i is defined
       action:
         none:

--- a/performance_test/null_rules.yml
+++ b/performance_test/null_rules.yml
@@ -6,7 +6,7 @@
       range:
         limit: 5
   rules:
-    - name:
-      condition: +event.i
+    - name: r1
+      condition: event.i is defined
       action:
         none:

--- a/performance_test/rules.yml
+++ b/performance_test/rules.yml
@@ -16,7 +16,7 @@
       condition: event.i == 2
       action:
         run_playbook:
-          name: playbooks/hello_events.yml
+          name: ./hello_playbook1.yml
     - name: r3
       condition: event.i == 3
       action:
@@ -30,6 +30,6 @@
           event:
             j: 4
     - name: r5
-      condition: +event.j
+      condition: event.j is defined
       action:
         none:


### PR DESCRIPTION
Fix performance tests, they were broken because of missing rule names and missing playbook.
To run the performance tests 
```
cd performance_test/
./run_perf.sh
```

Since they get behind most of the time would it make sense to run them as part of GitHub action