### PR TITLE
Decrease python minimal version to 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,9 @@ env:
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: ["main"]
   pull_request:
-    branches: [ 'main' ]
+    branches: ["main"]
 
 jobs:
   tests:
@@ -17,29 +17,39 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.10" ]
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Java 
+
+      - name: Install Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install package
         run: python -m pip install -e .
+
       - name: Install test dependencies
         run: python -m pip install -r requirements_test.txt
+
       - name: Install `ansible.eda` collection
         run: ansible-galaxy collection install ansible.eda
+
       - name: Run tests via Durable rules
         run: pytest
+
       - name: Run tests via Drools
         run: pytest
         env:
-          RULES_ENGINE: durable_rules
+          RULES_ENGINE: drools

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Please ensure you have installed all components listed in the **Requirements** s
 Requirements
 ------------
 
-* Python >=3.9
+* Python >=3.8
 * Python 3 pip
 * Python 3 development libraries
 
@@ -30,7 +30,7 @@ Installation via pip
 
     JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
-2. We use a rules engine called Drools which is written in Java and needs to be compiled from source, by 
+2. We use a rules engine called Drools which is written in Java and needs to be compiled from source, by
    setting the following environment variable::
 
     export PIP_NO_BINARY=jpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
 	License :: OSI Approved :: Apache Software License
 	Natural Language :: English
 	Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
@@ -25,7 +26,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.8
 install_requires = 
 	asyncio
 	durable_rules

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = py39, flake8
+envlist = flake8,py38-{durable,drools},py39-{durable,drools},py310-{durable,drools}
 isolated_build = True
 
 [travis]
 python =
+    3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv:flake8]
 basepython = python
@@ -14,6 +16,9 @@ commands = flake8 ansible_rulebook tests
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
+    PIP_NO_BINARY = jpy
+    durable: RULES_ENGINE=durable_rules
+    drools: RULES_ENGINE=drools
 deps =
     -r{toxinidir}/requirements_dev.txt
 ; If you want to make tox run the tests with the same versions, create a


### PR DESCRIPTION
Reverts https://github.com/ansible/ansible-rulebook/pull/208

According to a recent conversation with @benthomasson has been decided to support python 3.8

Includes: 
- Update minimal version in setup and docs
- Update GH action to run supported versions. Fix engine envvar
- Update tox
