### PR TITLE
[AAP-7240] Handle null events from the rule engine

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -335,7 +335,9 @@ class RuleSetRunner:
                 single_match = None
                 if os.environ.get("EDA_RULES_ENGINE", "drools") == "drools":
                     keys = list(rules_engine_result.data.keys())
-                    if len(keys) == 1:
+                    if len(keys) == 0:
+                        single_match = {}
+                    elif len(keys) == 1:
                         single_match = rules_engine_result.data[keys[0]]
                     else:
                         multi_match = rules_engine_result.data
@@ -345,7 +347,7 @@ class RuleSetRunner:
                     else:
                         multi_match = rules_engine_result._m
                 variables_copy = variables.copy()
-                if single_match:
+                if single_match is not None:
                     variables_copy["event"] = single_match
                     variables_copy["fact"] = single_match
                     event = single_match


### PR DESCRIPTION
The Rule engine in certain cases will trigger a rule match without any events. We have seen this with a single condition
- condition: event.xyz is not defined

https://issues.redhat.com/browse/AAP-7240