### PR TITLE
AAP-7205 add e2e tests for operators

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,12 @@ jobs:
         run: ansible-galaxy collection install git+https://github.com/ansible/event-driven-ansible
 
       - name: Run tests via Durable rules
-        run: pytest -vvv
+        run: pytest -m "not e2e" -vv
 
       - name: Run tests via Drools
-        run: pytest -vvv
+        run: pytest -m "not e2e" -vv
         env:
           EDA_RULES_ENGINE: drools
+
+      - name: Run e2e tests
+        run: pytest -m "e2e"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
-asyncio_mode=strict
-
+asyncio_mode = strict
+log_file_level = INFO
+log_cli = true
+markers =
+    e2e: mark for end to end tests

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(params=["durable_rules", "drools"])
+def rules_engine(request):
+    return {"EDA_RULES_ENGINE": request.param}

--- a/tests/e2e/files/inventories/default_inventory.yml
+++ b/tests/e2e/files/inventories/default_inventory.yml
@@ -1,0 +1,4 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/tests/e2e/files/playbooks/print_event.yml
+++ b/tests/e2e/files/playbooks/print_event.yml
@@ -1,0 +1,6 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Print event
+      ansible.builtin.debug:
+        msg: "Event matched: {{ event }}"

--- a/tests/e2e/files/rulebooks/operators/test_eq_operator_int.yml
+++ b/tests/e2e/files/rulebooks/operators/test_eq_operator_int.yml
@@ -1,0 +1,13 @@
+---
+- name: Test equal operator (int)
+  hosts: all
+  sources:
+    - range:
+        limit: 8
+  rules:
+    - name: r1
+      condition: event.i == 4
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_eq_operator_str.yml
+++ b/tests/e2e/files/rulebooks/operators/test_eq_operator_str.yml
@@ -1,0 +1,14 @@
+---
+- name: Test equal operator (str)
+  hosts: all
+  sources:
+    - range:
+        limit: 8
+        str_enable: true
+  rules:
+    - name: r1
+      condition: event.i == "4"
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_ge_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_ge_operator.yml
@@ -1,0 +1,14 @@
+---
+- name: Test greater or equal operator
+  hosts: all
+  sources:
+    - range:
+        limit: 8
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.i >= 5
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_gt_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_gt_operator.yml
@@ -1,0 +1,14 @@
+---
+- name: Test greater than operator
+  hosts: all
+  sources:
+    - range:
+        limit: 8
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.i > 4
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_is_defined_operator_int.yml
+++ b/tests/e2e/files/rulebooks/operators/test_is_defined_operator_int.yml
@@ -1,0 +1,14 @@
+---
+- name: Test is defined operator (int)
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.i is defined
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_is_defined_operator_nested.yml
+++ b/tests/e2e/files/rulebooks/operators/test_is_defined_operator_nested.yml
@@ -1,0 +1,15 @@
+---
+- name: Test is defined operator nested
+  hosts: all
+  sources:
+    - nested:
+        j_limit: 5
+        i_limit: 1
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.nested is defined
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_is_defined_operator_str.yml
+++ b/tests/e2e/files/rulebooks/operators/test_is_defined_operator_str.yml
@@ -1,0 +1,15 @@
+---
+- name: Test is defined operator (str)
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+        str_enable: true
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.i is defined
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_le_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_le_operator.yml
@@ -1,0 +1,14 @@
+---
+- name: Test less or equal operator
+  hosts: all
+  sources:
+    - range:
+        limit: 8
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.i <= 3
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_lt_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_lt_operator.yml
@@ -1,0 +1,14 @@
+---
+- name: Test less than operator
+  hosts: all
+  sources:
+    - range:
+        limit: 8
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.i < 4
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_ne_operator_int.yml
+++ b/tests/e2e/files/rulebooks/operators/test_ne_operator_int.yml
@@ -1,0 +1,14 @@
+---
+- name: Test less than operator
+  hosts: all
+  sources:
+    - range:
+        limit: 8
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.i != 5
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_ne_operator_str.yml
+++ b/tests/e2e/files/rulebooks/operators/test_ne_operator_str.yml
@@ -1,0 +1,15 @@
+---
+- name: Test not equal operator
+  hosts: all
+  sources:
+    - range:
+        limit: 8
+        str_enable: true
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.i != "5"
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_not_defined_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_not_defined_operator.yml
@@ -1,0 +1,14 @@
+---
+- name: Test is not defined operator
+  hosts: all
+  sources:
+    - range:
+        limit: 5
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.idonotexist is not defined
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/files/rulebooks/operators/test_not_defined_operator_nested.yml
+++ b/tests/e2e/files/rulebooks/operators/test_not_defined_operator_nested.yml
@@ -1,0 +1,15 @@
+---
+- name: Test is not defined operator nested
+  hosts: all
+  sources:
+    - nested:
+        j_limit: 5
+        i_limit: 1
+        # delay: 1
+  rules:
+    - name: r1
+      condition: event.nested.idonotexist is not defined
+      action:
+        run_playbook:
+          name: ./playbooks/print_event.yml
+          json_mode: true

