### PR TITLE
Add log_format and log_date_format in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,8 @@
 asyncio_mode = strict
 log_file_level = INFO
 log_cli = true
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
 markers =
     e2e: mark for end to end tests
     temporal: mark for time based tests


### PR DESCRIPTION
When the timed use cases fail, the time in the log messages will help in debugging.