### PR TITLE
[AAP-8433] Support for search/match/regex

### DIFF
--- a/ansible_rulebook/condition_types.py
+++ b/ansible_rulebook/condition_types.py
@@ -35,10 +35,21 @@ class Identifier(NamedTuple):
     value: str
 
 
+class KeywordValue(NamedTuple):
+    name: String
+    value: Union[Integer, String, Boolean]
+
+
+class SearchType(NamedTuple):
+    kind: String
+    pattern: String
+    options: List[KeywordValue] = None
+
+
 class OperatorExpression(NamedTuple):
     left: Union[Float, Integer, String, List]
     operator: str
-    right: Union[Float, Integer, String, List]
+    right: Union[Float, Integer, String, List, SearchType]
 
 
 class NegateExpression(NamedTuple):
@@ -60,6 +71,8 @@ class Condition(NamedTuple):
         OperatorExpression,
         ExistsExpression,
         NegateExpression,
+        KeywordValue,
+        SearchType,
     ]
 
 
@@ -73,4 +86,6 @@ ConditionTypes = Union[
     Float,
     ExistsExpression,
     NegateExpression,
+    KeywordValue,
+    SearchType,
 ]

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -25,8 +25,10 @@ from ansible_rulebook.condition_types import (
     Float,
     Identifier,
     Integer,
+    KeywordValue,
     NegateExpression,
     OperatorExpression,
+    SearchType,
     String,
 )
 from ansible_rulebook.exception import VarsKeyMissingException
@@ -102,6 +104,21 @@ def visit_condition(parsed_condition: ConditionTypes, variables: Dict):
         return {"Integer": parsed_condition.value}
     elif isinstance(parsed_condition, Float):
         return {"Float": parsed_condition.value}
+    elif isinstance(parsed_condition, SearchType):
+        data = dict(
+            kind=visit_condition(parsed_condition.kind, variables),
+            pattern=visit_condition(parsed_condition.pattern, variables),
+        )
+        if parsed_condition.options:
+            data["options"] = [
+                visit_condition(v, variables) for v in parsed_condition.options
+            ]
+        return {"SearchType": data}
+    elif isinstance(parsed_condition, KeywordValue):
+        return dict(
+            name=visit_condition(parsed_condition.name, variables),
+            value=visit_condition(parsed_condition.value, variables),
+        )
     elif isinstance(parsed_condition, OperatorExpression):
         if parsed_condition.operator in OPERATOR_MNEMONIC:
             return create_binary_node(
@@ -117,6 +134,10 @@ def visit_condition(parsed_condition: ConditionTypes, variables: Dict):
                             parsed_condition.left, variables
                         )
                     }
+            elif isinstance(parsed_condition.right, SearchType):
+                return create_binary_node(
+                    "SearchMatchesExpression", parsed_condition, variables
+                )
         elif parsed_condition.operator == "is not":
             if isinstance(parsed_condition.right, Identifier):
                 if parsed_condition.right.value == "defined":
@@ -125,6 +146,10 @@ def visit_condition(parsed_condition: ConditionTypes, variables: Dict):
                             parsed_condition.left, variables
                         )
                     }
+            elif isinstance(parsed_condition.right, SearchType):
+                return create_binary_node(
+                    "SearchNotMatchesExpression", parsed_condition, variables
+                )
         else:
             raise Exception(f"Unhandled token {parsed_condition}")
     elif isinstance(parsed_condition, ExistsExpression):

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -84,6 +84,18 @@ Conditions support the following operators:
      - To check if a variable is defined
    * - is not defined
      - To check if a variable is not defined
+   * - is match(pattern,ignorecase=true)
+     - To check if the pattern exists in the beginning
+   * - is not match(pattern,ignorecase=true)
+     - To check if the pattern does not exist in the beginning of the string
+   * - is search(pattern,ignorecase=true)
+     - To check if the pattern exists anywhere in the string
+   * - is not search(pattern,ignorecase=true)
+     - To check if the pattern does not exist anywhere in the string
+   * - is regex(pattern,ignorecase=true)
+     - To check if the regular expression pattern exists in the string
+   * - is not regex(pattern,ignorecase=true)
+     - To check if the regular expression pattern does not exist in the string
    * - `<<`
      - Assignment operator, to save the matching events or facts with events or facts prefix
    * - not
@@ -498,6 +510,77 @@ Throttle actions to counter event storms: Passive
 | When evaluating a single event you can compare multiple
 | properties/attributes from the event using **and** or **or**
 
+String search
+-------------
+
+    .. code-block:: yaml
+
+        name: string search example
+        condition: event.url is search("example.com", ignorecase=true)
+        action:
+          print_event:
+
+| To search for a pattern anywhere in the string. In the above example we check if
+| the event.url has "example.com" anywhere in its value. The option controls that this
+| is a case insensitive search
+
+    .. code-block:: yaml
+
+        name: string not search example
+        condition: event.url is not search("example.com", ignorecase=true)
+        action:
+          print_event:
+
+| In the above example we check if the event.url does not have "example.com" anywhere in its value
+| And the option controls that this is a case insensitive search.
+
+String match
+------------
+
+    .. code-block:: yaml
+
+        name: string match example
+        condition: event.url is match("http://www.example.com", ignorecase=true)
+        action:
+          print_event:
+
+| To search for a pattern in the beginning of string. In the above example we check if
+| the event.url has "http://www.example.com" in the beginning. The option controls that this
+| is a case insensitive search
+
+    .. code-block:: yaml
+
+        name: string not search example
+        condition: event.url is not match("http://www.example.com", ignorecase=true)
+        action:
+          print_event:
+
+| In the above example we check if the event.url does not have "http://www.example.com" in the beginning 
+| And the option controls that this is a case insensitive search.
+
+String regular expression
+-------------------------
+
+    .. code-block:: yaml
+
+        name: string regex example
+        condition: event.url is regex("example\.com", ignorecase=true)
+        action:
+          print_event:
+
+| To search for a regex pattern in the string. In the above example we check if
+| the event.url has "example.com" in its value. The option controls that this
+| is a case insensitive search
+
+    .. code-block:: yaml
+
+        name: string not regex example
+        condition: event.url is not regex("example\.com", ignorecase=true)
+        action:
+          print_event:
+
+| In the above example we check if the event.url does not have "example.com" in its value
+| And the option controls that this is a case insensitive search.
 
 FAQ
 ***

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.1.7
+	drools_jpy == 0.1.8
 
 [options.packages.find]
 include = 

