### PR TITLE
Set a small default number for EDA_RUN_PLAYBOOK_MAX_DELAY

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -462,7 +462,7 @@ class PlaybookActionRunner:
         self.actions = OrderedDict()
         self.result = None
         self.stopped = True
-        self.delay = int(os.environ.get("EDA_RUN_PLAYBOOK_MAX_DELAY", 0))
+        self.delay = float(os.environ.get("EDA_RUN_PLAYBOOK_MAX_DELAY", 0.01))
 
     async def start(self, name: str):
         if not self.stopped:

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -463,6 +463,9 @@ class PlaybookActionRunner:
         self.result = None
         self.stopped = True
         self.delay = float(os.environ.get("EDA_RUN_PLAYBOOK_MAX_DELAY", 0.01))
+        # Protect against explicit user configuration
+        if self.delay == 0:
+            self.delay = 0.01
 
     async def start(self, name: str):
         if not self.stopped:


### PR DESCRIPTION
This helps to prevent cpu peg

https://issues.redhat.com/browse/AAP-7918