### PR TITLE
print help if run without arguments

### DIFF
--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -156,6 +156,10 @@ def main(args: List[str] = None) -> int:
     parser = get_parser()
     args = parser.parse_args(args)
 
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
     if args.version:
         show_version()
 


### PR DESCRIPTION
This PR:
- Makes  `ansible-rulebook` print the help section if no argument is given 
- Closes #223
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>