### PR TITLE
AAP-7116 Enable drools for python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,11 +51,6 @@ jobs:
         run: pytest
 
       - name: Run tests via Drools
-        run: |
-          if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
-            echo "Skipping tests via drools for python 3.11"
-          else
-            pytest
-          fi
+        run: pytest
         env:
           RULES_ENGINE: drools

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -29,12 +29,6 @@ import sys
 from typing import List, NoReturn
 
 if os.environ.get("RULES_ENGINE", "drools") == "drools":
-    if sys.version_info >= (3, 11):
-        print(
-            "Drools engine is not available for python 3.11 "
-            "or higher versions."
-        )
-        sys.exit(1)
     if os.environ.get("JAVA_HOME") is None:
         print(
             "JAVA_HOME is not set. "

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy;python_version<"3.11"
+	drools_jpy
 
 [options.packages.find]
 include = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-# TODO: add env for py311-drools when https://github.com/jpy-consortium/jpy/issues/95 is solved
-envlist = flake8,py38-{durable,drools},py39-{durable,drools},py310-{durable,drools},py311-durable
+envlist = flake8,py38-{durable,drools},py39-{durable,drools},py310-{durable,drools},py311-{durable,drools}
 isolated_build = True
 
 [travis]


### PR DESCRIPTION
Enable drools engine for python 3.11
Close https://issues.redhat.com/browse/AAP-7116
