### PR TITLE
Fix msg warning about pytest-vcr

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ markers =
     e2e: mark for end to end tests
     temporal: mark for time based tests
     long_run: mark for long running tests
+    vcr: required by tests that use pytest-vcr


### PR DESCRIPTION
Every mark should be registered in the pytest conf:

```
tests/test_controller.py:32
  /home/alex/repos/redhat/ansible/eda/ansible-rulebook/tests/test_controller.py:32: PytestUnknownMarkWarning: Unknown pytest.mark.vcr - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.vcr()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

```