### PR TITLE
[AAP-6910] Report error when assignment is invalid

### DIFF
--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -36,3 +36,8 @@ class ControllerApiException(Exception):
 class VarsKeyMissingException(Exception):
 
     pass
+
+
+class InvalidAssignmentException(Exception):
+
+    pass

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -18,6 +18,7 @@ import pytest
 import yaml
 
 from ansible_rulebook.condition_parser import parse_condition
+from ansible_rulebook.exception import InvalidAssignmentException
 from ansible_rulebook.json_generator import (
     generate_dict_rulesets,
     visit_condition,
@@ -418,3 +419,18 @@ def test_generate_dict_ruleset(rulebook):
         ast = yaml.safe_load(f.read())
 
     assert ruleset == ast
+
+
+def test_invalid_assignment_operator():
+    with pytest.raises(InvalidAssignmentException):
+        visit_condition(
+            parse_condition("event.first << fact.range.i == 'Hello'"), {}
+        )
+
+
+def test_invalid_nested_assignment_operator():
+    with pytest.raises(InvalidAssignmentException):
+        visit_condition(
+            parse_condition("events.first.abc.xyz << fact.range.i == 'Hello'"),
+            {},
+        )


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-6910
https://issues.redhat.com/browse/AAP-6909

When an assignment is invalid raise an error with the following message

```
  event.i << event.nested.i == 1
```
Only events and facts can be used in assignment. event.i is invalid.

We dont support nested vars
    
```
     event.iabc.xyz << event.nested.i == 1
```
event.iabc.xyz is invalid.Valid values start with events or facts. e.g events.var1 or facts.var1 Where var1 can only contain alpha numeric and _ charachters