### PR TITLE
Intermittent test failures

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -47,6 +47,18 @@ def load_rulebook(rules_file):
     return ruleset_queues, event_log
 
 
+async def get_queue_item(queue, timeout=0.5, times=1):
+    for _ in range(times):
+        try:
+            item = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            await asyncio.sleep(timeout)
+            continue
+        if item:
+            return item
+    return None
+
+
 def validate_events(event_log, **kwargs):
     shutdown_events = 0
     job_events = 0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -21,7 +21,7 @@ from ansible_rulebook.exception import VarsKeyMissingException
 from ansible_rulebook.messages import Shutdown
 from ansible_rulebook.util import load_inventory
 
-from .test_engine import load_rulebook, validate_events
+from .test_engine import get_queue_item, load_rulebook, validate_events
 
 
 class SourceTask:
@@ -1395,7 +1395,7 @@ async def test_54_time_window():
             load_inventory("playbooks/inventory.yml"),
         )
 
-        event = event_log.get_nowait()
+        event = await get_queue_item(event_log, 10, 2)
         assert event["type"] == "Action", "1"
         assert event["action"] == "print_event", "1"
         assert event["matching_events"] == {


### PR DESCRIPTION
The example test_54_time_window fails intermittently, since the test introduces a delay of 10 seconds, the queue get might get the occasional QueueEmpty exception. Attempting to fix it by adding a retry if we get the QueueEmpty exception.

Fixes #346