### PR TITLE
[AAP-7647] Support for in and contains in condition

### DIFF
--- a/ansible_rulebook/condition_types.py
+++ b/ansible_rulebook/condition_types.py
@@ -32,9 +32,9 @@ class Identifier(NamedTuple):
 
 
 class OperatorExpression(NamedTuple):
-    left: Union[Integer, String]
+    left: Union[Integer, String, List]
     operator: str
-    right: Union[Integer, String]
+    right: Union[Integer, String, List]
 
 
 class ExistsExpression(NamedTuple):

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -161,6 +161,22 @@ def visit_condition(parsed_condition: ConditionTypes, variables: Dict):
                     ),
                 }
             }
+        elif parsed_condition.operator == "in":
+            return create_binary_node(
+                "ItemInListExpression", parsed_condition, variables
+            )
+        elif parsed_condition.operator == "not in":
+            return create_binary_node(
+                "ItemNotInListExpression", parsed_condition, variables
+            )
+        elif parsed_condition.operator == "contains":
+            return create_binary_node(
+                "ListContainsItemExpression", parsed_condition, variables
+            )
+        elif parsed_condition.operator == "not contains":
+            return create_binary_node(
+                "ListNotContainsItemExpression", parsed_condition, variables
+            )
         else:
             raise Exception(f"Unhandled token {parsed_condition}")
     elif isinstance(parsed_condition, ExistsExpression):
@@ -170,6 +186,15 @@ def visit_condition(parsed_condition: ConditionTypes, variables: Dict):
         return visit_condition(parsed_condition.value, variables).__pos__()
     else:
         raise Exception(f"Unhandled token {parsed_condition}")
+
+
+def create_binary_node(name, parsed_condition, variables):
+    return {
+        name: {
+            "lhs": visit_condition(parsed_condition.left, variables),
+            "rhs": visit_condition(parsed_condition.right, variables),
+        }
+    }
 
 
 def visit_rule(parsed_rule: Rule, variables: Dict):

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -631,6 +631,14 @@ currently supported
      - To check if a variable is defined
    * - is not defined
      - To check if a variable is not defined
+   * - in
+     - Check if an item on the left hand side exists in a list defined on the right hand side
+   * - not in
+     - Check if an item on the left hand side does not exist in a list defined on the right hand side.
+   * - contains
+     - Check if a list on the left hand side contains the item defined on the right hand side
+   * - not contains
+     - Check if a list on the left hand side does not contain the item defined on the right hand side
    * - `<<`
      - Assignment operator, to save the matching events or facts with events or facts prefix
 

--- a/tests/examples/40_in.yml
+++ b/tests/examples/40_in.yml
@@ -1,0 +1,12 @@
+---
+- name: 40 in
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i in [1,2,3,4]
+      action:
+        debug:

--- a/tests/examples/41_not_in.yml
+++ b/tests/examples/41_not_in.yml
@@ -1,0 +1,12 @@
+---
+- name: 41 not in
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i not in [11,21,31,41]
+      action:
+        debug:

--- a/tests/examples/42_contains.yml
+++ b/tests/examples/42_contains.yml
@@ -1,0 +1,12 @@
+---
+- name: 42 contains
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.id_list contains 1 
+      action:
+        debug:

--- a/tests/examples/43_not_contains.yml
+++ b/tests/examples/43_not_contains.yml
@@ -1,0 +1,12 @@
+---
+- name: 43 not contains
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.id_list not contains 10
+      action:
+        debug:

--- a/tests/examples/44_in_and.yml
+++ b/tests/examples/44_in_and.yml
@@ -1,0 +1,12 @@
+---
+- name: 44 in and
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i > 3 and event.i in [1,2,3,4]
+      action:
+        debug:

--- a/tests/examples/45_in_or.yml
+++ b/tests/examples/45_in_or.yml
@@ -1,0 +1,12 @@
+---
+- name: 45 in or
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i > 5 or event.i in [1,2,3,4]
+      action:
+        debug:

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -187,6 +187,75 @@ def test_parse_condition():
         {},
     )
 
