### PR TITLE
Remove uuid print in --version flag

### DIFF
--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -125,7 +125,6 @@ def get_parser() -> argparse.ArgumentParser:
 
 def show_version() -> NoReturn:
     print(ansible_rulebook.__version__)
-    print(settings.identifier)
     sys.exit(0)
 
 


### PR DESCRIPTION
I really believe this print is completely useless for the "--version" flag, it generates a new uuid each time is executed. It has no relation with the version and confuses everybody. 