### PR TITLE
AAP-8681 update json schema: rulesets minlength

### DIFF
--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -3,6 +3,7 @@
     "$id": "http://ansible.com/schema/ruleset.json",
     "type": "array",
     "items": {"$ref": "#/$defs/ruleset"},
+    "minItems": 1,
     "$defs": {
         "ruleset": {
             "type": "object",


### PR DESCRIPTION
A rulebook can not contain an empty list of rulesets, update the schema accordingly
closes https://issues.redhat.com/browse/AAP-8681