### PR TITLE
Pin flake8 version

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,4 +1,4 @@
-flake8
+flake8==5.0.4
 flake8-bugbear
 isort
 black


### PR DESCRIPTION
There is a new release of flake (6.0.0) that seems is not parsing correctly the comment in the setup.cfg, causing all our tests to fail. This PR pin the version to the most recent working version. 