### PR TITLE
Add more options to generic source plugin for time based tests

### DIFF
--- a/tests/sources/generic.py
+++ b/tests/sources/generic.py
@@ -14,40 +14,95 @@
 
 import asyncio
 import random
+import time
 from datetime import datetime
 from typing import Any, Dict
+
+""" A generic source plugin that allows you to insert custom data
+
+    The event data to insert into the queue is specified in the required
+    parameter payload and is an array of events.
+
+    Optional Parameters:
+    randomize    True|False Randomize the events in the payload, default False
+    display      True|False Display the event data in stdout, default False
+    add_timestamp True|False Add an event timestamp, default False
+    time_format   local|iso8601|epoch  The time format of event timestamp,
+                  default local
+    create_index str   The index to create for each event starts at 0
+    startup_delay int  Number of seconds to wait before injecting events
+                       into the queue. Default 0
+    event_delay int    Number of seconds to wait before injecting the next
+                       event from the payload. Default 0
+    repeat_delay int   Number of seconds to wait before injecting a repeated
+                       event from the payload. Default 0
+    loop_delay int     Number of seconds to wait before inserting the
+                       next set of events. Default 0
+    shutdown_after int Number of seconds to wait before shutting down the
+                       plugin. Default 0
+    loop_count int     Number of times the set of events in the playload
+                       should be repeated. Default 0
+    repeat_count int   Number of times each individual event in the playload
+                       should be repeated. Default 1
+
+"""
 
 
 async def main(queue: asyncio.Queue, args: Dict[str, Any]):
     payload = args.get("payload")
     randomize = args.get("randomize", False)
+    display = args.get("display", False)
     add_timestamp = args.get("timestamp", False)
-    create_index = args.get("create_index", None)
-    delay = int(args.get("delay", 0))
-    loop_count = int(args.get("loop_count", 1))  # -1 infinite
+    time_format = args.get("time_format", "local")
+    create_index = args.get("create_index", "")
+
+    startup_delay = int(args.get("startup_delay", 0))
+    event_delay = int(args.get("event_delay", 0))
+    repeat_delay = int(args.get("repeat_delay", 0))
     loop_delay = int(args.get("loop_delay", 0))
+    shutdown_after = int(args.get("shutdown_after", 0))
+
+    loop_count = int(args.get("loop_count", 1))  # -1 infinite
+    repeat_count = int(args.get("repeat_count", 1))
+    if time_format not in ["local", "iso8601", "epoch"]:
+        raise ValueError("time_format must be one of local, iso8601, epoch")
 
     if not isinstance(payload, list):
         payload = [payload]
 
     iteration = 0
     index = 0
+
+    await asyncio.sleep(startup_delay)
+
     while iteration != loop_count:
         if loop_delay > 0 and iteration > 0:
             await asyncio.sleep(loop_delay)
         if randomize:
             random.shuffle(payload)
         for event in payload:
-            extras = {}
-            if create_index:
-                extras[f"{create_index}"] = index
-            if add_timestamp:
-                extras["timestamp"] = str(datetime.now())
-            event.update(extras)
-            await queue.put(event)
-            await asyncio.sleep(delay)
-            index += 1
+            for _ in range(repeat_count):
+                data = {}
+                if create_index:
+                    data[create_index] = index
+                if add_timestamp:
+                    if time_format == "local":
+                        data["timestamp"] = str(datetime.now())
+                    elif time_format == "epoch":
+                        data["timestamp"] = int(time.time())
+                    elif time_format == "iso8601":
+                        data["timestamp"] = datetime.now().isoformat()
+
+                index += 1
+                data.update(event)
+                if display:
+                    print(data)
+                await queue.put(data)
+                await asyncio.sleep(repeat_delay)
+
+            await asyncio.sleep(event_delay)
         iteration += 1
+    await asyncio.sleep(shutdown_after)
 
 
 if __name__ == "__main__":
@@ -61,9 +116,16 @@ if __name__ == "__main__":
             MockQueue(),
             dict(
                 randomize=True,
+                startup_delay=1,
                 create_index="my_index",
                 loop_count=2,
+                repeat_count=2,
+                repeat_delay=1,
+                event_delay=2,
+                loop_delay=3,
+                shutdown_after=11,
                 timestamp=True,
+                display=True,
                 payload=[dict(i=1), dict(f=3.14159), dict(b=False)],
             ),
         )


### PR DESCRIPTION
Added the following options
 - **startup_delay** : nnn How long to wait before the plugin starts putting events into the queue. Default 0
 - **shutdown_after** : nnn How long to wait before the plugin shutsdown specified in seconds. Default 0
 - **repeat_count**   : nnn The number of times each event in the payload should be repeated. Default 1
 - **repeat_delay**   : nnn How long to wait before repeating events. Default 0
 - **event_delay**    : nnn How loing to wait before sending the next event in the payload. Default 0
 - **display**        : True|False   print the event being injected. Default False

If the payload say contains two events [e1, e2]

The repeat_count=2 and repeat_delay allows you to do [e1,sleep(repeat_delay),e1,sleep(repeat_delay),e2,sleep(repeat_delay),e2,sleep(repeat_delay)]

The event_delay allows you to do
[e1,sleep(event_delay),e2]

The earlier implemented loop_delay with loop_count=2 allows you to do [e1,e2,sleep(loop_delay),e1,e2,sleep(loop_delay)]

The shutdown_after with loop_count=2 allows you to do [e1,e2,e1,e2] sleep(shutdown_after)