### PR TITLE
Use cmdline option --print_events

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import argparse
 import asyncio
 import logging
 import os
@@ -45,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 # FIXME(cutwater): Replace parsed_args with clear interface
-async def run(parsed_args) -> None:
+async def run(parsed_args: argparse.ArgumentParser) -> None:
 
     if parsed_args.worker and parsed_args.websocket_address and parsed_args.id:
         logger.info("Starting worker mode")
@@ -92,8 +93,7 @@ async def run(parsed_args) -> None:
         ruleset_queues,
         variables,
         inventory,
-        parsed_args.redis_host_name,
-        parsed_args.redis_port,
+        parsed_args,
         project_data_file,
     )
 

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -29,6 +29,7 @@ Options:
     --redis_port=<p>            Redis port
     --debug                     Show debug logging
     --verbose                   Show verbose logging
+    --print-events              Print events after reading from source queue
     --version                   Show the version and exit
     --websocket-address=<w>     Connect the event log to a websocket
     --id=<i>                    Identifier
@@ -134,6 +135,11 @@ def get_parser() -> argparse.ArgumentParser:
         "--controller-token",
         help="Controller API authentication token",
     )
+    parser.add_argument(
+        "--print-events",
+        action="store_true",
+        help="Print events to stdout, disabled if used with --debug",
+    )
     return parser
 
 
@@ -184,6 +190,8 @@ def main(args: List[str] = None) -> int:
         print("Error: inventory is required")
         return 1
 
+    if args.debug:
+        args.print_events = False
     if args.controller_url:
         if args.controller_token:
             job_template_runner.host = args.controller_url

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,6 +18,7 @@ The `ansible-rulebook` CLI supports the following options::
                                 from the environment
     --debug                     Show debug logging, writes to stdout
     --verbose                   Show verbose logging, overwrites debug writes to stdout
+    --print_events              Print events after reading from source queue
     --version                   Show the version and exit
     --websocket-address=<w>     Connect the event log to a websocket
     --id=<i>                    Identifier


### PR DESCRIPTION
--print-events allows for the printing of events as they are being read from the source queue.
If --debug is used --print-events is disabled, since --debug logs the event already.

```
ansible-rulebook --inventory ./tests/playbooks/inventory.yml -S ./tests/sources --rulebook rule1.yml --print-events
{   'address': {'city': 'Bedrock', 'state': 'NJ', 'street': '123 Any Street'},
    'age': 10,
    'name': 'Fred Flintstone'}
Shutdown()
```