### PR TITLE
Vars related cleanup

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -258,7 +258,7 @@ class RuleSetRunner:
 
     async def run_ruleset(self):
         self.stopped = False
-        prime_facts(self.name, self.hosts_facts, self.variables)
+        prime_facts(self.name, self.hosts_facts)
         self.pa_runner_task = asyncio.create_task(
             self.pa_runner.start(self.name), name=self.name
         )
@@ -535,15 +535,9 @@ class PlaybookActionRunner:
         await self.actions.put(action_args)
 
 
-def prime_facts(name: str, hosts_facts: List[Dict], variables: Dict):
+def prime_facts(name: str, hosts_facts: List[Dict]):
     for data in hosts_facts:
         try:
             lang.assert_fact(name, data)
-        except MessageNotHandledException:
-            pass
-
-    if variables:
-        try:
-            lang.assert_fact(name, variables)
         except MessageNotHandledException:
             pass

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -217,7 +217,12 @@ Condition with fact and event
         action:
           debug:
 
-In the above example the custom.expected_index was set using the set_fact action in the running of the rulebook
+| In the above example the custom.expected_index was set using the set_fact action in 
+| the running of the rulebook. You cannot compare a fact and event directly in the same
+| condition. First the fact has to be assigned to a local variable, **facts.first** in the
+| above example and then that local variable can be compared with event.i. When you use a 
+| fact and event it would always have to be in the context of multiple conditions using **all**.
+| `Differences between facts and events <events_and_facts.html>`_
 
 
 Condition with vars and event
@@ -233,8 +238,21 @@ Condition with vars and event
         action:
           debug:
 
-In the above example the person.year and person.age was passed in a variables file via ``--vars`` from the
-command line to ansible-rulebook.
+| In the above example the person.year and person.age was passed in a variables file via 
+| ``--vars`` from the command line to ansible-rulebook. The usage of vars allows us to 
+| preserve the data type.  Environment variable values are always treated as strings and 
+| you would have to do the type conversion in the playbook or job template.
+
+    .. code-block:: yaml
+
+        name: Single condition comparing vars and event
+        condition: event.name == vars.name
+        action:
+          debug:
+
+| Vars can be used in single condition rules, like above because vars are resolved when
+| the ruleset is loaded before being passed into the rule engine. If the vars is missing
+| ansible-rulebook reports an error.
 
 | When evaluating a single event you can compare multiple
 | properties/attributes from the event using **and** or **or**

--- a/tests/e2e/files/rulebooks/operators/test_in_str_multiple_extra_vars_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_in_str_multiple_extra_vars_operator.yml
@@ -13,10 +13,7 @@
             - Baratheon
   rules:
     - name: r1
-      condition:
-        all:
-          - facts.custom << fact.houses is defined
-          - event.extra_payload.houses contains "Stark" and event.i in facts.custom.in_operator_int_array
+      condition: event.extra_payload.houses contains "Stark" and event.i in vars.in_operator_int_array
       action:
         run_playbook:
           name: ./playbooks/print_event.yml

--- a/tests/e2e/files/rulebooks/operators/test_not_in_int_extra_vars_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_not_in_int_extra_vars_operator.yml
@@ -13,10 +13,7 @@
             - Baratheon
   rules:
     - name: r1
-      condition:
-        all:
-          - facts.custom << fact.in_operator_int_array is defined
-          - event.i not in facts.custom.in_operator_int_array
+      condition: event.i not in vars.in_operator_int_array
       action:
         run_playbook:
           name: ./playbooks/print_event.yml

--- a/tests/e2e/files/rulebooks/operators/test_not_in_str_extra_vars_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_not_in_str_extra_vars_operator.yml
@@ -9,10 +9,7 @@
           house: Martell
   rules:
     - name: r1
-      condition:
-        all:
-          - facts.custom << fact.houses is defined
-          - event.extra_payload.house not in facts.custom.houses
+      condition: event.extra_payload.house not in vars.houses
       action:
         run_playbook:
           name: ./playbooks/print_event.yml

--- a/tests/examples/28_right_side_condition_template.yml
+++ b/tests/examples/28_right_side_condition_template.yml
@@ -1,5 +1,5 @@
 ---
-- name: 28 test jinja templating on the right side of the condition
+- name: 28 test vars
   hosts: all
   sources:
     - name: range
@@ -7,9 +7,6 @@
         limit: 5
   rules:
     - name: r1
-      condition:
-        all:
-          - facts.first << fact.custom.expected_index is defined
-          - event.i == facts.first.custom.expected_index
+      condition: event.i == vars.custom.expected_index
       action:
         debug:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -754,11 +754,10 @@ async def test_28_right_side_condition_template():
     assert event["type"] == "Action", "1"
     assert event["action"] == "debug", "2"
     assert event["matching_events"] == {
-        "first": {"custom": {"expected_index": 2}},
-        "m_1": {"i": 2},
+        "m": {"i": 2},
     }, "3"
     event = event_log.get_nowait()
-    assert event["type"] == "Shutdown", "7"
+    assert event["type"] == "Shutdown", "4"
     assert event_log.empty()
 
 


### PR DESCRIPTION
Since we have the vars namespace for accessing variables passed in from the vars-file or env_vars we don't have to send the vars to the rule engine. The vars are resolved before we send the ruleset to Drools. Added additional notes in documentation.