### PR TITLE
Move collection installation to repository for GH action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: python -m pip install -r requirements_test.txt
 
       - name: Install `ansible.eda` collection
-        run: ansible-galaxy collection install ansible.eda
+        run: ansible-galaxy collection install git+https://github.com/ansible/event-driven-ansible
 
       - name: Run tests via Durable rules
         run: pytest


### PR DESCRIPTION
Galaxy requests are rate limited by IP causing error in our GH action. This PR change the installation method to use the source code instead the public galaxy repository. 