### PR TITLE
Do not send ProcessedEvent for unmatched events

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -125,8 +125,8 @@ async def test_run_rulesets():
     )
 
     checks = {
-        "max_events": 23,
-        "processed_events": 5,
+        "max_events": 22,
+        "processed_events": 4,
         "shutdown_events": 1,
         "job_events": 1,
         "ansible_events": 9,
@@ -155,8 +155,6 @@ async def test_run_rules_with_assignment():
 
     assert event_log.get_nowait()["type"] == "Action", "0"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "1"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '1'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "2"
     assert event_log.get_nowait()["type"] == "Shutdown", "3"
     assert event_log.empty()
 
@@ -181,8 +179,6 @@ async def test_run_rules_with_assignment2():
 
     assert event_log.get_nowait()["type"] == "Action", "0"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "1"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '1'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "2"
     assert event_log.get_nowait()["type"] == "Shutdown", "3"
     assert event_log.empty()
 
@@ -242,8 +238,8 @@ async def test_run_multiple_hosts():
     )
 
     checks = {
-        "max_events": 27,
-        "processed_events": 6,
+        "max_events": 25,
+        "processed_events": 4,
         "shutdown_events": 1,
         "job_events": 1,
         "ansible_events": 13,
@@ -274,19 +270,9 @@ async def test_run_multiple_hosts2():
         load_inventory("playbooks/inventory1.yml"),
     )
 
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '0'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "1"
-    assert event_log.get_nowait()["type"] == "Action", "1.1"
+    assert event_log.get_nowait()["type"] == "Action", "1"
     assert event_log.get_nowait()["type"] == "ProcessedEvent", "2"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '2.5'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "3"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '4'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "5"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '6'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "7"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '8'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "9"
-    assert event_log.get_nowait()["type"] == "Shutdown", "10"
+    assert event_log.get_nowait()["type"] == "Shutdown", "3"
     assert event_log.empty()
 
 
@@ -312,20 +298,9 @@ async def test_run_multiple_hosts3():
         load_inventory("playbooks/inventory.yml"),
     )
 
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '0'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "1"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '2'
-    assert event_log.get_nowait()["type"] == "Action", "2"
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "3"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '4'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "5"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '6'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "7"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '8'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "9"
-    # assert event_log.get_nowait()['type'] == 'MessageNotHandled', '10'
-    assert event_log.get_nowait()["type"] == "ProcessedEvent", "11"
-    assert event_log.get_nowait()["type"] == "Shutdown", "12"
+    assert event_log.get_nowait()["type"] == "Action", "1"
+    assert event_log.get_nowait()["type"] == "ProcessedEvent", "2"
+    assert event_log.get_nowait()["type"] == "Shutdown", "3"
     assert event_log.empty()
 
 
@@ -382,8 +357,8 @@ async def test_run_rulesets_on_hosts():
     )
 
     checks = {
-        "max_events": 23,
-        "processed_events": 5,
+        "max_events": 22,
+        "processed_events": 4,
         "shutdown_events": 1,
         "job_events": 1,
         "ansible_events": 9,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -405,8 +405,6 @@ async def test_15_multiple_events_all():
     )
 
     event = event_log.get_nowait()
-    assert event["type"] == "ProcessedEvent", "0"
-    event = event_log.get_nowait()
     assert event["type"] == "Action", "1"
     assert event["action"] == "debug", "2"
     event = event_log.get_nowait()
@@ -494,8 +492,6 @@ async def test_18_multiple_sources_all():
         dict(),
     )
 
-    event = event_log.get_nowait()
-    assert event["type"] == "ProcessedEvent", "0"
     event = event_log.get_nowait()
     assert event["type"] == "Action", "1"
     assert event["action"] == "debug", "2"
@@ -625,8 +621,6 @@ async def test_23_nested_data():
     )
 
     event = event_log.get_nowait()
-    assert event["type"] == "ProcessedEvent", "0"
-    event = event_log.get_nowait()
     assert event["type"] == "Action", "1"
     event = event_log.get_nowait()
     assert event["type"] == "ProcessedEvent", "2"
@@ -707,7 +701,6 @@ async def test_26_print_events():
         dict(),
     )
 
-    event_log.get_nowait()
     event = event_log.get_nowait()
     assert event["type"] == "Action", "1"
     assert event["action"] == "print_event", "2"
@@ -743,8 +736,6 @@ async def test_27_var_root():
     )
 
     event = event_log.get_nowait()
-    assert event["type"] == "ProcessedEvent", "0"
-    event = event_log.get_nowait()
     assert event["type"] == "Action", "1"
     assert event["action"] == "print_event", "2"
 
@@ -773,7 +764,6 @@ async def test_28_right_side_condition_template():
         dict(),
     )
 
-    event_log.get_nowait()
     event = event_log.get_nowait()
     assert event["type"] == "Action", "1"
     assert event["action"] == "debug", "2"
@@ -944,8 +934,8 @@ async def test_35_multiple_rulesets_1_fired():
     )
 
     checks = {
-        "max_events": 5,
-        "processed_events": 2,
+        "max_events": 4,
+        "processed_events": 1,
         "shutdown_events": 1,
         "actions": [
             "35 multiple rulesets 1::r1::set_fact",
@@ -977,8 +967,8 @@ async def test_36_multiple_rulesets_both_fired():
         dict(),
     )
     checks = {
-        "max_events": 6,
-        "processed_events": 3,
+        "max_events": 5,
+        "processed_events": 2,
         "shutdown_events": 1,
         "actions": [
             "36 multiple rulesets 1::r1::set_fact",


### PR DESCRIPTION
There is no need to add empty ProcessedEvent to event_log for events that do not match any rules.

Resolves AAP-6141

Type `ProcessedEvent`, `EmptyEvent`, `MessageNotHandled` are not processed by eda-server at all. In theory we could stop sending these event-log completely. Open for discussion.

We could also added an ENV to preserve the feature of adding a ProcessedEvent for every event like before as discussed in [AAP-6141](https://issues.redhat.com/browse/AAP-6141). Is there any use for such event log? 