### PR TITLE
[AAP-8470] Added support for vars namespace

### DIFF
--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -31,3 +31,8 @@ class RulenameDuplicateException(Exception):
 class ControllerApiException(Exception):
 
     pass
+
+
+class VarsKeyMissingException(Exception):
+
+    pass

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -15,19 +15,20 @@ Each of the condition(s) can use information from
  * Event received
  * Previously saved events within the rule
  * Longer term facts about the system
- * Variables provided by the user at startup saved as facts
+ * Variables provided by the user at startup saved as vars
 
 When writing conditions
   * use the **event** prefix when accessing data from the current event
-  * use the **fact** prefix when accessing data from the saved facts or passed in variables
+  * use the **fact** prefix when accessing data from the set_facts actions in the rulebook
   * use the **events** prefix when assigning variables and accessing data within the rule
   * use the **facts** prefix when assigning variables and accessing data within the rule
+  * use the **vars** prefix when accessing variables passed in via --vars and --env-vars
 
 
 .. note::
     A condition **cannot** contain Jinja style substitution when accessing variables passed in
     from the command line, we loose the data type information and the rule engine will not
-    process the condition. Instead use the fact prefix to `access the data passed <#condition-with-fact-and-event-fact-being-passed-in-via-variables-on-command-line>`_ in from the
+    process the condition. Instead use the vars prefix to `access the data passed <#condition-with-vars-and-event>`_ in from the
     command line
 
 
@@ -173,12 +174,12 @@ Multiple conditions with facts and events and **all** of one of them have to mat
         action:
           debug:
 
-Condition with fact and event, fact being passed in via --variables on command line
------------------------------------------------------------------------------------
+Condition with fact and event
+-----------------------------
 
     .. code-block:: yaml
 
-        name: Condition using a passed in variable and an event
+        name: Condition using a set_fact fact and an event
         condition:
           all:
             - facts.first << fact.custom.expected_index is defined
@@ -186,7 +187,23 @@ Condition with fact and event, fact being passed in via --variables on command l
         action:
           debug:
 
-In the above example the custom.expected_index was passed in a variables file via ``--variables`` from the
+In the above example the custom.expected_index was set using the set_fact action in the running of the rulebook
+
+
+Condition with vars and event
+-----------------------------
+
+    .. code-block:: yaml
+
+        name: Condition using a passed in variable and an event
+        condition:
+          all:
+            - event.year == vars.person.year
+            - event.age == vars.person.age
+        action:
+          debug:
+
+In the above example the person.year and person.age was passed in a variables file via ``--vars`` from the
 command line to ansible-rulebook.
 
 | When evaluating a single event you can compare multiple

--- a/tests/examples/51_vars_namespace.yml
+++ b/tests/examples/51_vars_namespace.yml
@@ -1,0 +1,57 @@
+---
+- name: 51 vars namespace
+  hosts: all
+  sources:
+    - generic:
+        payload:
+          - name: Fred Flintstone
+            address:
+               street: 123 Any Street
+               city: Bedrock
+               state: NJ
+          - year: 2003
+          - active: true
+          - age: 45
+          - threshold: 34.56
+  # This test needs a variables yml with the following payload
+  # ---
+  # person:
+  #   age: 45
+  #   name: Fred Flintstone
+  #   active: true
+  #   reliability: 86.9
+  #   address:
+  #     street: 123 Any Street
+  #     city: Bedrock
+  #     state: NJ
+  #     years_active:
+  #       - 2001
+  #       - 2002
+  #       - 2003
+  #       - 2004
+  rules:
+    - name: str_test
+      condition: event.address.street == vars.person.address.street
+      action:
+        echo:
+          message: String comparison works
+    - name: list_test
+      condition: event.year in vars.person.address.years_active
+      action:
+        echo:
+          message: List in works
+    - name: bool_test
+      condition: event.active == vars.person.active
+      action:
+        echo:
+          message: Boolean works
+    - name: int_test
+      condition: event.age == vars.person.age
+      action:
+        echo:
+          message: Int works
+    - name: float_test
+      condition: event.threshold < vars.person.reliability
+      action:
+        echo:
+          message: Float works


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-8470

Allows conditions to contain data from the variables or environment variables passed via --vars or --env-vars

e.g.
```
    event.address.street == vars.person.address.street
    event.year in vars.person.address.years_active
```

Supports string, integer, floats, booleans, list. 