### PR TITLE
Added temporal use cases and handle async responses from Drools

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -22,6 +22,7 @@ from pprint import PrettyPrinter, pformat
 from typing import Any, Dict, List, Optional, cast
 
 from drools import ruleset as lang
+from drools.dispatch import establish_async_channel, handle_async_messages
 from drools.exceptions import (
     MessageNotHandledException,
     MessageObservedException,
@@ -200,6 +201,11 @@ async def run_rulesets(
             hosts_facts = collect_ansible_facts(inventory)
 
     ruleset_tasks = []
+    reader, writer = await establish_async_channel()
+    ruleset_tasks.append(
+        asyncio.create_task(handle_async_messages(reader, writer))
+    )
+
     for ruleset_queue_plan in rulesets_queue_plans:
         ruleset_runner = RuleSetRunner(
             event_log=event_log,

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Dict, List, NamedTuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 from drools.ruleset import Ruleset as EngineRuleSet
 
@@ -44,6 +44,13 @@ class Action(NamedTuple):
 class Condition(NamedTuple):
     when: str
     value: List[ct.Condition]
+    timeout: Optional[str] = None
+
+
+class Throttle(NamedTuple):
+    group_by_attributes: List[str]
+    once_within: Optional[str] = None
+    once_after: Optional[str] = None
 
 
 class Rule(NamedTuple):
@@ -51,6 +58,7 @@ class Rule(NamedTuple):
     condition: Condition
     action: Action
     enabled: bool
+    throttle: Optional[Throttle] = None
 
 
 class RuleSet(NamedTuple):

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -51,6 +51,28 @@
                 ]
             }
         },