+    assert {
+        "ItemInListExpression": {
+            "lhs": {"Fact": "i"},
+            "rhs": [{"Integer": 1}, {"Integer": 2}, {"Integer": 3}],
+        }
+    } == visit_condition(parse_condition("fact.i in [1,2,3]"), {})
+
+    assert {
+        "ItemInListExpression": {
+            "lhs": {"Fact": "name"},
+            "rhs": [
+                {"String": "fred"},
+                {"String": "barney"},
+                {"String": "wilma"},
+            ],
+        }
+    } == visit_condition(
+        parse_condition("fact.name in ['fred','barney','wilma']"), {}
+    )
+
+    assert {
+        "ItemNotInListExpression": {
+            "lhs": {"Fact": "i"},
+            "rhs": [{"Integer": 1}, {"Integer": 2}, {"Integer": 3}],
+        }
+    } == visit_condition(parse_condition("fact.i not in [1,2,3]"), {})
+
+    assert {
+        "ItemNotInListExpression": {
+            "lhs": {"Fact": "name"},
+            "rhs": [
+                {"String": "fred"},
+                {"String": "barney"},
+                {"String": "wilma"},
+            ],
+        }
+    } == visit_condition(
+        parse_condition("fact.name not in ['fred','barney','wilma']"), {}
+    )
+    assert {
+        "ListContainsItemExpression": {
+            "lhs": {"Fact": "mylist"},
+            "rhs": {"Integer": 1},
+        }
+    } == visit_condition(parse_condition("fact.mylist contains 1"), {})
+
+    assert {
+        "ListContainsItemExpression": {
+            "lhs": {"Fact": "friends"},
+            "rhs": {"String": "fred"},
+        }
+    } == visit_condition(parse_condition("fact.friends contains 'fred'"), {})
+
+    assert {
+        "ListNotContainsItemExpression": {
+            "lhs": {"Fact": "mylist"},
+            "rhs": {"Integer": 1},
+        }
+    } == visit_condition(parse_condition("fact.mylist not contains 1"), {})
+
+    assert {
+        "ListNotContainsItemExpression": {
+            "lhs": {"Fact": "friends"},
+            "rhs": {"String": "fred"},
+        }
+    } == visit_condition(
+        parse_condition("fact.friends not contains 'fred'"), {}
+    )
+
 
 @pytest.mark.parametrize(
     "rulebook",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1026,3 +1026,175 @@ async def test_38_shutdown_action():
     assert event["action"] == "shutdown", "1"
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "2"
+
+
+@pytest.mark.skipif(
+    os.environ.get("EDA_RULES_ENGINE", "drools") == "durable_rules",
+    reason="durable rules does not support in",
+)
+@pytest.mark.asyncio
+async def test_40_in():
+    ruleset_queues, event_log = load_rulebook("examples/40_in.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(i=1))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "debug", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "3"
+
+
+@pytest.mark.skipif(
+    os.environ.get("EDA_RULES_ENGINE", "drools") == "durable_rules",
+    reason="durable rules does not support not in",
+)
+@pytest.mark.asyncio
+async def test_41_not_in():
+    ruleset_queues, event_log = load_rulebook("examples/41_not_in.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(i=1))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "debug", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "3"
+
+
+@pytest.mark.skipif(
+    os.environ.get("EDA_RULES_ENGINE", "drools") == "durable_rules",
+    reason="durable rules does not support contains",
+)
+@pytest.mark.asyncio
+async def test_42_contains():
+    ruleset_queues, event_log = load_rulebook("examples/42_contains.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(id_list=[1, 2, 3]))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "debug", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "3"
+
+
+@pytest.mark.skipif(
+    os.environ.get("EDA_RULES_ENGINE", "drools") == "durable_rules",
+    reason="durable rules does not support not contains",
+)
+@pytest.mark.asyncio
+async def test_43_not_contains():
+    ruleset_queues, event_log = load_rulebook("examples/43_not_contains.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(id_list=[1, 2, 3]))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "debug", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "3"
+
+
+@pytest.mark.skipif(
+    os.environ.get("EDA_RULES_ENGINE", "drools") == "durable_rules",
+    reason="durable rules does not support in",
+)
+@pytest.mark.asyncio
+async def test_44_in_and():
+    ruleset_queues, event_log = load_rulebook("examples/44_in_and.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(i=0))
+    queue.put_nowait(dict(i=1))
+    queue.put_nowait(dict(i=2))
+    queue.put_nowait(dict(i=3))
+    queue.put_nowait(dict(i=4))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "debug", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "3"
+
+
+@pytest.mark.skipif(
+    os.environ.get("EDA_RULES_ENGINE", "drools") == "durable_rules",
+    reason="durable rules does not support in",
+)
+@pytest.mark.asyncio
+async def test_45_in_or():
+    ruleset_queues, event_log = load_rulebook("examples/45_in_or.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(i=4))
+    queue.put_nowait(dict(i=8))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "debug", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "3"
+    assert event["action"] == "debug", "3"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "4"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "5"


### PR DESCRIPTION
Added support for
* in
* not in
* contains
* not contains

https://issues.redhat.com/browse/AAP-7647

e.g.

   1. event.mylist contains "alert"
   2. event.name in ["alert","warning"]
   3. event.name not in ["error","warning"]
   4. event.mylist not contains "error"

This is a Drools only feature and wont work with durable rules