### PR TITLE
Update to use drools_jpy 0.1.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.1.6
+	drools_jpy == 0.1.7
 
 [options.packages.find]
 include = 


### PR DESCRIPTION
Updated setup.cfg to point to the new version
- Support for new temporal AST changes
- The rule engine logs are written to stdout/stderr