### PR TITLE
Adding e2e tests for string search operators

### DIFF
--- a/tests/e2e/files/rulebooks/operators/test_string_search_match.yml
+++ b/tests/e2e/files/rulebooks/operators/test_string_search_match.yml
@@ -1,0 +1,62 @@
+---
+- name: Test the string search operator match
+  hosts: all
+  sources:
+    - generic:
+        payload:
+          - line1: I'm not the pheasant plucker
+          - line1: I'm the pheasant plucker's son
+          - line1: "I'm only plucking pheasants"
+            line2: "'til the pheasant plucker comes"
+          - line1: |
+              She sells 50 seashells
+              by the seashore
+          - line1: |
+              Peter Piper picked @ peck
+              of pickled peppers
+          - line1: |
+              How can a clam cram
+              in a clean cream can
+
+  rules:
+    - name: Single condition match, case sensitive
+      condition: event.line1 is match("I'm not", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #1"
+
+    - name: Single condition match, case insensitive
+      condition: event.line1 is match("I'm THE pheasant", ignorecase=true)
+      action:
+        echo:
+          message: "Output for testcase #2"
+
+    - name: Multi condition match case sensitive & insensitive with negation
+      condition: >
+        event.line1 is match("I'm only plucKING", ignorecase=true) and
+        event.line2 is not match("'til THE", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #3"
+
+    - name: Single condition multiline match, case sensitive
+      condition: event.line1 is match("She sells", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #4"
+
+    - name: Multi condition multiline match, case insensitive
+      condition: >
+        event.line1 is match("PeTEr PiPER", ignorecase=true) or
+        event.line1 is match("of piCKLED", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #5"
+
+    - name: Multi condition multiline match, case sensitive & insensitive with negation
+      condition: >
+        event.line1 is not match("In A clEAN", ignorecase=false) and
+        event.line1 is match("HoW CAN a clAm Cram", ignorecase=true)
+      action:
+        echo:
+          message: "Output for testcase #6"

--- a/tests/e2e/files/rulebooks/operators/test_string_search_regex.yml
+++ b/tests/e2e/files/rulebooks/operators/test_string_search_regex.yml
@@ -1,0 +1,62 @@
+---
+- name: Test the string search operator regex
+  hosts: all
+  sources:
+    - generic:
+        payload:
+          - line1: I'm not the pheasant plucker
+          - line1: I'm the pheasant plucker's son
+          - line1: "I'm only plucking pheasants"
+            line2: "'til the pheasant plucker comes"
+          - line1: |
+              She sells 50 seashells
+              by the seashore
+          - line1: |
+              Peter Piper picked @ peck
+              of pickled peppers
+          - line1: |
+              How can a clam cram
+              in a clean cream can
+
+  rules:
+    - name: Single condition regex, case sensitive
+      condition: event.line1 is regex("^I'm.{9}pheas", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #1"
+
+    - name: Single condition regex, case insensitive
+      condition: event.line1 is regex("plUCk.(r's).son$", ignorecase=true)
+      action:
+        echo:
+          message: "Output for testcase #2"
+
+    - name: Multi condition regex case sensitive & insensitive with negation
+      condition: >
+        event.line1 is regex(".*KING.pheaSAnts$", ignorecase=true) and
+        event.line2 is not regex("^.til.{10}ant$", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #3"
+
+    - name: Single condition multiline regex, case sensitive
+      condition: event.line1 is regex("[e-s].*[5:0]", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #4"
+
+    - name: Multi condition multiline regex, case insensitive
+      condition: >
+        event.line1 is regex("^PeTER.{7}.[i-p].{5}@", ignorecase=true) or
+        event.line1 is regex(".ickled$", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #5"
+
+    - name: Multi condition multiline regex, case sensitive & insensitive with negation
+      condition: >
+        event.line1 is not regex("^Cram..an", ignorecase=false) and
+        event.line1 is regex("(?s)a.cla[m].*cream", ignorecase=true)
+      action:
+        echo:
+          message: "Output for testcase #6"

--- a/tests/e2e/files/rulebooks/operators/test_string_search_search.yml
+++ b/tests/e2e/files/rulebooks/operators/test_string_search_search.yml
@@ -1,0 +1,62 @@
+---
+- name: Test the string search operator search
+  hosts: all
+  sources:
+    - generic:
+        payload:
+          - line1: I'm not the pheasant plucker
+          - line1: I'm the pheasant plucker's son
+          - line1: "I'm only plucking pheasants"
+            line2: "'til the pheasant plucker comes"
+          - line1: |
+              She sells 50 seashells
+              by the seashore
+          - line1: |
+              Peter Piper picked @ peck
+              of pickled peppers
+          - line1: |
+              How can a clam cram
+              in a clean cream can
+
+  rules:
+    - name: Single condition search, case sensitive
+      condition: event.line1 is search("not the pheasant", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #1"
+
+    - name: Single condition search, case insensitive
+      condition: event.line1 is search("PluCKer'S soN", ignorecase=true)
+      action:
+        echo:
+          message: "Output for testcase #2"
+
+    - name: Multi condition search case sensitive & insensitive with negation
+      condition: >
+        event.line1 is search("PlUckinG pheaSANTs", ignorecase=true) and
+        event.line2 is not search("the plucker is not coming", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #3"
+
+    - name: Single condition multiline search, case sensitive
+      condition: event.line1 is search("50 seashells", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #4"
+
+    - name: Multi condition multiline search, case insensitive
+      condition: >
+        event.line1 is search("piCKed @ peck", ignorecase=true) or
+        event.line1 is search("pepper piCkles", ignorecase=false)
+      action:
+        echo:
+          message: "Output for testcase #5"
+
+    - name: Multi condition multiline search, case sensitive & insensitive with negation
+      condition: >
+        event.line1 is not search("can A clAM", ignorecase=false) and
+        event.line1 is search("CleaN cReam", ignorecase=true)
+      action:
+        echo:
+          message: "Output for testcase #6"

--- a/tests/e2e/test_operators.py
+++ b/tests/e2e/test_operators.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 
 import pytest
+from pytest_check import check
 
 from . import utils
 
@@ -399,3 +400,58 @@ def test_not_operator():
     ]
 
     assert len(printed_events) == 2
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "rulebook",
+    [
+        pytest.param(
+            "test_string_search_match.yml",
+            id="string_search_match",
+        ),
+        pytest.param(
+            "test_string_search_search.yml",
+            id="string_search_search",
+        ),
+        pytest.param(
+            "test_string_search_regex.yml",
+            id="string_search_regex",
+        ),
+    ],
+)
+def test_string_search(rulebook):
+    """
+    Execute a rulebook that performs search, match and regex operations
+    on a string.
+    """
+
+    rulebook = utils.BASE_DATA_PATH / f"rulebooks/operators/{rulebook}"
+    cmd = utils.Command(rulebook=rulebook)
+
+    LOGGER.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd,
+        timeout=DEFAULT_TIMEOUT,
+        capture_output=True,
+        cwd=utils.BASE_DATA_PATH,
+        text=True,
+    )
+
+    with check:
+        assert "Output for testcase #1" in result.stdout, "testcase #1 failed"
+
+    with check:
+        assert "Output for testcase #2" in result.stdout, "testcase #2 failed"
+
+    with check:
+        assert "Output for testcase #3" in result.stdout, "testcase #3 failed"
+
+    with check:
+        assert "Output for testcase #4" in result.stdout, "testcase #4 failed"
+
+    with check:
+        assert "Output for testcase #5" in result.stdout, "testcase #5 failed"
+
+    with check:
+        assert "Output for testcase #6" in result.stdout, "testcase #6 failed"


### PR DESCRIPTION
String search operators include search, match and regex (with negation).

Closes [AAP-8745](https://issues.redhat.com/browse/AAP-8745).