### PR TITLE
[AAP-9025] Check for duplicate ruleset names

### DIFF
--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -23,6 +23,16 @@ class RulenameEmptyException(Exception):
     pass
 
 
+class RulesetNameDuplicateException(Exception):
+
+    pass
+
+
+class RulesetNameEmptyException(Exception):
+
+    pass
+
+
 class RulenameDuplicateException(Exception):
 
     pass

--- a/tests/rules/test_blank_ruleset_name.yml
+++ b/tests/rules/test_blank_ruleset_name.yml
@@ -1,0 +1,12 @@
+---
+- name: ' '
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 1
+      action:
+        debug:

--- a/tests/rules/test_duplicate_ruleset_names.yml
+++ b/tests/rules/test_duplicate_ruleset_names.yml
@@ -1,0 +1,23 @@
+---
+- name: ruleset1
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 1
+      action:
+        debug:
+- name: ruleset1
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 1
+      action:
+        debug:

--- a/tests/rules/test_missing_ruleset_name.yml
+++ b/tests/rules/test_missing_ruleset_name.yml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 1
+      action:
+        debug:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -20,6 +20,10 @@ import pytest
 import yaml
 from drools.ruleset import assert_fact as set_fact, post
 
+from ansible_rulebook.exception import (
+    RulesetNameDuplicateException,
+    RulesetNameEmptyException,
+)
 from ansible_rulebook.rule_generator import generate_rulesets
 from ansible_rulebook.rules_parser import parse_rule_sets
 
@@ -131,3 +135,42 @@ async def test_generate_rules_multiple_conditions_all_3():
         durable_rulesets[0].plan.queue.get_nowait().actions[0].action
         == "debug"
     )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_ruleset_names():
+    os.chdir(HERE)
+    with open("rules/test_duplicate_ruleset_names.yml") as f:
+        data = yaml.safe_load(f.read())
+
+    with pytest.raises(RulesetNameDuplicateException) as exc_info:
+        parse_rule_sets(data)
+
+    assert (
+        str(exc_info.value)
+        == "Ruleset with name: ruleset1 defined multiple times"
+    )
+
+
+@pytest.mark.asyncio
+async def test_blank_ruleset_names():
+    os.chdir(HERE)
+    with open("rules/test_blank_ruleset_name.yml") as f:
+        data = yaml.safe_load(f.read())
+
+    with pytest.raises(RulesetNameEmptyException) as exc_info:
+        parse_rule_sets(data)
+
+    assert str(exc_info.value) == "Ruleset name cannot be an empty string"
+
+
+@pytest.mark.asyncio
+async def test_missing_ruleset_names():
+    os.chdir(HERE)
+    with open("rules/test_missing_ruleset_name.yml") as f:
+        data = yaml.safe_load(f.read())
+
+    with pytest.raises(RulesetNameEmptyException) as exc_info:
+        parse_rule_sets(data)
+
+    assert str(exc_info.value) == "Ruleset name not provided"


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-9025
Prevent duplicate, empty ruleset names from being processed