### PR TITLE
Increase timeout of e2e tests

### DIFF
--- a/tests/e2e/test_operators.py
+++ b/tests/e2e/test_operators.py
@@ -9,7 +9,7 @@ import pytest
 from . import utils
 
 LOGGER = logging.getLogger(__name__)
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 15
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_runtime.py
+++ b/tests/e2e/test_runtime.py
@@ -11,7 +11,7 @@ import pytest
 from . import utils
 
 LOGGER = logging.getLogger(__name__)
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 15
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_websocket.py
+++ b/tests/e2e/test_websocket.py
@@ -11,7 +11,7 @@ import websockets.server as ws_server
 from . import utils
 
 LOGGER = logging.getLogger(__name__)
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 15
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Increase the timeout of e2e tests to avoid occasional failures due to GH actions performance. 

In next iterations we will implement other improvements to reduce the time execution of some tests. 