### PR TITLE
Fix broken test, was missing localhost in events

### DIFF
--- a/tests/playbooks/inventory.yml
+++ b/tests/playbooks/inventory.yml
@@ -3,3 +3,4 @@ all:
   hosts:
     localhost:
       ansible_connection: local
+      ansible_python_interpreter: "{{ansible_playbook_python}}"


### PR DESCRIPTION
The ansible-playbook was skipping the playbook since none of the hosts matched with this warning.
```
PLAY [Print Hello World and set as fact] ***************************************
skipping: no hosts matched
```
Fixed the event payload to include meta hosts.