### PR TITLE
Skip temporal tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: pytest -m "not e2e" -vv -n auto
+        run: pytest -m "not e2e and not temporal" -vv -n auto


### PR DESCRIPTION
In CI the temporal examples takes upwards of 5 minutes because the examples have time delays. This is causing PR's to fail.
Maybe we should look to move the temporal tests to e2e workflow or run a scheduled workflow that can run once an hour to catch any issues.