### PR TITLE
[AAP-5424] Catch source exceptions and return with exit code = 1

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -76,15 +76,20 @@ async def run(parsed_args) -> None:
     logger.info("Cancelling event source tasks")
     for task in tasks:
         task.cancel()
+
+    error_found = False
     results = await asyncio.gather(*tasks, return_exceptions=True)
     for result in results:
         if isinstance(result, Exception) and not isinstance(
             result, CancelledError
         ):
             logger.error(result)
+            error_found = True
 
     logger.info("Main complete")
     await event_log.put(dict(type="Exit"))
+    if error_found:
+        raise Exception("One of the source plugins failed")
 
 
 # TODO(cutwater): Maybe move to util.py

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -155,6 +155,7 @@ async def start_source(
         logger.info("Task cancelled")
     except BaseException:
         logger.exception("Source error")
+        raise
     finally:
         await queue.put(Shutdown())
 


### PR DESCRIPTION
Resolves AAP-5424: [CLI] ansible-events returns incorrect return code