### PR TITLE
Removed event key count limits

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -47,11 +47,7 @@ from ansible_rulebook.rule_types import (
     RuleSetQueue,
 )
 from ansible_rulebook.rules_parser import parse_hosts
-from ansible_rulebook.util import (
-    collect_ansible_facts,
-    json_count,
-    substitute_variables,
-)
+from ansible_rulebook.util import collect_ansible_facts, substitute_variables
 
 logger = logging.getLogger(__name__)
 
@@ -300,7 +296,6 @@ class RuleSetRunner:
                 PrettyPrinter(indent=4).pprint(data)
 
             logger.debug("Received event : " + str(data))
-            json_count(data)
             if isinstance(data, Shutdown):
                 logger.info("Shutdown message received: " + str(data))
                 await self._stop(data)

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -21,7 +21,6 @@ import subprocess
 import sys
 import tempfile
 import typing
-from pprint import pprint
 from typing import Any, Dict, List, Union
 
 import ansible_runner
@@ -75,28 +74,6 @@ def load_inventory(inventory_file: str) -> Any:
     with open(inventory_file) as f:
         inventory_data = yaml.safe_load(f.read())
     return inventory_data
-
-
-def json_count(data):
-    s = 0
-    q = []
-    q.append(data)
-    while q:
-        o = q.pop()
-        if isinstance(o, dict):
-            s += len(o)
-            if len(o) > 255:
-                pprint(data)
-                raise Exception(
-                    f"Only 255 values supported per dictionary found {len(o)}"
-                )
-            if s > 255:
-                pprint(data)
-                raise Exception(
-                    f"Only 255 values supported per dictionary found {s}"
-                )
-            for i in o.values():
-                q.append(i)
 
 
 def collect_ansible_facts(inventory: Dict) -> List[Dict]:


### PR DESCRIPTION
There is a limit of 255 keys in an event payload.
The key size limit was used for durable rules. Now that we have switched to drools we don't have the key count limit