--- a/tests/examples/58_string_search.yml
+++ b/tests/examples/58_string_search.yml
@@ -1,0 +1,44 @@
+---
+- name: 58 String searches
+  hosts: all
+  sources:
+    - name: generic
+      generic:
+        payload:
+          - url1: "https://example.com/users/foo/resources/bar"
+          - url2: "https://example.com/groups/foo/resources/bar"
+          - url3: "https://example.com/others/foo/resources/bar"
+          - url4: "https://redhat.com/users/foo/resources/bar"
+          - url5: "https://redhat.com/abc/foo/resources/bar"
+          - url6: "https://redhat.com/xyz/foo/resources/bar"
+  rules:
+    - name: match
+      condition: event.url1 is match("https://example.com/users/.*/resources",ignorecase=true,multiline=true)
+      action:
+        echo:
+          message: match works
+    - name: search
+      condition: event.url2 is search("groups/.*/resources/.*")
+      action:
+        echo:
+          message: search works
+    - name: regex
+      condition: event.url3 is regex("example\.com/others/foo")
+      action:
+        echo:
+          message: Regex works
+    - name: not match
+      condition: event.url4 is not match("https://example.com/users/.*/resources",ignorecase=true,multiline=true)
+      action:
+        echo:
+          message: not match works
+    - name: not search
+      condition: event.url5 is not search("groups/.*/resources/.*")
+      action:
+        echo:
+          message: not search works
+    - name: not regex
+      condition: event.url6 is not regex("example\.com/others/foo")
+      action:
+        echo:
+          message: not regex works

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -306,6 +306,81 @@ def test_parse_condition():
         parse_condition("fact.friends not contains 'fred'"), {}
     )
 
+    assert {
+        "SearchMatchesExpression": {
+            "lhs": {"Event": "url"},
+            "rhs": {
+                "SearchType": {
+                    "kind": {"String": "match"},
+                    "pattern": {
+                        "String": "https://example.com/users/.*/resources"
+                    },
+                    "options": [
+                        {
+                            "name": {"String": "ignorecase"},
+                            "value": {"Boolean": True},
+                        }
+                    ],
+                }
+            },
+        }
+    } == visit_condition(
+        parse_condition(
+            "event.url is "
+            + 'match("https://example.com/users/.*/resources", '
+            + "ignorecase=true)"
+        ),
+        {},
+    )
+
+    assert {
+        "SearchNotMatchesExpression": {
+            "lhs": {"Event": "url"},
+            "rhs": {
+                "SearchType": {
+                    "kind": {"String": "match"},
+                    "pattern": {
+                        "String": "https://example.com/users/.*/resources"
+                    },
+                    "options": [
+                        {
+                            "name": {"String": "ignorecase"},
+                            "value": {"Boolean": True},
+                        }
+                    ],
+                }
+            },
+        }
+    } == visit_condition(
+        parse_condition(
+            "event.url is not "
+            + 'match("https://example.com/users/.*/resources",ignorecase=true)'
+        ),
+        {},
+    )
+    assert {
+        "SearchMatchesExpression": {
+            "lhs": {"Event": "url"},
+            "rhs": {
+                "SearchType": {
+                    "kind": {"String": "regex"},
+                    "pattern": {"String": "example.com/foo"},
+                    "options": [
+                        {
+                            "name": {"String": "ignorecase"},
+                            "value": {"Boolean": True},
+                        }
+                    ],
+                }
+            },
+        }
+    } == visit_condition(
+        parse_condition(
+            'event.url is regex("example.com/foo",ignorecase=true)'
+        ),
+        {},
+    )
+
 
 @pytest.mark.parametrize(
     "rulebook",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1484,3 +1484,29 @@ async def test_57_once_after_multi():
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "6"
     source_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_58_string_search():
+    ruleset_queues, event_log = load_rulebook("examples/58_string_search.yml")
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    source_task = asyncio.create_task(
+        start_source(rs.sources[0], ["sources"], {}, queue)
+    )
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+
+    for i in range(6):
+        event = event_log.get_nowait()
+        assert event["type"] == "Action", f"{i}"
+        assert event["action"] == "echo", f"{i}"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "6"
+    source_task.cancel()


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-8433

Support string search in conditions.

https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tests.html#testing-strings

- match  = pattern for searching in beginning of string
- search = pattern for searching anywhere in string
- regex  = pattern for using regular expression to do search

Updated to latest version of drools

e.g.
```
condition: event.url2 is search("groups/.*/resources/.*")
```