### PR TITLE
Replace ansible_events_id with ansible_rulebook_id for job event

### DIFF
--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -246,7 +246,7 @@ async def run_playbook(
         dict(
             type="Job",
             job_id=job_id,
-            ansible_events_id=settings.identifier,
+            ansible_rulebook_id=settings.identifier,
             name=playbook_name,
             ruleset=source_ruleset_name,
             rule=source_rule_name,
@@ -335,7 +335,7 @@ async def run_module(
         dict(
             type="Job",
             job_id=job_id,
-            ansible_events_id=settings.identifier,
+            ansible_rulebook_id=settings.identifier,
             name=module_name,
             ruleset=source_ruleset_name,
             rule=source_rule_name,


### PR DESCRIPTION
Fix job event log to use new key of `ansible_rulebook_id`