### PR TITLE
[AAP-6342] Don't use {{ }} in conditions

### DIFF
--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -25,10 +25,15 @@ Conditions
 
 When writing conditions 
   * use the **event** prefix when accessing data from the current event
-  * use the **fact** prefix when accessing data from the saved facts
+  * use the **fact** prefix when accessing data from the saved facts or passed in variables
   * use the **events** prefix when assigning variables and accessing data within the rule
   * use the **facts** prefix when assigning variables and accessing data within the rule
 
+
+| A condition **cannot** contain Jinja style substitution when accessing variables passed in
+| from the command line, we loose the data type information and the rule engine will not
+| process the condition. Instead use the fact prefix to access the data passed in from the
+| command line
 
 The following is an example rule::
 
@@ -104,6 +109,18 @@ Multiple conditions with facts and events and **all** of one of them have to mat
           - event.target_os == "windows"
       action:
         debug:
+
+Condition with fact and event, fact being passed in via --variables on command line
+-----------------------------------------------------------------------------------
+::
+
+      name: Condition using a passed in variable and an event
+      condition: event.i == fact.custom.expected_index
+      action:
+        debug:
+
+In the above example the custom.expected_index was passed in via --variables from the
+command line to ansible-rulebook.
 
 | When evaluating a single event you can compare multiple 
 | properties/attributes from the event using **and** or **or**

--- a/tests/examples/28_right_side_condition_template.yml
+++ b/tests/examples/28_right_side_condition_template.yml
@@ -7,6 +7,6 @@
         limit: 5
   rules:
     - name: r1
-      condition: event.i == "{{ custom.expected_index }}"
+      condition: event.i == fact.custom.expected_index
       action:
         debug:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -736,8 +736,8 @@ async def test_27_var_root():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RULES_ENGINE", "drools") == "drools",
-    reason="durable rules only test, issues with jinja substitution",
+    os.environ.get("RULES_ENGINE", "durable_rules") == "durable_rules",
+    reason="durable rules does not support using prior saved facts",
 )
 @pytest.mark.asyncio
 async def test_28_right_side_condition_template():


### PR DESCRIPTION
If we use the Jinja style substition in a condition we loose the data type. If we get variables from the user via the command line --variables we can set them as a fact in the rule engine and use fact. prefix to access it.

https://issues.redhat.com/browse/AAP-6342

This doesn't work in durable rules since in durable rules the assert_fact doesn't save the fact for later use. If the fact is not used its discarded. And in our case we are comparing an event and a fact in the same condition and we can't assert a fact and an event in the same call to satisfy durable rules conditions.