### PR TITLE
Pin drools version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy
+	drools_jpy == 0.1.6
 
 [options.packages.find]
 include = 


### PR DESCRIPTION
Pip doesn't upgrade dependencies in existing installations if there is no a specified version, which can lead to confusion and generate unexpected results since a critical part of the functionality relies on this package. Pinning it we enforce that we are using always the right version of the package. 