--- a/tests/e2e/test_operators.py
+++ b/tests/e2e/test_operators.py
@@ -1,0 +1,237 @@
+"""
+Module with tests for operators
+"""
+import logging
+import subprocess
+
+import pytest
+
+from . import utils
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_TIMEOUT = 10
+
+
+@pytest.mark.xfail(reason="BUG: https://issues.redhat.com/browse/AAP-7206")
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "rulebook",
+    [
+        pytest.param("test_lt_operator.yml", id="lt"),
+        pytest.param("test_le_operator.yml", id="le"),
+    ],
+)
+def test_less_operators(rules_engine, rulebook):
+    """
+    GIVEN a rulebook with range source plugin that produces 8 events
+        and a condition like "i less than 4"
+        or a condition like "i less or equal 3"
+        and an action to run a playbook that prints the event
+    WHEN the program is executed
+    THEN the playbook must be executed 4 times printing each event
+        and the program must finish without errors
+    """
+    rulebook = utils.BASE_DATA_PATH / f"rulebooks/operators/{rulebook}"
+    cmd = utils.Command(rulebook=rulebook)
+
+    LOGGER.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd,
+        env=utils.get_environ(rules_engine),
+        timeout=DEFAULT_TIMEOUT,
+        capture_output=True,
+        cwd=utils.BASE_DATA_PATH,
+    )
+
+    output = utils.assert_playbook_output(result)
+
+    printed_events = [
+        line for line in output if "Event matched" in line["stdout"]
+    ]
+
+    assert len(printed_events) == 4
+
+    for event, expected in zip(printed_events, range(4)):
+        assert f"{{'i': {expected}}}" in event["stdout"]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "rulebook, expected",
+    [
+        pytest.param("test_eq_operator_int.yml", "{'i': 4}", id="int"),
+        pytest.param("test_eq_operator_str.yml", "{'i': '4'}", id="str"),
+    ],
+)
+def test_eq_operator(rules_engine, rulebook, expected):
+    """
+    GIVEN a rulebook with range source plugin that produces 8 events
+        and a condition like "i equal 4"
+        or a condition like "i equal '4'" (str)
+        and an action to run a playbook that prints the event
+    WHEN the program is executed
+    THEN the playbook must be executed 1 time printing the event
+        and the program must finish without errors
+    """
+    rulebook = utils.BASE_DATA_PATH / f"rulebooks/operators/{rulebook}"
+    cmd = utils.Command(rulebook=rulebook)
+
+    LOGGER.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd,
+        env=utils.get_environ(rules_engine),
+        timeout=DEFAULT_TIMEOUT,
+        capture_output=True,
+        cwd=utils.BASE_DATA_PATH,
+    )
+
+    output = utils.assert_playbook_output(result)
+
+    printed_event = next(
+        line for line in output if "Event matched" in line["stdout"]
+    )
+
+    assert expected in printed_event["stdout"]
+
+
+@pytest.mark.xfail(reason="BUG: https://issues.redhat.com/browse/AAP-7206")
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "rulebook",
+    [
+        pytest.param("test_ge_operator.yml", id="ge_operator"),
+        pytest.param("test_gt_operator.yml", id="gt_operator"),
+    ],
+)
+def test_greater_operators(rules_engine, rulebook):
+    """
+    GIVEN a rulebook with range source plugin that produces 8 events
+        and a condition like "i greater or equal than 5"
+        or a condition like "i greater than 4"
+        and an action to run a playbook that prints the event
+    WHEN the program is executed
+    THEN the playbook must be executed 3 times printing the event
+        and the program must finish without errors
+    """
+    rulebook = utils.BASE_DATA_PATH / f"rulebooks/operators/{rulebook}"
+    cmd = utils.Command(rulebook=rulebook)
+
+    LOGGER.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd,
+        env=utils.get_environ(rules_engine),
+        timeout=DEFAULT_TIMEOUT,
+        capture_output=True,
+        cwd=utils.BASE_DATA_PATH,
+    )
+
+    output = utils.assert_playbook_output(result)
+
+    printed_events = [
+        line for line in output if "Event matched" in line["stdout"]
+    ]
+
+    assert len(printed_events) == 3
+
+    for event, expected in zip(printed_events, range(5, 8)):
+        assert f"{{'i': {expected}}}" in event["stdout"]
+
+
+@pytest.mark.xfail(reason="BUG: https://issues.redhat.com/browse/AAP-7206")
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "rulebook",
+    [
+        pytest.param("test_ne_operator_str.yml", id="str"),
+        pytest.param("test_ne_operator_int.yml", id="int"),
+    ],
+)
+def test_ne_operator(rules_engine, rulebook, request):
+    """
+    GIVEN a rulebook with range source plugin that produces 8 events
+        and a condition like "i not equal 5"
+        and an action to run a playbook that prints the event
+    WHEN the program is executed
+    THEN the playbook must be executed 7 times printing the event
+        and the program must finish without errors
+    """
+    rulebook = utils.BASE_DATA_PATH / f"rulebooks/operators/{rulebook}"
+    cmd = utils.Command(rulebook=rulebook)
+
+    LOGGER.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd,
+        env=utils.get_environ(rules_engine),
+        timeout=DEFAULT_TIMEOUT,
+        capture_output=True,
+        cwd=utils.BASE_DATA_PATH,
+    )
+
+    output = utils.assert_playbook_output(result)
+
+    printed_events = [
+        line for line in output if "Event matched" in line["stdout"]
+    ]
+
+    assert len(printed_events) == 7
+    for event, expected in zip(printed_events, [0, 1, 2, 3, 4, 6, 7]):
+        if "str" in request.node.callspec.id:
+            expected = f"{{'i': '{expected}'}}"
+        else:
+            expected = f"{{'i': {expected}}}"
+        assert expected in event["stdout"]
+
+
+@pytest.mark.xfail(reason="BUG: https://issues.redhat.com/browse/AAP-7206")
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "rulebook",
+    [
+        pytest.param("test_is_defined_operator_str.yml", id="str"),
+        pytest.param("test_is_defined_operator_int.yml", id="int"),
+        pytest.param("test_is_defined_operator_nested.yml", id="nested"),
+        pytest.param(
+            "test_not_defined_operator.yml",
+            id="negative",
+            marks=pytest.mark.xfail(
+                reason="Bug https://issues.redhat.com/browse/AAP-7240"
+            ),
+        ),
+        pytest.param(
+            "test_not_defined_operator_nested.yml",
+            id="negative_nested",
+            marks=pytest.mark.xfail(
+                reason="Bug https://issues.redhat.com/browse/AAP-7240"
+            ),
+        ),
+    ],
+)
+def test_defined_operator(rules_engine, rulebook):
+    """
+    GIVEN a rulebook with range source plugin that produces 5 events
+        and a condition like "i is defined"
+        and an action to run a playbook that prints the event
+    WHEN the program is executed
+    THEN the playbook must be executed 5 times printing the event
+        and the program must finish without errors
+    """
+
+    rulebook = utils.BASE_DATA_PATH / f"rulebooks/operators/{rulebook}"
+    cmd = utils.Command(rulebook=rulebook)
+
+    LOGGER.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd,
+        env=utils.get_environ(rules_engine),
+        timeout=DEFAULT_TIMEOUT,
+        capture_output=True,
+        cwd=utils.BASE_DATA_PATH,
+    )
+
+    output = utils.assert_playbook_output(result)
+
+    printed_events = [
+        line for line in output if "Event matched" in line["stdout"]
+    ]
+
+    assert len(printed_events) == 5

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -1,0 +1,108 @@
+"""module with utils for e2e tests"""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from subprocess import CompletedProcess
+from typing import Iterable, List, Optional, Union
+
+BASE_DATA_PATH = Path(f"{__file__}").parent / Path("files")
+DEFAULT_SOURCES = Path(f"{__file__}").parent / Path("../sources")
+DEFAULT_INVENTORY = BASE_DATA_PATH / "inventories/default_inventory.yml"
+
+
+@dataclass
+class Command:
+    """
+    Represents the command and their arguments and
+    provides methods to render it for cmd runners
+    """
+
+    rulebook: Path
+    program_name: str = "ansible-rulebook"
+    cwd: Path = BASE_DATA_PATH
+    inventory: Path = DEFAULT_INVENTORY
+    sources: Optional[Path] = DEFAULT_SOURCES
+    vars_file: Optional[Path] = None
+    envvars: Optional[str] = None
+    proc_id: Union[str, int, None] = None
+    verbose: bool = False
+    debug: bool = False
+    websocket: Optional[str] = None
+    project_tarball: Optional[Path] = None
+    worker_mode: bool = False
+
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def __iter__(self) -> Iterable:
+        return (item for item in self.to_list())
+
+    def to_list(self) -> List:
+        result = [self.program_name]
+
+        result.extend(["-i", str(self.inventory.absolute())])
+
+        if self.sources:
+            result.extend(["-S", str(self.sources.absolute())])
+        if self.vars_file:
+            result.extend(["--vars", str(self.vars_file.absolute())])
+        if self.envvars:
+            result.extend(["--env-vars", self.envvars])
+        if self.proc_id:
+            result.extend(["--id", str(self.proc_id)])
+        if self.websocket:
+            result.extend(["--websocket-address", self.websocket])
+        if self.project_tarball:
+            result.extend(
+                ["--project-tarball", str(self.project_tarball.absolute())]
+            )
+        if self.worker_mode:
+            result.append("--worker")
+        if self.rulebook:
+            result.extend(["--rulebook", str(self.rulebook.absolute())])
+        if self.verbose:
+            result.append("--verbose")
+        if self.debug:
+            result.append("--debug")
+
+        return result
+
+    def to_string(self) -> str:
+        return " ".join(self.to_list())
+
+
+def jsonify_output(output: str) -> List[dict]:
+    """
+    Receives an str from the cmd output when json_mode is enabled
+    and returns the list of dicts
+    """
+    return [json.loads(line) for line in output.splitlines()]
+
+
+def assert_playbook_output(result: CompletedProcess) -> List[dict]:
+    """
+    Common logic to assert a succesful execution of a run_playbook action.
+    Returns the stdout deserialized
+    """
+    assert result.returncode == 0
+    assert not result.stderr
+
+    output = jsonify_output(result.stdout.decode())
+
+    assert output[-1]["event_data"]["ok"]
+    assert not output[-1]["event_data"]["failures"]
+
+    return output
+
+
+def get_environ(envvars: dict) -> dict:
+    """
+    Returns a copy of the environment and updates it
+    with the received dict.
+    """
+
+    environ = os.environ.copy()
+    environ.update(envvars)
+    return environ

