### PR TITLE
[AAP-9235] Allow for actions to finish in an ordered shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - group_by_attributes
 - Support multiple actions for a rule
 - Support for search/match/regex 
+- Support for graceful shutdown, timeout to allow actions to complete
 
 ### Fixed
 

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -74,7 +74,10 @@ async def run(parsed_args: argparse.ArgumentParser) -> None:
 
     logger.info("Starting sources")
     tasks, ruleset_queues = spawn_sources(
-        rulesets, variables, [parsed_args.source_dir]
+        rulesets,
+        variables,
+        [parsed_args.source_dir],
+        parsed_args.shutdown_delay,
     )
 
     logger.info("Starting rules")
@@ -165,6 +168,7 @@ def spawn_sources(
     rulesets: List[RuleSet],
     variables: Dict[str, Any],
     source_dirs: List[str],
+    shutdown_delay: float,
 ) -> Tuple[List[asyncio.Task], List[RuleSetQueue]]:
     tasks = []
     ruleset_queues = []
@@ -177,6 +181,7 @@ def spawn_sources(
                     source_dirs,
                     variables,
                     source_queue,
+                    shutdown_delay,
                 )
             )
             tasks.append(task)

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -22,6 +22,7 @@ import sys
 from typing import List, NoReturn
 
 import ansible_rulebook.util as util
+from ansible_rulebook.messages import DEFAULT_SHUTDOWN_DELAY
 
 # ensure a valid JVM is available and configures JAVA_HOME if necessary
 # must be done before importing any other modules
@@ -122,6 +123,14 @@ def get_parser() -> argparse.ArgumentParser:
         "--print-events",
         action="store_true",
         help="Print events to stdout, redundant and disabled with -vv",
+    )
+    parser.add_argument(
+        "--shutdown-delay",
+        default=os.environ.get("EDA_SHUTDOWN_DELAY", DEFAULT_SHUTDOWN_DELAY),
+        type=float,
+        help="Maximum number of seconds to wait after issuing a "
+        " graceful shutdown, default: 60. The process will shutdown if "
+        " all actions complete before this time period",
     )
     return parser
 

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -12,10 +12,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from .messages import Shutdown
+
 
 class ShutdownException(Exception):
+    def __init__(self, shutdown: Shutdown):
+        self.shutdown = shutdown
 
-    pass
+    def __str__(self):
+        return str(self.shutdown)
 
 
 class RulenameEmptyException(Exception):

--- a/ansible_rulebook/messages.py
+++ b/ansible_rulebook/messages.py
@@ -12,10 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import NamedTuple
+from dataclasses import dataclass
+
+DEFAULT_SHUTDOWN_DELAY = 60.0
 
 
-class Shutdown(NamedTuple):
+@dataclass(frozen=True)
+class Shutdown:
     message: str = "Not specified"
-    delay: float = 0.0
+    delay: float = DEFAULT_SHUTDOWN_DELAY
+    kind: str = "graceful"
     source_plugin: str = ""

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -389,7 +389,11 @@
                     "type": ["object","null"],
                     "properties": {
                         "delay": {"type": "number" },
-                        "message": {"type": "string" }
+                        "message": {"type": "string" },
+                        "kind" : {
+                           "type": "string",
+                           "enum": ["graceful", "now"]
+                        }
                     },
                     "additionalProperties": false
                 }

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -325,16 +325,20 @@ shutdown
      - Description
      - Required
    * - delay
-     - A numeric value about how long to wait before shutting down, default 0.0
+     - A numeric value about how long to wait in seconds before shutting down, default 60.0
      - No
    * - message
      - A message to be associated with this shutdown 
+     - No
+   * - kind
+     - Kind of shutdown can be either **graceful** or **now**. default is graceful.
      - No
 
 | Generate a shutdown event which will terminate the ansible-rulebook process.
 | If there are multiple rule-sets running in your rule book, issuing a shutdown will cause
 | all other rule-sets to end, care needs to be taken to account for running playbooks which
-| can be impacted when one of the rule set decides to shutdown.
+| can be impacted when one of the rule set decides to shutdown. A shutdown message is
+| broadcast to all running rule-sets.
 
 Example:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -35,6 +35,7 @@ The `ansible-rulebook` CLI supports the following options:
     --controller-ssl-verify CONTROLLER_SSL_VERIFY
                             How to verify SSL when connecting to the controller, yes|no|<path to a CA bundle>, default to yes for https connection
     --print-events        Print events to stdout, redundant and disabled with -vv
