### PR TITLE
Don't serialize execution of job templates

### DIFF
--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -233,7 +233,7 @@ async def run_rulesets(
 
 
 class RuleSetRunner:
-    ANSIBLE_ACTIONS = ("run_playbook", "run_module", "run_job_template")
+    ANSIBLE_ACTIONS = ("run_playbook", "run_module")
 
     def __init__(
         self,


### PR DESCRIPTION
Based on the dev sync call last week we only want to serialize the execution of playbooks and modules but not the job templates.