### PR TITLE
Changed var root example to use generic plugin

### DIFF
--- a/tests/examples/27_var_root.yml
+++ b/tests/examples/27_var_root.yml
@@ -2,9 +2,17 @@
 - name: 27 multiple events all with var_root
   hosts: all
   sources:
-    - name: range
-      range:
-        limit: 5
+    - name: generic
+      generic:
+        payload:
+          - webhook:
+              payload:
+                url: http://www.example.com
+                action: merge
+          - kafka:
+              message:
+                topic: testing
+                channel: red
   rules:
     - name: r1
       condition:


### PR DESCRIPTION
The current example was using the range plugin and putting dictionary data into the queue. Changed it to use the generic plugin which can insert arbitrary data.