### PR TITLE
Added a builtin action : echo

### DIFF
--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -134,6 +134,39 @@ async def print_event(
     )
 
 
+async def echo(
+    event_log,
+    inventory: Dict,
+    hosts: List,
+    variables: Dict,
+    facts: Dict,
+    project_data_file: str,
+    source_ruleset_name: str,
+    source_rule_name: str,
+    ruleset: str,
+    name: Optional[str] = None,
+    var_root: Union[str, Dict, None] = None,
+    message: Optional[str] = None,
+):
+    if var_root:
+        update_variables(variables, var_root)
+
+    print(str(datetime.now()) + " : " + message)
+    sys.stdout.flush()
+    await event_log.put(
+        dict(
+            type="Action",
+            action="echo",
+            activation_id=settings.identifier,
+            ruleset=source_ruleset_name,
+            rule=source_rule_name,
+            playbook_name=name,
+            run_at=str(datetime.utcnow()),
+            matching_events=_get_events(variables),
+        )
+    )
+
+
 async def set_fact(
     event_log,
     inventory: Dict,
@@ -777,6 +810,7 @@ actions: Dict[str, Callable] = dict(
     run_module=run_module,
     run_job_template=run_job_template,
     shutdown=shutdown,
+    echo=echo,
 )
 
 

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -74,7 +74,8 @@
                         {"$ref": "#/$defs/print-event-action"},
                         {"$ref": "#/$defs/debug-action"},
                         {"$ref": "#/$defs/none-action"},
-                        {"$ref": "#/$defs/shutdown-action"}
+                        {"$ref": "#/$defs/shutdown-action"},
+                        {"$ref": "#/$defs/echo-action"}
                     ]
                 }
             },
@@ -266,6 +267,23 @@
             },
             "required": [
                 "debug"
+            ]
+        },
+        "echo-action": {
+            "type": "object",
+            "properties": {
+                "echo": {
+                    "type": ["object"],
+                    "properties": {
+                        "message": {"type": "string" }
+                    }
+                },
+		"required": [
+			"message"
+		]
+            },
+            "required": [
+                "echo"
             ]
         },
         "none-action": {

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -15,6 +15,7 @@ The following actions are supported:
 - `shutdown`_
 - `debug`_
 - `none`_
+- `echo`_
 
 run_playbook
 ************
@@ -348,3 +349,24 @@ none
 ****
   No action, useful when writing tests
   No arguments needed
+
+echo
+****
+.. list-table:: Write a user specified message to stdout
+   :widths: 25 150 10
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Required
+   * - message
+     - A terse message to display to stdout
+     - Yes
+
+Example:
+
+.. code-block:: yaml
+
+    action:
+      echo:
+        message: Hello World

--- a/tests/examples/48_echo.yml
+++ b/tests/examples/48_echo.yml
@@ -1,0 +1,13 @@
+---
+- name: 53 echo
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 1
+      action:
+        echo:
+          message: Hurray it works

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1271,3 +1271,26 @@ async def test_47_generic_plugin():
     assert event["type"] == "ProcessedEvent", "4"
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "5"
+
+
+@pytest.mark.asyncio
+async def test_48_echo():
+    ruleset_queues, event_log = load_rulebook("examples/48_echo.yml")
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(i=1))
+    queue.put_nowait(Shutdown())
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "echo", "1"
+    event = event_log.get_nowait()
+    assert event["type"] == "ProcessedEvent", "2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "5"


### PR DESCRIPTION
The debug/print_event have lot of information and don't allow for terse messages. This becomes difficult to comprehend when we have multiple conditions in a rule, which match multiple events. When doing a demo instead of seeing a lot of attributes flow by we can echo terse messages along with a time stamp. The timestamp allows for timer based rules to see if they popped at the expected times.

e.g.
```
- name: r1
      condition: event.i == 1
      action:
        echo:
          message: Hurray it works
```

Displays
```
2023-01-13 21:20:47.028365 : Hurray it works
```