### PR TITLE
[AAP-6465] Support multiple actions for a rule

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -317,7 +317,18 @@ class RuleSetRunner:
             #    break
 
             action_item = cast(ActionContext, queue_item)
-            await self._call_action(*action_item)
+            for action in action_item.actions:
+                await self._call_action(
+                    action_item.ruleset,
+                    action_item.rule,
+                    action.action,
+                    action.action_args,
+                    action_item.variables,
+                    action_item.inventory,
+                    action_item.hosts,
+                    action_item.facts,
+                    action_item.c,
+                )
 
         logger.info("Stopped waiting for actions on events from %s", self.name)
 

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -195,7 +195,7 @@ def visit_rule(parsed_rule: Rule, variables: Dict):
     data = {
         "name": parsed_rule.name,
         "condition": generate_condition(parsed_rule.condition, variables),
-        "action": visit_action(parsed_rule.action, variables),
+        "actions": visit_actions(parsed_rule.actions, variables),
         "enabled": parsed_rule.enabled,
     }
 
@@ -203,6 +203,10 @@ def visit_rule(parsed_rule: Rule, variables: Dict):
         data.update(visit_throttle(parsed_rule.throttle, variables))
 
     return {"Rule": data}
+
+
+def visit_actions(actions: List[Action], variables: Dict):
+    return [visit_action(a, variables) for a in actions]
 
 
 def visit_action(parsed_action: Action, variables: Dict):