+        "throttle": {
+            "type": "object",
+	    "oneOf": [
+		    {"required": ["once_within", "group_by_attributes"]},
+		    {"required": ["once_after", "group_by_attributes"]}
+	    ],
+            "properties": {
+                "once_within" : {
+                    "type": "string",
+                    "pattern": "^\\d+\\s(milliseconds?|seconds?|minutes?|hours?|days?)$"
+                },
+                "once_after" : {
+                    "type": "string",
+                    "pattern": "^\\d+\\s(milliseconds?|seconds?|minutes?|hours?|days?)$"
+                },
+                "group_by_attributes": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
+            },
+            "additionalProperties": false
+        },
         "rule": {
             "type": "object",
             "properties": {
@@ -59,11 +81,13 @@
                     "minLength": 1,
                     "pattern": "\\S"
                 },
+                "throttle": {"$ref": "#/$defs/throttle"},
                 "condition": {
                     "anyOf": [
                         { "type": "string" },
                         {"$ref": "#/$defs/all-condition"},
-                        {"$ref": "#/$defs/any-condition"}
+                        {"$ref": "#/$defs/any-condition"},
+                        {"$ref": "#/$defs/not-all-condition"}
                     ]
                 },
                 "action": {
@@ -95,8 +119,30 @@
                 "all": {
                     "type": "array",
                     "items": { "type": "string" }
+                },
+                "timeout" : {
+                    "type": "string",
+                    "pattern": "^\\d+\\s(milliseconds?|seconds?|minutes?|hours?|days?)$"
                 }
             },
+            "additionalProperties": false
+        },
+        "not-all-condition": {
+            "type": "object",
+            "properties": {
+                "not_all": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                },
+                "timeout" : {
+                    "type": "string",
+                    "pattern": "^\\d+\\s(milliseconds?|seconds?|minutes?|hours?|days?)$"
+                }
+            },
+            "required": [
+                "timeout",
+                "not_all"
+            ],
             "additionalProperties": false
         },
         "any-condition": {

--- a/docs/development_environment.rst
+++ b/docs/development_environment.rst
@@ -132,6 +132,17 @@ To run E2E tests
 
     pytest -m e2e
 
+To run Temporal tests
+
+.. code-block:: console
+
+    pytest -m temporal
+
+To skip running Temporal tests
+
+.. code-block:: console
+
+    pytest -m "not temporal"
 
 Building
 ---------

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ log_file_level = INFO
 log_cli = true
 markers =
     e2e: mark for end to end tests
+    temporal: mark for time based tests

--- a/tests/examples/52_once_within.yml
+++ b/tests/examples/52_once_within.yml
@@ -1,0 +1,27 @@
+---
+- name: 52 once within
+  hosts: all
+  sources:
+    - generic:
+        loop_count: 20
+        payload:
+          - alert:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: HostA
+          - alert:
+               level: error
+               message: Disk failure
+            meta:
+               hosts: HostA
+  rules:
+    - name: r1
+      condition: event.alert.level == "warning" or event.alert.level == "error"
+      action:
+        debug:
+      throttle:
+          once_within: 2 seconds
+          group_by_attributes:
+             - event.meta.hosts
+             - event.alert.level

--- a/tests/examples/53_once_within_multiple_hosts.yml
+++ b/tests/examples/53_once_within_multiple_hosts.yml
@@ -1,0 +1,27 @@
+---
+- name: 53 once within multiple hosts
+  hosts: all
+  sources:
+    - generic:
+        loop_count: 20
+        payload:
+          - alert:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: HostA
+          - alert:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: HostB
+  rules:
+    - name: r1
+      condition: event.alert.level == "warning" or event.alert.level == "error"
+      action:
+        debug:
+      throttle:
+        once_within: 2 seconds
+        group_by_attributes:
+           - event.meta.hosts
+           - event.alert.level

--- a/tests/examples/54_time_window.yml
+++ b/tests/examples/54_time_window.yml
@@ -1,0 +1,24 @@
+---
+- name: 54 time window
+  hosts: all
+  sources:
+    - generic:
+        create_index: event_index
+        shutdown_after: 15
+        event_delay: 5
+        payload:
+          - alert:
+               code: 1001
+               message: Applying maintenance
+          - alert:
+               code: 1002
+               message: Restarted
+  rules:
+    - name: maint cycle
+      condition:
+         all:
+            - event.alert.code == 1001
+            - event.alert.code == 1002
+         timeout: 10 seconds
+      action:
+        print_event:

--- a/tests/examples/55_not_all.yml
+++ b/tests/examples/55_not_all.yml
@@ -1,0 +1,27 @@
+---
+- name: 55 not all
+  hosts: all
+  sources:
+    - generic:
+        create_index: event_index
+        timestamp: true
+        event_delay: 15
+        display: false
+        shutdown_after: 5
+        payload:
+          - alert:
+               code: 1001
+               message: Applying maintenance
+          - alert:
+               code: 1002
+               message: Restarted
+  rules:
+    - name: maint failed
+      condition:
+         not_all:
+           - event.alert.code == 1001
+           - event.alert.code == 1002
+         timeout: 10 seconds
+      action:
+        echo:
+          message: "Not all conditions met"

--- a/tests/examples/56_once_after.yml
+++ b/tests/examples/56_once_after.yml
@@ -1,0 +1,32 @@
+---
+- name: 56 once after
+  hosts: all
+  sources:
+    - generic:
+        loop_count: 2
+        loop_delay: 1
+        timestamp: true
+        shutdown_after: 15
+        create_index: event_index
+        payload:
+          - alert:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: localhost0
+          - alert:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: localhost1
+  rules:
+    - name: r1
+      condition: event.alert.level == "warning" or event.alert.level == "error"
+      action:
+        echo:
+          message: Once after 10 seconds
+      throttle:
+         once_after: 10 seconds
+         group_by_attributes:
+           - event.meta.hosts
+           - event.alert.level

--- a/tests/examples/57_once_after_multi.yml
+++ b/tests/examples/57_once_after_multi.yml
@@ -1,0 +1,72 @@
+---
+- name: 57 once after multiple
+  hosts: all
+  sources:
+    - generic:
+        loop_count: 3
+        loop_delay: 15
+        shutdown_after: 60
+        timestamp: true
+        create_index: event_index
+        payload:
+          - r1:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: localhost.11
+          - r1:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: localhost.12
+          - r2:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: localhost.21
+          - r2:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: localhost.22
+          - r3:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: localhost31
+          - r3:
+               level: warning
+               message: Low disk space
+            meta:
+               hosts: localhost32
+  rules:
+    - name: r1
+      condition: event.r1.level == "warning" or event.r1.level == "error"
+      action:
+        echo:
+          message: r1 works
+      throttle:
+         once_after: 15 seconds
+         group_by_attributes:
+           - event.meta.hosts
+           - event.r1.level
+    - name: r2
+      condition: event.r2.level == "warning" or event.r2.level == "error"
+      action:
+        echo:
+          message: r2 works
+      throttle:
+         once_after: 30 seconds
+         group_by_attributes:
+           - event.meta.hosts
+           - event.r2.level
+    - name: r3
+      condition: event.r3.level == "warning" or event.r3.level == "error"
+      action:
+        echo:
+          message: r3 works
+      throttle:
+         once_after: 45 seconds
+         group_by_attributes:
+           - event.meta.hosts
+           - event.r3.level


### PR DESCRIPTION
- Added time constraints in rules schema
- Allow for async communication between Drools and Python
- Added
* Throttle support via
       1. once_within
       2. once_after
* Time windows for conditions
      timeout: nnn seconds
* Not all conditions met in a time window
```
   condition:
             not_all:
                 - condition1
                 - condition2
             timeout: nnn seconds 
```
https://issues.redhat.com/browse/AAP-7354
https://issues.redhat.com/browse/AAP-7360
https://issues.redhat.com/browse/AAP-7284
https://issues.redhat.com/browse/AAP-7706

This PR contains examples which can be executed standalone to demonstrate some of these features.

**time window example**
```
ansible-rulebook --inventory ./tests/playbooks/inventory.yml -S ./tests/sources --rulebook tests/examples/54_time_window.yml
```

**not_all example**
```
ansible-rulebook --inventory ./tests/playbooks/inventory.yml -S ./tests/sources --rulebook tests/examples/55_not_all.yml
```

**once_within**
```
ansible-rulebook --inventory ./tests/playbooks/inventory.yml -S ./tests/sources --rulebook tests/examples/52_once_within.yml
```

**once_after**
```
ansible-rulebook --inventory ./tests/playbooks/inventory.yml -S ./tests/sources --rulebook tests/examples/56_once_after.yml
```

**once_after with multiple timers**
```
ansible-rulebook --inventory ./tests/playbooks/inventory.yml -S ./tests/sources --rulebook tests/examples/57_once_after_multi.yml
```

Since these time based examples take time to run they have been excluded from running during CI testing.
Locally in the dev environment you can set

**export EDA_RUN_TIME_TESTS=yes**
and then run the pytest and it will run the time based tests

Some of the examples take over a minute to run when there are multiple timers involved.
