### PR TITLE
[AAP-8555] Error parsing not condition

### DIFF
--- a/ansible_rulebook/condition_parser.py
+++ b/ansible_rulebook/condition_parser.py
@@ -149,7 +149,6 @@ all_terms = (
 condition = infix_notation(
     all_terms,
     [
-        ("not", 1, OpAssoc.RIGHT, lambda toks: NegateExpression(*toks[0])),
         (
             one_of("* /"),
             2,
@@ -208,6 +207,7 @@ condition = infix_notation(
             OpAssoc.LEFT,
             lambda toks: OperatorExpressionFactory(toks[0]),
         ),
+        ("not", 1, OpAssoc.RIGHT, lambda toks: NegateExpression(*toks[0])),
         (
             one_of(["and", "or"]),
             2,

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -380,9 +380,9 @@ Negation Example
 | In this example the boolean expression is evaluated first and then negated.
 
 .. note::
-    ``not`` operator can work without parenthesis when the value is a boolean, E.g ``condition: not event.disabled``
+    ``not`` operator can work without parenthesis when the value is a single logical statement
 
-    In the rest of the cases the expression must be enclosed in parenthesis. E.g ``condition: not (event.i == 4)``
+    If there are multiple logical statements with **or** or **and** please use round brackets like shown above.
 
 
 Adding time constraints for rules with multiple conditions

--- a/tests/examples/50_negation.yml
+++ b/tests/examples/50_negation.yml
@@ -8,6 +8,8 @@
            - b: false
            - bt: true
            - i: 10
+           - msg: Fred
+           - j: 9
   rules:
     - name: r1
       condition: not event.b
@@ -19,5 +21,13 @@
         print_event:
     - name: r3
       condition: not (event.i > 50 or event.i < 10)
+      action:
+        print_event:
+    - name: r4
+      condition: not event.msg == "Barney"
+      action:
+        print_event:
+    - name: r5
+      condition: not event.j >= 10
       action:
         print_event:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1244,7 +1244,15 @@ async def test_50_negation():
         assert event["action"] == "print_event", "5"
         assert event["matching_events"] == {"m": {"i": 10}}, "5"
         event = event_log.get_nowait()
-        assert event["type"] == "Shutdown", "7"
+        assert event["type"] == "Action", "6"
+        assert event["action"] == "print_event", "6"
+        assert event["matching_events"] == {"m": {"msg": "Fred"}}, "6"
+        event = event_log.get_nowait()
+        assert event["type"] == "Action", "7"
+        assert event["action"] == "print_event", "7"
+        assert event["matching_events"] == {"m": {"j": 9}}, "7"
+        event = event_log.get_nowait()
+        assert event["type"] == "Shutdown", "8"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When using multiple logical statments in a condition with or/and we need ( and ) to resolve ambiguities. Otherwise we should be able to parse simple conditions with a not without braces. The not has a priority over the and and or.

https://issues.redhat.com/browse/AAP-8555
e.g. all of these are valid

```
   condition: not event.i == 5
```

```
   condition: not event.msg == "Barney"
```

```
   condition: not event.j >= 10
```

```
   condition: not event.my_boolean
```

But if you use and/or you need surrounding round braces
```
   condition: not (event.i > 50 or event.i < 10)
```