### PR TITLE
Remove asyncio from required dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ packages = find:
 python_requires = >=3.8
 install_requires = 
     aiohttp
-	asyncio
 	durable_rules
 	pyparsing >= 3.0
 	jsonschema


### PR DESCRIPTION
asyncio is included in Python3 and we don't have to add it as an external dependency