### PR TITLE
Support for standalone booleans in conditions

### DIFF
--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -124,12 +124,14 @@ def parse_action(action: Dict) -> rt.Action:
 def parse_condition(condition: Any) -> rt.Condition:
     if isinstance(condition, str):
         return rt.Condition("all", [parse_condition_value(condition)])
+    elif isinstance(condition, bool):
+        return rt.Condition("all", [parse_condition_value(str(condition))])
     elif isinstance(condition, dict):
         keys = list(condition.keys())
         if len(condition) == 1 and keys[0] in ["any", "all"]:
             when = keys[0]
             return rt.Condition(
-                when, [parse_condition_value(c) for c in condition[when]]
+                when, [parse_condition_value(str(c)) for c in condition[when]]
             )
         else:
             raise Exception(

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -62,6 +62,7 @@
                 "condition": {
                     "anyOf": [
                         { "type": "string" },
+                        { "type": "boolean" },
                         {"$ref": "#/$defs/all-condition"},
                         {"$ref": "#/$defs/any-condition"}
                     ]

--- a/tests/examples/51_literal_boolean.yml
+++ b/tests/examples/51_literal_boolean.yml
@@ -1,0 +1,21 @@
+---
+- name: 51 literal boolean
+  hosts: all
+  sources:
+    - name: generic
+      generic:
+        payload:
+          - e1:
+              data:
+                port: 5000
+                enabled: true
+          - e2:
+              extra:
+                msg: Hello World
+
+  rules:
+    - name: print event always
+      condition: true
+      action:
+        print_event:
+          pretty: true


### PR DESCRIPTION
This helps when we want to print events without knowing the contents of the event.
The literal boolean true allows the condition to pass and the action print_event can be used to print the event

This would usually be used for bulding the rulebook, you would not use it in production.

```
    - name: print event always
      condition: true
      action:
        print_event:
          pretty: true
```

Once you have satisfied with getting the event data you can disable this rule by using
```
    - name: never run
      condition: false
      action:
        print_event:
          pretty: true
```

In programming parlance this is equivalent to doing

```
   if true:
     .....
```
or
```
   if false:
     .....
```
An easier way to comment out a condition