### PR TITLE
Refactor: Change an attribute name

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -248,7 +248,7 @@ class RuleSetRunner:
 
         logger.info("Waiting for event from %s", self.name)
         while True:
-            data = await self.ruleset_queue_plan.queue.get()
+            data = await self.ruleset_queue_plan.source_queue.get()
             json_count(data)
             if isinstance(data, Shutdown):
                 await asyncio.wait(self.action_tasks)
@@ -318,7 +318,7 @@ class RuleSetRunner:
             # TODO: is it really necessary to add such event to event_log?
             await self.event_log.put(dict(type="MessageNotHandled"))
         except ShutdownException:
-            await self.ruleset_queue_plan.queue.put(Shutdown())
+            await self.ruleset_queue_plan.source_queue.put(Shutdown())
         except Exception:
             logger.exception("Error processing %s", data)
 

--- a/ansible_rulebook/rule_generator.py
+++ b/ansible_rulebook/rule_generator.py
@@ -221,7 +221,7 @@ if os.environ.get("EDA_RULES_ENGINE", "durable_rules") == "durable_rules":
     ) -> List[EngineRuleSetQueuePlan]:
         rulesets = []
 
-        for ansible_ruleset, queue in ruleset_queues:
+        for ansible_ruleset, source_queue in ruleset_queues:
             a_ruleset = ruleset(ansible_ruleset.name)
             plan = Plan(queue=asyncio.Queue())
             with a_ruleset:
@@ -244,7 +244,9 @@ if os.environ.get("EDA_RULES_ENGINE", "durable_rules") == "durable_rules":
                             ),
                         )(fn)
                         logger.info(r.define())
-            rulesets.append(EngineRuleSetQueuePlan(a_ruleset, queue, plan))
+            rulesets.append(
+                EngineRuleSetQueuePlan(a_ruleset, source_queue, plan)
+            )
 
         return rulesets
 
@@ -258,7 +260,7 @@ else:
 
         rulesets = []
 
-        for ansible_ruleset, queue in ruleset_queues:
+        for ansible_ruleset, source_queue in ruleset_queues:
             ruleset_ast = visit_ruleset(ansible_ruleset, variables)
             drools_ruleset = DroolsRuleset(
                 name=ansible_ruleset.name,
@@ -281,6 +283,6 @@ else:
                     )
 
             rulesets.append(
-                EngineRuleSetQueuePlan(drools_ruleset, queue, plan)
+                EngineRuleSetQueuePlan(drools_ruleset, source_queue, plan)
             )
         return rulesets

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -79,7 +79,7 @@ class ActionContext(NamedTuple):
 
 class RuleSetQueue(NamedTuple):
     ruleset: RuleSet
-    queue: asyncio.Queue
+    source_queue: asyncio.Queue
 
 
 @dataclass
@@ -89,5 +89,5 @@ class Plan:
 
 class EngineRuleSetQueuePlan(NamedTuple):
     ruleset: EngineRuleSet
-    queue: asyncio.Queue
+    source_queue: asyncio.Queue
     plan: Plan


### PR DESCRIPTION
Too many attributes were being called **queue**. Renaming one of the **queue** attributes to **source_queue** to indicate that it is used for sources.