### PR TITLE
Set log level for the drools package

### DIFF
--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -172,6 +172,7 @@ def setup_logging(args: argparse.Namespace) -> None:
         stream = sys.stdout
 
     logging.basicConfig(stream=stream, level=level, format=LOG_FORMAT)
+    logging.getLogger("drools.").setLevel(level)
 
 
 def main(args: List[str] = None) -> int:


### PR DESCRIPTION
Since we delay setting of the log level till we parse the command line drools runs with the root logger settings.
This PR sets the log level for the drools package to be the same as for the ansible-rulebook based on the --verbose or --debug