### PR TITLE
Add a generic source plugin for tests

### DIFF
--- a/tests/examples/47_generic_plugin.yml
+++ b/tests/examples/47_generic_plugin.yml
@@ -1,0 +1,18 @@
+---
+- name: 47 Generic Plugin with boolean and integer test
+  hosts: all
+  sources:
+    - name: generic
+      generic:
+        payload:
+           - b: true
+           - i: 42
+  rules:
+    - name: r1
+      condition: event.b == true
+      action:
+        print_event:
+    - name: r2
+      condition: event.i == 42
+      action:
+        print_event:

--- a/tests/sources/generic.py
+++ b/tests/sources/generic.py
@@ -1,0 +1,49 @@
+#  Copyright 2022 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import asyncio
+import random
+from typing import Any, Dict
+
+
+async def main(queue: asyncio.Queue, args: Dict[str, Any]):
+    payload = args.get("payload")
+    randomize = args.get("randomize", False)
+    delay = int(args.get("delay", 0))
+    if not isinstance(payload, list):
+        payload = [payload]
+
+    if randomize:
+        random.shuffle(payload)
+
+    for event in payload:
+        await queue.put(event)
+        await asyncio.sleep(delay)
+
+
+if __name__ == "__main__":
+
+    class MockQueue:
+        async def put(self, event):
+            print(event)
+
+    asyncio.run(
+        main(
+            MockQueue(),
+            dict(
+                randomize=True,
+                payload=[dict(i=1), dict(f=3.14159), dict(b=False)],
+            ),
+        )
+    )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1242,3 +1242,32 @@ async def test_45_in_or():
     assert event["type"] == "ProcessedEvent", "4"
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "5"
+
+
+@pytest.mark.asyncio
+async def test_47_generic_plugin():
+    ruleset_queues, event_log = load_rulebook("examples/47_generic_plugin.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(i=42))
+    queue.put_nowait(dict(b=True))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "print_event", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "3"
+    assert event["action"] == "print_event", "3"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "4"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "5"


### PR DESCRIPTION
Since we support different data types integer, boolean we need something that allows us to put different data types in the payload for comparison in conditions. The current "range" plugin only works with integers, and some of the old tests use the range plugin in the rulebook but put custom payload in the tests. I would like to convert all those test cases to use the generic plugin and put the payload directly into the rulebook.