### PR TITLE
Added example to show how json filter works

### DIFF
--- a/tests/examples/60_json_filter.yml
+++ b/tests/examples/60_json_filter.yml
@@ -1,0 +1,34 @@
+---
+- name: 60 json filter
+  hosts: all
+  sources:
+    - generic:
+        payload:
+          key1:
+            key2:
+              f_ignore_1: 1
+              f_ignore_2: 2
+          key3:
+            key4:
+              f_use_1: 42
+              f_use_2: 45
+      filters:
+        - ansible.eda.json_filter:
+            include_keys:  
+              - key3
+              - key4
+              - f_use*
+            exclude_keys:
+              - "*"
+
+  rules:
+    - name: r1
+      condition: event.key3.key4.f_use_1 == 42
+      action:
+        echo:
+          message: Hurray filtering works
+    - name: r2
+      condition: event.key1.key2.f_ignore_1 == 1
+      action:
+        echo:
+          message: Should never fire

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1548,3 +1548,31 @@ async def test_59_multiple_actions():
     }
     validate_events(event_log, **checks)
     source_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_60_json_filter():
+    ruleset_queues, event_log = load_rulebook("examples/60_json_filter.yml")
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    source_task = asyncio.create_task(
+        start_source(rs.sources[0], ["sources"], {}, queue)
+    )
+
+    await run_rulesets(
+        event_log,
+        ruleset_queues,
+        dict(),
+        load_inventory("playbooks/inventory.yml"),
+    )
+
+    checks = {
+        "max_events": 2,
+        "shutdown_events": 1,
+        "actions": [
+            "60 json filter::r1::echo",
+        ],
+    }
+    validate_events(event_log, **checks)
+    source_task.cancel()


### PR DESCRIPTION
Need an example to demonstrate how json_filter works We have to exclude all keys with *
and include only those keys that we need. Each level of the key should be a separate array item.

e.g. to pick up key3.key4.f_use* keys each level needs to be listed separately

```
      filters:
        - ansible.eda.json_filter:
            include_keys:
              - key3
              - key4
              - f_use*
            exclude_keys:
              - "*"
```