+    --shutdown-delay      Maximum number of seconds to wait after a graceful shutdown is issued, default is 60. Can also be set via an env var called EDA_SHUTDOWN_DELAY. The process will shutdown if all actions complete before this time period
 
 
 To get help from `ansible-rulebook` run the following:

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -104,7 +104,7 @@ def test_run_playbook(update_environment):
     """
 
     rulebook = utils.BASE_DATA_PATH / "rulebooks/actions/test_run_playbook.yml"
-    env = update_environment({"SOURCE_SHUTDOWN_AFTER": "6"})
+    env = update_environment({"SOURCE_SHUTDOWN_AFTER": "10"})
 
     cmd = utils.Command(rulebook=rulebook, envvars="SOURCE_SHUTDOWN_AFTER")
 

--- a/tests/examples/36_multiple_rulesets_both_fired.yml
+++ b/tests/examples/36_multiple_rulesets_both_fired.yml
@@ -2,8 +2,12 @@
 - name: 36 multiple rulesets 1
   hosts: all
   sources:
-    - range:
-        limit: 5
+    - generic:
+        loop_count: 5
+        startup_delay: 1
+        create_index: i
+        payload:
+          - x: 1
   rules:
     - name: r1
       condition: event.i == 1
@@ -19,8 +23,12 @@
 - name: 36 multiple rulesets 2
   hosts: all
   sources:
-    - range:
-        limit: 5
+    - generic:
+        loop_count: 5
+        shutdown_after: 10
+        payload:
+          - y: 1
+          - y: 2
   rules:
     - name: r1
       condition: event.fire_rule == True

--- a/tests/examples/38_shutdown.yml
+++ b/tests/examples/38_shutdown.yml
@@ -4,7 +4,8 @@
   gather_facts: false
   sources:
     - range:
-        limit: 5
+        limit: 2
+        delay: 3
   rules:
     - name: "Host 1 rule"
       condition: event.i == 1

--- a/tests/examples/66_sleepy_playbook.yml
+++ b/tests/examples/66_sleepy_playbook.yml
@@ -1,0 +1,42 @@
+---
+- name: 66 sleepy playbook
+  hosts: all
+  sources:
+    - generic:
+        create_index: i
+        loop_count: 5
+        shutdown_after: 45
+        payload:
+          - name: fred
+  rules:
+    - name: r1
+      condition: event.i == 0
+      action:
+        print_event:
+    - name: r2
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: playbooks/sleeper.yml
+- name: terminate gracefully
+  hosts: all
+  sources:
+    - generic:
+        create_index: j
+        loop_count: 5
+        shutdown_after: 45
+        payload:
+          - name: barney
+  rules:
+    - name: r11
+      condition: event.j == 0
+      action:
+        echo:
+          message: Next issuing shutdown 
+    - name: r12
+      condition: event.j == 1
+      action:
+        shutdown:
+          message: Issuing graceful shutdown after 5 seconds
+          delay: 5.0
+          kind: graceful

--- a/tests/examples/67_shutdown_now.yml
+++ b/tests/examples/67_shutdown_now.yml
@@ -1,0 +1,41 @@
+---
+- name: 67 shutdown now
+  hosts: all
+  sources:
+    - generic:
+        create_index: i
+        loop_count: 5
+        shutdown_after: 45
+        payload:
+          - name: fred
+  rules:
+    - name: r1
+      condition: event.i == 0
+      action:
+        print_event:
+    - name: r2
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: playbooks/sleeper.yml
+- name: terminate now
+  hosts: all
+  sources:
+    - generic:
+        create_index: j
+        loop_count: 5
+        shutdown_after: 45
+        payload:
+          - name: barney
+  rules:
+    - name: r11
+      condition: event.j == 0
+      action:
+        echo:
+          message: Next issuing ungraceful shutdown 
+    - name: r12
+      condition: event.j == 1
+      action:
+        shutdown:
+          message: Issuing shutdown now
+          kind: now

--- a/tests/playbooks/sleeper.yml
+++ b/tests/playbooks/sleeper.yml
@@ -1,0 +1,13 @@
+---
+- name: Sleeps for 5 minutes
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Sleepy
+      ansible.builtin.debug:
+        msg: 'Hello from Sleepy, will sleep for next 5 minutes'
+
+    - name: snore
+      ansible.builtin.pause:
+        minutes: 5
+...

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -65,9 +65,15 @@ def validate_events(event_log, **kwargs):
     ansible_events = 0
     action_events = 0
     actions = []
+    max_events = 0
 
-    for _ in range(kwargs["max_events"]):
+    while True:
+        if event_log.empty() and kwargs.get("drain_event_log", False):
+            break
+        if "max_events" in kwargs and kwargs["max_events"] == max_events:
+            break
         event = event_log.get_nowait()
+        max_events += 1
         print(event)
         if event["type"] == "Action":
             action_events += 1


### PR DESCRIPTION
Gracefully handle shutdowns by allowing queued actions to complete. We found issues on ppc64le env where the processes were running slower and leading to actions not getting completed before the Shutdown was getting issued.

There are 2 kinds of Shutdowns

- graceful
- now

A shutdown of kind=graceful, which is the default allows for actions to complete and then ends the processes.
A shutdown of kind=now, doesn't wait for actions to complete and it ends all tasks

We run ansible playbooks using the ansible_runner which has a cancel_callback to cancel a running playbook, when we get a  shutdown, we cancel running playbooks.

https://issues.redhat.com/browse/AAP-9235

  
 --shutdown-delay command line can be used to specify the maximum time in seconds
      to wait after a shutdown is issued. The process shuts down if all actions are completed before this time. 
      Equivalent env var is EDA_SHUTDOWN_DELAY