### PR TITLE
Set logger for websocket connect

### DIFF
--- a/ansible_rulebook/websocket.py
+++ b/ansible_rulebook/websocket.py
@@ -85,7 +85,9 @@ async def request_workload(activation_id, websocket_address):
 
 async def send_event_log_to_websocket(event_log, websocket_address):
     logger.info("websocket %s connecting", websocket_address)
-    async for websocket in websockets.connect(websocket_address):
+    async for websocket in websockets.connect(
+        websocket_address, logger=logger
+    ):
         logger.info("websocket %s connected", websocket_address)
         event = None
         try:


### PR DESCRIPTION
The websockets library will print connection failure and retry messages at INFO level through the provided logger.

Resolves AAP-6564: ansible-rulebook doesn't handle wrong websocket servers