### PR TITLE
[AAP-4436] Combine the same playbook on multiple hosts

### DIFF
--- a/tests/rules/test_combine_hosts.yml
+++ b/tests/rules/test_combine_hosts.yml
@@ -1,0 +1,13 @@
+---
+- name: Combine hosts when run the same playbook
+  hosts: localhost0, localhost1
+  sources:
+    - name: range
+      range:
+        limit: 2
+  rules:
+    - name: r1
+      condition: event.i is defined
+      action:
+        run_playbook:
+          name: playbooks/hello_events.yml

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,7 +7,7 @@ from ansible_rulebook.engine import run_rulesets
 from ansible_rulebook.messages import Shutdown
 from ansible_rulebook.util import load_inventory
 
-from .test_engine import load_rulebook
+from .test_engine import load_rulebook, validate_events
 
 
 @pytest.mark.asyncio
@@ -972,32 +972,6 @@ async def test_36_multiple_rulesets_both_fired():
         ],
     }
     validate_events(event_log, **checks)
-
-
-def validate_events(event_log, **kwargs):
-    processed_events = 0
-    shutdown_events = 0
-    actions = []
-
-    for _ in range(kwargs["max_events"]):
-        event = event_log.get_nowait()
-        print(event)
-        if event["type"] == "ProcessedEvent":
-            processed_events += 1
-        elif event["type"] == "Action":
-            actions.append(
-                f"{event['ruleset']}::{event['rule']}::{event['action']}"
-            )
-        elif event["type"] == "Shutdown":
-            shutdown_events += 1
-
-    assert event_log.empty()
-    if "actions" in kwargs:
-        assert kwargs["actions"] == actions
-    if "processed_events" in kwargs:
-        assert kwargs["processed_events"] == processed_events
-    if "shutdown_events" in kwargs:
-        assert kwargs["shutdown_events"] == shutdown_events
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Run the same playbook only once based on multiple events in a
configurable time window through environmental variable
RUN_PLAYBOOK_DELAY (seconds). Combine hosts collected from all
related events.

Resolves AAP-4436: Combine the same action together on multiple hosts
based on multiple events in a certain period of time

This work only places run_playbook actions into the combinable queue. Technically all other actions can be treated the same way, but I feel there is no need since they are all quick actions. The only exception is the run_module action which can be easily handled the same way after the review.

depends on #202 
replaces #159 