### PR TITLE
AAP-5333 - Adding test to verify correct return codes

### DIFF
--- a/tests/e2e/files/rulebooks/hello_events_with_var.yml
+++ b/tests/e2e/files/rulebooks/hello_events_with_var.yml
@@ -1,0 +1,14 @@
+---
+- name: Hello Events with variable
+  hosts: all
+  sources:
+    - range:
+        limit: "{{ RANGE_LIMIT }}"
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+      action:
+        run_module:
+          name: ansible.builtin.debug
+          module_args:
+            msg: Hello there!

--- a/tests/e2e/files/rulebooks/malformed_rulebook.yml
+++ b/tests/e2e/files/rulebooks/malformed_rulebook.yml
@@ -1,0 +1,13 @@
+---
+- name: Malformed rulebook
+  hosts: all
+  sources:
+    - range:
+  rules:
+    - name: This is poorly formatted
+      condition: event.i == 1
+      action:
+      run_module:
+      name: ansible.builtin.debug
+      module_args:
+      msg: I am invalid

--- a/tests/e2e/test_runtime.py
+++ b/tests/e2e/test_runtime.py
@@ -1,0 +1,76 @@
+"""
+Module with tests for general CLI runtime
+"""
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from . import utils
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_TIMEOUT = 10
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "rulebook, inventory, range_limit, expected_rc",
+    [
+        pytest.param(
+            "hello_events_with_var.yml",
+            utils.DEFAULT_INVENTORY,
+            "5",
+            0,
+            id="successful_rc",
+        ),
+        pytest.param(
+            "test_check_rc.yml",
+            Path("nonexistent.yml"),
+            "5",
+            1,
+            id="failed_rc_wrong_inventory",
+        ),
+        pytest.param(
+            "test_check_rc.yml",
+            utils.DEFAULT_INVENTORY,
+            "notanint",
+            1,
+            id="failed_rc_bad_var",
+        ),
+        pytest.param(
+            "malformed_rulebook.yml",
+            utils.DEFAULT_INVENTORY,
+            "5",
+            1,
+            id="failed_rc_rulebook_validation",
+        ),
+    ],
+)
+def test_program_return_code(
+    rules_engine, rulebook, inventory, range_limit, expected_rc
+):
+    """
+    GIVEN a valid or invalid rulebook
+        and a valid or invalid environment variable
+        and a valid or invalid inventory
+    WHEN the program is executed
+    THEN the program must exit with the correct return code
+    """
+    os.environ["RANGE_LIMIT"] = range_limit
+
+    rulebook = utils.BASE_DATA_PATH / f"rulebooks/{rulebook}"
+    cmd = utils.Command(
+        rulebook=rulebook, envvars="RANGE_LIMIT", inventory=inventory
+    )
+
+    LOGGER.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd,
+        env=utils.get_environ(rules_engine),
+        timeout=DEFAULT_TIMEOUT,
+        cwd=utils.BASE_DATA_PATH,
+    )
+
+    assert result.returncode == expected_rc


### PR DESCRIPTION
Closes [AAP-5333](https://issues.redhat.com/browse/AAP-5333). Adding test case to validate correct return codes after program execution.

- Successful RC
- Failed RC due to non-existent inventory
- Failed RC due to bad variable
- Failed RC due to poorly formatted rulebook