### PR TITLE
Removing PIP_NO_BINARY env var

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,17 +65,12 @@ Ready to contribute? Here's how to set up `ansible_rulebook` for local developme
     $ git clone git@github.com:your_name_here/ansible-rulebook.git
 
 3. We use a rules engine called Drools which is written in Java. From our python code
-   we directly call the Drools Java classes using JPY. JPY needs Java to be installed on
-   the machine. There are wheel distributions for JPY but they might not match your hardware
-   so you would have to compile the JPY from source to get the package and shared object appropriate
-   for your machine.
-   To compile from Source you would need to set the following env var
-   export PIP_NO_BINARY=jpy
+   we directly call the Drools Java classes using JPY. The following criteria must be
+   met for JPY to work correctly:
 
    * Java 11+ installed
    * Environment variable JAVA_HOME set accordingly
    * Maven 3.8.1+ installed, might come bundled in some Java installs
-
 
 4. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR $HOME
 USER 0
 RUN dnf install -y java-17-openjdk-devel maven
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-ENV PIP_NO_BINARY=jpy
 RUN pip install -U pip \
     && pip install ansible \
     ansible-runner \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,16 +30,11 @@ Installation via pip
 
     JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
-2. We use a rules engine called Drools which is written in Java and needs to be compiled from source, by
-   setting the following environment variable::
-
-    export PIP_NO_BINARY=jpy
-
-3. Install `ansible-rulebook` and dependencies via `pip`::
+2. Install `ansible-rulebook` and dependencies via `pip`::
 
     pip install wheel ansible-rulebook ansible ansible-runner
 
-4. Install the required Ansible collections::
+3. Install the required Ansible collections::
 
     ansible-galaxy collection install community.general ansible.eda
 
@@ -53,7 +48,6 @@ On Fedora-like systems:
     dnf --assumeyes install gcc java-17-openjdk maven python3-devel python3-pip
     export JDK_HOME=/usr/lib/jvm/java-17-openjdk
     export JAVA_HOME=$JDK_HOME
-    export PIP_NO_BINARY=jpy
     pip3 install -U Jinja2
     pip3 install ansible ansible-rulebook ansible-runner wheel
 
@@ -64,7 +58,6 @@ On Ubuntu systems:
     apt-get --assume-yes install build-essential maven openjdk-17-jdk python3-dev python3-pip
     export JDK_HOME=/usr/lib/jvm/java-17-openjdk-amd64
     export JAVA_HOME=$JDK_HOME
-    export PIP_NO_BINARY=jpy
     export PATH=$PATH:~/.local/bin
     pip3 install -U Jinja2
     pip3 install ansible ansible-rulebook ansible-runner wheel

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ commands = flake8 ansible_rulebook tests
 passenv = JAVA_HOME
 setenv =
     PYTHONPATH = {toxinidir}
-    PIP_NO_BINARY = jpy
     durable: EDA_RULES_ENGINE=durable_rules
     drools: EDA_RULES_ENGINE=drools
 deps =


### PR DESCRIPTION
Closes [AAP-7759](https://issues.redhat.com/browse/AAP-7759). Removing all references to this env var since we no longer need to force compilation of JPY from source.