### PR TITLE
AAP-7680 add more info to --version flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,9 @@ jobs:
         run: ansible-galaxy collection install git+https://github.com/ansible/event-driven-ansible
 
       - name: Run tests via Durable rules
-        run: pytest
+        run: pytest -vvv
 
       - name: Run tests via Drools
-        run: pytest
+        run: pytest -vvv
         env:
           EDA_RULES_ENGINE: drools

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -37,6 +37,7 @@ Options:
 """
 import argparse
 import asyncio
+import importlib.metadata
 import logging
 import os
 import sys
@@ -53,6 +54,7 @@ if os.environ.get("EDA_RULES_ENGINE", "drools") == "drools":
 import ansible_rulebook
 from ansible_rulebook import app
 from ansible_rulebook.conf import settings
+from ansible_rulebook.util import get_java_version
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +126,19 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def show_version() -> NoReturn:
-    print(ansible_rulebook.__version__)
+    rules_engine = f"{os.environ.get('EDA_RULES_ENGINE', 'durable-rules')}"
+    java_home = f"{os.environ.get('JAVA_HOME', 'JAVA_HOME not present')}"
+
+    result = [
+        f"{ansible_rulebook.__version__}",
+        f"  Executable location = {sys.argv[0]}",
+        f"  Rules engine = {rules_engine}",
+        f"  Drools_jpy version = {importlib.metadata.version('drools_jpy')}",
+        f"  Java home = {java_home}",
+        f"  Java version = {get_java_version()}",
+        f"  Python version = {''.join(sys.version.splitlines())}",
+    ]
+    print("\n".join(result))
     sys.exit(0)
 
 

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -15,6 +15,8 @@
 import glob
 import json
 import os
+import shutil
+import subprocess
 import tempfile
 from pprint import pprint
 from typing import Any, Dict, List, Union
@@ -124,3 +126,18 @@ def collect_ansible_facts(inventory: Dict) -> List[Dict]:
             hosts_facts.append(data)
 
     return hosts_facts
+
+
+def get_java_version() -> str:
+    exec_path = shutil.which("java")
+    if not exec_path:
+        return "Java executable not found."
+    try:
+        result = subprocess.run(
+            [exec_path, "--version"], capture_output=True, check=True
+        )
+    except subprocess.CalledProcessError as exc:
+        print(exc)
+        return "Java error"
+
+    return result.stdout.splitlines()[0].decode()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,22 @@
+import re
+
+import pytest
+
+from ansible_rulebook.cli import show_version
+
+
+def test_show_version(capsys):
+    with pytest.raises(SystemExit):
+        show_version()
+    output = capsys.readouterr()
+    assert not output.err
+    pattern = re.compile(
+        r"""(.+)\d+\.\d+\.\d+'
+  Executable location = (.+)
+  Rules engine = (drools|durable-rules)
+  Drools_jpy version = \d+\.\d+\.\d+
+  Java home = (.+)
+  Java version = (.+)\d+\.\d+\.\d+(.+)
+  Python version = \d+\.\d+\.\d+ (.+)$"""
+    )
+    assert pattern.match(output.out)

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,11 @@ python =
 
 [testenv:flake8]
 basepython = python
-deps = flake8
+deps = flake8==5.0.4
 commands = flake8 ansible_rulebook tests
 
 [testenv]
+passenv = JAVA_HOME
 setenv =
     PYTHONPATH = {toxinidir}
     PIP_NO_BINARY = jpy


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/AAP-7680
This command with the extended info can be used in issue template and contributing guides to provide a better info.
Taking as reference the `ansible --version` command

Also fixes the flake version when running it through tox. 
Also adds `-vv` flag to pytest to have the complete output in case of test fail. 

How to test: run `ansible-rulebook --version`
Expected output

```
__version__ = '0.9.4'
  Executable location = /home/alex/repos/redhat/ansible/eda/ansible-rulebook/venv/bin/ansible-rulebook
  Rules engine = durable_rules
  Drools_jpy version = 0.1.1
  Java home = /usr/lib/jvm/java-17-openjdk-17.0.3.0.7-1.fc34.x86_64
  Java version = openjdk 17.0.3 2022-04-19
  Python version = 3.9.13 (main, May 18 2022, 00:00:00) [GCC 11.3.1 20220421 (Red Hat 11.3.1-2)]
```
