### PR TITLE
Allow for empty payloads in generic source for testing purposes

### DIFF
--- a/tests/sources/generic.py
+++ b/tests/sources/generic.py
@@ -81,6 +81,8 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
         if randomize:
             random.shuffle(payload)
         for event in payload:
+            if not event:
+                continue
             for _ in range(repeat_count):
                 data = {}
                 if create_index:


### PR DESCRIPTION
If the payload is empty then skip over it, in some special cases the ruleset might not need any direct events but would be using set_facts to generate the data.
This came about in PR https://github.com/ansible/ansible-rulebook/pull/349 Where there is no payload. 
https://github.com/ansible/ansible-rulebook/blob/3f9793c702401590807b027133c4ca70ec672884/tests/e2e/files/rulebooks/actions/test_run_playbook.yml#L48
This leads to an error in the source
```
2023-02-14 16:38:53,582 - ansible_rulebook.engine - ERROR - Source error
Traceback (most recent call last):
  File "/Users/madhukanoor/devsrc/ansible-rulebook/ansible_rulebook/engine.py", line 154, in start_source
    await entrypoint(fqueue, args)
  File "/Users/madhukanoor/devsrc/ansible-rulebook/tests/e2e/../sources/generic.py", line 97, in main
    data.update(event)
```