### PR TITLE
Fix schema validation for empty additionalProperties

### DIFF
--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -45,7 +45,10 @@
                 }
             },
             "additionalProperties": {
-                "type": "object"
+                "oneOf":[
+                    {"type": "object"},
+                    {"type": "null"}
+                ]
             }
         },
         "rule": {


### PR DESCRIPTION
Fix an issue where JSON schema validation is failing when no source plugin options are defined in a ruleset. This is due to the schema not accepting null types for the additionalProperties key.

Addresses [AAP-7760](https://issues.redhat.com/browse/AAP-7760).