### PR TITLE
Don't create an asyncio.Queue for every event coming in

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -285,10 +285,6 @@ class RuleSetRunner:
                 )
                 result = await self.call_action(*item)
 
-            # create a new plan queue for current event so that results
-            # can be concatenated
-            self.ruleset_queue_plan.plan.queue = asyncio.Queue()
-
             try:
                 lang.post(self.name, data)
             except MessageObservedException:


### PR DESCRIPTION
We have a single plan queue per Ruleset, where all rules can queue their Actions. The rule engines gives us back the event data when a rule is triggered, we don't need to separate every event into a separate asyncio.Queue.