### PR TITLE
Fixed the example of how to use fact and events

### DIFF
--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -115,7 +115,10 @@ Condition with fact and event, fact being passed in via --variables on command l
 ::
 
       name: Condition using a passed in variable and an event
-      condition: event.i == fact.custom.expected_index
+      condition:
+        all:
+           - facts.first << fact.custom.expected_index is defined
+           - event.i == facts.first.custom.expected_index
       action:
         debug:
 


### PR DESCRIPTION
A fact and an event can't be compared in a simple condition. The fact has to be first assigned to a temporary events field. Then the saved events field can be compared with the event. e.g.
```
       condition:
         all:
           - facts.first << fact.custom.expected_index is defined
           - event.i == facts.first.custom.expected_index
```
Previously you could do this
```
condition: event.i == fact.custom.expected_index
```
The simple single condition syntax cannot be used for comparing event and fact anymore.
This change was introduced in
https://github.com/ansible/ansible-rulebook/commit/eb4110b1eaadd64e3972661a4d0ca6921143208b

But the document was not fixed.
This PR fixes the documentation