### PR TITLE
[AAP-9251] Fixed exclusion of disabled rules

### DIFF
--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -128,15 +128,15 @@ def parse_rules(rules: Dict) -> List[rt.Rule]:
         else:
             throttle = None
 
-        rule_list.append(
-            rt.Rule(
-                name=name,
-                condition=parse_condition(rule["condition"]),
-                actions=parse_actions(rule),
-                enabled=rule.get("enabled", True),
-                throttle=throttle,
-            )
+        rule = rt.Rule(
+            name=name,
+            condition=parse_condition(rule["condition"]),
+            actions=parse_actions(rule),
+            enabled=rule.get("enabled", True),
+            throttle=throttle,
         )
+        if rule.enabled:
+            rule_list.append(rule)
 
     return rule_list
 

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -86,6 +86,7 @@
                     "minLength": 1,
                     "pattern": "\\S"
                 },
+                "enabled": { "type": "boolean" },
                 "throttle": {"$ref": "#/$defs/throttle"},
                 "condition": {
                     "anyOf": [

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -29,6 +29,9 @@ A rule comprises:
    * - action
      - See :doc:`actions`
      - or actions
+   * - enabled
+     - If the rule should be enabled, default is true. Can be set to false to disable a rule.
+     - No
 
 
 
@@ -63,3 +66,23 @@ Example: Multiple actions
 
 | In the above example the 2 actions are executed in order. First
 | we call run_playbook and then when it ends we call print_event
+
+Example: Disable a rule
+
+    .. code-block:: yaml
+
+        rules:
+          - name: An automatic remediation rule
+            condition: event.outage == true
+            enabled: false
+            action:
+              run_playbook:
+                name: remediate_outage.yml
+
+          - name: Print event with linux
+            condition: event.target_os == "linux" or
+            action:
+              debug:
+
+| In the above example the first rule is disabled by setting enabled to false
+| This can be used when testing to temporarily disable a rule.

--- a/tests/examples/68_disabled_rule.yml
+++ b/tests/examples/68_disabled_rule.yml
@@ -1,0 +1,19 @@
+---
+- name: 68 disabled rule
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 1
+      action:
+        echo:
+          message: Should get fired
+    - name: r2
+      enabled: false
+      condition: event.i == 2
+      action:
+        echo:
+          message: Should not get fired

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1689,3 +1689,27 @@ async def test_65_selectattr_3():
             ],
         }
         validate_events(event_log, **checks)
+
+
+@pytest.mark.asyncio
+async def test_68_disabled_rule():
+    ruleset_queues, event_log = load_rulebook("examples/68_disabled_rule.yml")
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    with SourceTask(rs.sources[0], "sources", {}, queue):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            dict(),
+            load_inventory("playbooks/inventory.yml"),
+        )
+
+        checks = {
+            "max_events": 2,
+            "shutdown_events": 1,
+            "actions": [
+                "68 disabled rule::r1::echo",
+            ],
+        }
+        validate_events(event_log, **checks)


### PR DESCRIPTION
A rule can optionally be disabled by setting enabled=false. This is handy when testing and certain rules need to be disabled temporarily. Fixed the json schema, added an example.

https://issues.redhat.com/browse/AAP-9251