--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+function run {
+    echo "RUNNING $1"
+    ansible-rulebook --rulebook "./${1}" --inventory ./playbooks/inventory.yml -S ./sources/ &>/dev/null
+    if [[ $? -ne 0 ]]; then
+        echo "PROBLEM with $1"
+    fi
+}
+
+for file in examples/*.yml; do
+    run $file
+done

--- a/tests/sources/nested.py
+++ b/tests/sources/nested.py
@@ -18,10 +18,14 @@ from typing import Any, Dict
 
 async def main(queue: asyncio.Queue, args: Dict[str, Any]):
     delay = args.get("delay", 0)
+    str_enable = args.get("str_enable", False)
 
-    for j in range(int(args["i_limit"])):
-        for i in range(int(args["j_limit"])):
-            await queue.put(dict(nested=dict(i=i, j=j)))
+    for i in range(int(args["i_limit"])):
+        for j in range(int(args["j_limit"])):
+            payload = {"nested": {"i": i, "j": j}}
+            if str_enable:
+                payload = {"nested": {"i": f"{i}", "j": f"{j}"}}
+            await queue.put(payload)
             await asyncio.sleep(delay)
 
 

--- a/tests/sources/range.py
+++ b/tests/sources/range.py
@@ -18,9 +18,11 @@ from typing import Any, Dict
 
 async def main(queue: asyncio.Queue, args: Dict[str, Any]):
     delay = args.get("delay", 0)
+    str_enable = args.get("str_enable", False)
 
     for i in range(int(args["limit"])):
-        await queue.put(dict(i=i))
+        payload = {"i": f"{i}"} if str_enable else {"i": i}
+        await queue.put(payload)
         await asyncio.sleep(delay)
 
 


### PR DESCRIPTION
1st delivery of the e2e test suite. Includes:
- CLI tests for basic usage of operators. Most of them are currently marked as XFAIL due to found bugs.
- Logging conf for pytest. 
- Little improvement for nested and range plugins
- Convenient simple bash script to run manually the rulebook in examples. 

Closes AAP-7205 