--- a/ansible_rulebook/rule_generator.py
+++ b/ansible_rulebook/rule_generator.py
@@ -22,6 +22,7 @@ from drools.ruleset import Ruleset as DroolsRuleset
 
 from ansible_rulebook.json_generator import visit_ruleset
 from ansible_rulebook.rule_types import (
+    Action,
     ActionContext,
     EngineRuleSetQueuePlan,
     Plan,
@@ -34,8 +35,7 @@ logger = logging.getLogger(__name__)
 def add_to_plan(
     ruleset: str,
     rule: str,
-    action: str,
-    action_args: Dict,
+    actions: List[Action],
     variables: Dict,
     inventory: Dict,
     hosts: List,
@@ -47,8 +47,7 @@ def add_to_plan(
         ActionContext(
             ruleset,
             rule,
-            action,
-            action_args,
+            actions,
             variables,
             inventory,
             hosts,
@@ -72,8 +71,7 @@ def make_fn(
         add_to_plan(
             ruleset,
             ansible_rule.name,
-            ansible_rule.action.action,
-            ansible_rule.action.action_args,
+            ansible_rule.actions,
             variables,
             inventory,
             hosts,

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -56,7 +56,7 @@ class Throttle(NamedTuple):
 class Rule(NamedTuple):
     name: str
     condition: Condition
-    action: Action
+    actions: List[Action]
     enabled: bool
     throttle: Optional[Throttle] = None
 
@@ -72,8 +72,7 @@ class RuleSet(NamedTuple):
 class ActionContext(NamedTuple):
     ruleset: str
     rule: str
-    action: str
-    actions_args: Dict
+    actions: List[Action]
     variables: Dict
     inventory: Dict
     hosts: List[str]

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -109,13 +109,24 @@ def parse_rules(rules: Dict) -> List[rt.Rule]:
             rt.Rule(
                 name=name,
                 condition=parse_condition(rule["condition"]),
-                action=parse_action(rule["action"]),
+                actions=parse_actions(rule),
                 enabled=rule.get("enabled", True),
                 throttle=throttle,
             )
         )
 
     return rule_list
+
+
+def parse_actions(rule: Dict) -> List[rt.Action]:
+    actions = []
+    if "actions" in rule:
+        for action in rule["actions"]:
+            actions.append(parse_action(action))
+    elif "action" in rule:
+        actions.append(parse_action(rule["action"]))
+
+    return actions
 
 
 def parse_action(action: Dict) -> rt.Action:

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -75,6 +75,10 @@
         },
         "rule": {
             "type": "object",
+            "oneOf": [
+                  {"required": ["name", "condition", "actions"]},
+                  {"required": ["name", "condition", "action"]}
+            ],
             "properties": {
                 "name": {
                     "type": "string",
@@ -89,6 +93,24 @@
                         {"$ref": "#/$defs/any-condition"},
                         {"$ref": "#/$defs/not-all-condition"}
                     ]
+                },
+                "actions": {
+                    "type": "array",
+                    "items": {
+                         "oneOf": [
+                                {"$ref": "#/$defs/run-playbook-action"},
+                                {"$ref": "#/$defs/run-module-action"},
+                                {"$ref": "#/$defs/run-job-template-action"},
+                                {"$ref": "#/$defs/post-event-action"},
+                                {"$ref": "#/$defs/set-fact-action"},
+                                {"$ref": "#/$defs/retract-fact-action"},
+                                {"$ref": "#/$defs/print-event-action"},
+                                {"$ref": "#/$defs/debug-action"},
+                                {"$ref": "#/$defs/none-action"},
+                                {"$ref": "#/$defs/shutdown-action"},
+                                {"$ref": "#/$defs/echo-action"}
+                         ]
+                     }
                 },
                 "action": {
                     "oneOf": [
@@ -106,11 +128,6 @@
                     ]
                 }
             },
-            "required": [
-                "name",
-                "condition",
-                "action"
-            ],
             "additionalProperties": false
         },
         "all-condition": {

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -2,8 +2,10 @@
 Rules
 =====
 
-Rules is a list of rules. Event driven automation uses rules to determine if an action should be taken when an event is received.
-The rule decides to run an action by evaluating the condition(s) that is defined by the rulebook author.
+| Rules is a list of rules. Event driven automation uses rules to determine if an action or 
+| actions should be taken when an event is received.
+| The rule decides to run an action or actions by evaluating the condition(s) 
+| that is defined by the rulebook author.
 
 A rule comprises:
 
@@ -21,13 +23,16 @@ A rule comprises:
    * - condition
      - See :doc:`conditions`
      - Yes
+   * - actions
+     - See :doc:`actions`
+     - or action
    * - action
      - See :doc:`actions`
-     - Yes
+     - or actions
 
 
 
-Example:
+Example: A single action
 
     .. code-block:: yaml
 
@@ -42,3 +47,19 @@ Example:
             condition: event.target_os == "linux" or
             action:
               debug:
+
+Example: Multiple actions
+
+    .. code-block:: yaml
+
+        rules:
+          - name: An automatic remediation rule
+            condition: event.outage == true
+            actions:
+              - run_playbook:
+                  name: remediate_outage.yml
+              - print_event:
+                  pretty: true
+
+| In the above example the 2 actions are executed in order. First
+| we call run_playbook and then when it ends we call print_event

--- a/tests/asts/rules.yml
+++ b/tests/asts/rules.yml
@@ -4,8 +4,8 @@
     name: Demo rules
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: slack
             action_args:
               color: good
@@ -21,8 +21,8 @@
         enabled: true
         name: send to slack3
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: slack
             action_args:
               color: warning
@@ -38,8 +38,8 @@
         enabled: true
         name: send to slack4
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: slack
             action_args:
               msg: '{{event}}'
@@ -54,8 +54,8 @@
         enabled: true
         name: send to slack5
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: slack
             action_args:
               msg: '{{event}}'
@@ -70,8 +70,8 @@
         enabled: true
         name: send to slack6
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: set_fact
             action_args:
               fact:
@@ -87,8 +87,8 @@
         enabled: true
         name: assert fact
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: log
             action_args: {}
         condition:

--- a/tests/asts/rules_with_assignment.yml
+++ b/tests/asts/rules_with_assignment.yml
@@ -4,8 +4,8 @@
     name: Demo rules with assignment
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args:
               events_event: '{{events.first}}'

--- a/tests/asts/rules_with_assignment2.yml
+++ b/tests/asts/rules_with_assignment2.yml
@@ -4,8 +4,8 @@
     name: Demo rules with assignment2
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args:
               events_event: '{{events.first}}'

--- a/tests/asts/rules_with_multiple_conditions.yml
+++ b/tests/asts/rules_with_multiple_conditions.yml
@@ -4,8 +4,8 @@
     name: Demo rules multiple conditions any
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args: {}
         condition:

--- a/tests/asts/rules_with_multiple_conditions2.yml
+++ b/tests/asts/rules_with_multiple_conditions2.yml
@@ -4,8 +4,8 @@
     name: Demo rules multiple conditions all
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args: {}
         condition:

--- a/tests/asts/rules_with_multiple_conditions3.yml
+++ b/tests/asts/rules_with_multiple_conditions3.yml
@@ -4,8 +4,8 @@
     name: Demo rules multiple conditions reference assignment
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args:
               first: '{{events.first}}'

--- a/tests/asts/rules_with_time.yml
+++ b/tests/asts/rules_with_time.yml
@@ -4,8 +4,8 @@
     name: Demo rules with time
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: set_fact
             action_args:
               fact:
@@ -17,8 +17,8 @@
         enabled: true
         name: promote time.tick to current_time fact
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: retract_fact
             action_args:
               fact:
@@ -30,8 +30,8 @@
         enabled: true
         name: retract current_time fact
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args: {}
         condition:
@@ -42,8 +42,8 @@
         name: matches current_time fact before it is retracted since facts fire all
           matching rules
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: shutdown
             action_args: {}
         condition:

--- a/tests/asts/rules_with_timestamp.yml
+++ b/tests/asts/rules_with_timestamp.yml
@@ -4,8 +4,8 @@
     name: Demo rules with timestamp
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: set_fact
             action_args:
               fact:
@@ -17,8 +17,8 @@
         enabled: true
         name: promote timestamp.unix_timestamp to current_time fact
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: set_fact
             action_args:
               fact:
@@ -36,8 +36,8 @@
         enabled: true
         name: set the initial time
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: retract_fact
             action_args:
               fact:
@@ -49,8 +49,8 @@
         enabled: true
         name: retract current_time fact
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args: {}
         condition:
@@ -60,8 +60,8 @@
         enabled: true
         name: debug
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: shutdown
             action_args: {}
         condition:

--- a/tests/asts/rules_with_vars.yml
+++ b/tests/asts/rules_with_vars.yml
@@ -4,8 +4,8 @@
     name: Rules with vars
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args: {}
         condition:

--- a/tests/asts/rules_without_assignment.yml
+++ b/tests/asts/rules_without_assignment.yml
@@ -4,8 +4,8 @@
     name: Demo rules multiple conditions all
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args:
               event: '{{event}}'

--- a/tests/asts/test_filters.yml
+++ b/tests/asts/test_filters.yml
@@ -4,8 +4,8 @@
     name: Test rule filters
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: print_event
             action_args:
               pretty: true
@@ -20,8 +20,8 @@
         enabled: true
         name: r1
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: print_event
             action_args: {}
         condition:
@@ -34,8 +34,8 @@
         enabled: true
         name: r2
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: run_playbook
             action_args:
               name: playbooks/hello_world_set_fact.yml
@@ -51,8 +51,8 @@
         enabled: true
         name: r3
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: print_event
             action_args: {}
         condition:

--- a/tests/asts/test_host_rules.yml
+++ b/tests/asts/test_host_rules.yml
@@ -4,8 +4,8 @@
     name: Test host rules
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: set_fact
             action_args:
               fact:
@@ -21,8 +21,8 @@
         enabled: true
         name: r1
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: run_playbook
             action_args:
               name: playbooks/hello_events.yml
@@ -36,8 +36,8 @@
         enabled: true
         name: r2
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: retract_fact
             action_args:
               fact:
@@ -53,8 +53,8 @@
         enabled: true
         name: r3
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: post_event
             action_args:
               event:
@@ -70,8 +70,8 @@
         enabled: true
         name: r4
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: none
             action_args: {}
         condition:

--- a/tests/asts/test_rules.yml
+++ b/tests/asts/test_rules.yml
@@ -4,8 +4,8 @@
     name: Test rules4
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: set_fact
             action_args:
               fact:
@@ -21,8 +21,8 @@
         enabled: true
         name: r1
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: run_playbook
             action_args:
               name: playbooks/hello_world_set_fact.yml
@@ -36,8 +36,8 @@
         enabled: true
         name: r2
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: retract_fact
             action_args:
               fact:
@@ -53,8 +53,8 @@
         enabled: true
         name: r3
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: post_event
             action_args:
               event:
@@ -70,8 +70,8 @@
         enabled: true
         name: r4
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: none
             action_args: {}
         condition:

--- a/tests/asts/test_rules_multiple_hosts.yml
+++ b/tests/asts/test_rules_multiple_hosts.yml
@@ -4,8 +4,8 @@
     name: Test rules multiple hosts
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: set_fact
             action_args:
               fact:
@@ -21,8 +21,8 @@
         enabled: true
         name: r1
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: run_playbook
             action_args:
               name: playbooks/hello_events.yml
@@ -36,8 +36,8 @@
         enabled: true
         name: r2
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: retract_fact
             action_args:
               fact:
@@ -53,8 +53,8 @@
         enabled: true
         name: r3
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: post_event
             action_args:
               event:
@@ -70,8 +70,8 @@
         enabled: true
         name: r4
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: none
             action_args: {}
         condition:

--- a/tests/asts/test_rules_multiple_hosts2.yml
+++ b/tests/asts/test_rules_multiple_hosts2.yml
@@ -4,8 +4,8 @@
     name: Test rules multiple hosts 2
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args: {}
         condition:

--- a/tests/asts/test_rules_multiple_hosts3.yml
+++ b/tests/asts/test_rules_multiple_hosts3.yml
@@ -4,8 +4,8 @@
     name: Test rules multiple hosts 3
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: debug
             action_args: {}
         condition:

--- a/tests/asts/test_set_facts.yml
+++ b/tests/asts/test_set_facts.yml
@@ -4,8 +4,8 @@
     name: Test Assert Fact of different data types
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: set_fact
             action_args:
               fact:
@@ -24,8 +24,8 @@
         enabled: true
         name: r1
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: run_playbook
             action_args:
               copy_files: true

--- a/tests/asts/test_simple.yml
+++ b/tests/asts/test_simple.yml
@@ -4,8 +4,8 @@
     name: Test rules simple
     rules:
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: print_event
             action_args:
               pretty: true
@@ -20,8 +20,8 @@
         enabled: true
         name: r1
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: print_event
             action_args: {}
         condition:
@@ -34,8 +34,8 @@
         enabled: true
         name: r2
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: run_playbook
             action_args:
               name: playbooks/hello_world_set_fact.yml
@@ -51,8 +51,8 @@
         enabled: true
         name: r3
     - Rule:
-        action:
-          Action:
+        actions:
+        - Action:
             action: print_event
             action_args: {}
         condition:

--- a/tests/examples/59_multiple_actions.yml
+++ b/tests/examples/59_multiple_actions.yml
@@ -1,0 +1,22 @@
+- hosts: all
+  name: 59 Multiple Actions
+  sources:
+  - name: range
+    range:
+      limit: 5
+  rules:
+  - name: r1
+    condition: event.i == 1
+    actions:
+      - debug:
+      - print_event:
+           pretty: true
+      - echo:
+           message: "Multiple Action Message1"
+      - echo:
+           message: "Multiple Action Message2"
+  - name: r2
+    condition: event.i == 2
+    action:
+      echo:
+        message: Single Action

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -43,7 +43,10 @@ async def test_generate_rules():
     print(durable_rulesets[0].ruleset.define())
     set_fact("Demo rules", {"payload": {"text": "hello"}})
 
-    assert durable_rulesets[0].plan.queue.get_nowait().action == "slack"
+    assert (
+        durable_rulesets[0].plan.queue.get_nowait().actions[0].action
+        == "slack"
+    )
     assert durable_rulesets[0].plan.queue.get_nowait().rule == "assert fact"
     assert durable_rulesets[0].plan.queue.get_nowait().ruleset == "Demo rules"
 
@@ -65,9 +68,15 @@ async def test_generate_rules_multiple_conditions_any():
     print(durable_rulesets[0].ruleset.define())
 
     post("Demo rules multiple conditions any", {"i": 0})
-    assert durable_rulesets[0].plan.queue.get_nowait().action == "debug"
+    assert (
+        durable_rulesets[0].plan.queue.get_nowait().actions[0].action
+        == "debug"
+    )
     post("Demo rules multiple conditions any", {"i": 1})
-    assert durable_rulesets[0].plan.queue.get_nowait().action == "debug"
+    assert (
+        durable_rulesets[0].plan.queue.get_nowait().actions[0].action
+        == "debug"
+    )
 
 
 @pytest.mark.asyncio
@@ -90,7 +99,10 @@ async def test_generate_rules_multiple_conditions_all():
     assert durable_rulesets[0].plan.queue.qsize() == 0
     post("Demo rules multiple conditions all", {"i": 1})
     assert durable_rulesets[0].plan.queue.qsize() == 1
-    assert durable_rulesets[0].plan.queue.get_nowait().action == "debug"
+    assert (
+        durable_rulesets[0].plan.queue.get_nowait().actions[0].action
+        == "debug"
+    )
 
 
 @pytest.mark.asyncio
@@ -115,4 +127,7 @@ async def test_generate_rules_multiple_conditions_all_3():
     assert durable_rulesets[0].plan.queue.qsize() == 0
     post("Demo rules multiple conditions reference assignment", {"i": 2})
     assert durable_rulesets[0].plan.queue.qsize() == 1
-    assert durable_rulesets[0].plan.queue.get_nowait().action == "debug"
+    assert (
+        durable_rulesets[0].plan.queue.get_nowait().actions[0].action
+        == "debug"
+    )


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-6465

A rule can have either a single action or a list of actions. If multiple actions are specified they are executed one after the other in the order they are specified in the rulebook. e.g.
```
   actions:
      - debug:
      - print_event:
           pretty: true
      - echo:
           message: "Multiple Action Message1"
      - echo:
           message: "Multiple Action Message2"
```