### PR TITLE
Fix codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: ./coverage.xml
-          flags: unittests
+          flags: "unittests-${{ matrix.python-version }}"
           name: codecov-umbrella
           verbose: true

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -63,9 +63,9 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: ./coverage.xml
-          flags: unittests
+          flags: "unittests-${{ matrix.python-version }}"
           name: codecov-umbrella
           verbose: true
 


### PR DESCRIPTION
Sometimes the upload fails due to outages in codecov. 
- Don't mark the workflow as failed if the upload fails (the job can be executed manually later)
- Add the python version to the flag. 