### PR TITLE
Only add namespace ansible_eda to extra_vars sent to playbooks

### DIFF
--- a/docs/events_and_facts.rst
+++ b/docs/events_and_facts.rst
@@ -44,3 +44,7 @@ Instead, the ``all`` operator must be used:
 
 
 You can combine `set_fact <actions.html#set-fact>`_ and `retract_fact <actions.html#retract-fact>`_ actions to manage the global state during the lifecycle of your rulebook.
+
+The text above describes how to use ``events`` or ``facts`` in a rulebook. A single matched ``event`` or multiple matched ``events`` are also
+sent to a playbook through extra_vars under namespace ``ansible_eda`` when a run_playbook or run_job_template action is executed. So in a playbook
+you should reference them as ``ansible_eda.event`` or ``ansible_eda.events``.

--- a/tests/e2e/files/rulebooks/actions/test_actions_sanity.yml
+++ b/tests/e2e/files/rulebooks/actions/test_actions_sanity.yml
@@ -35,7 +35,7 @@
         run_module:
           name: ansible.builtin.debug
           module_args:
-            msg: "Event matched: {{ ansible_eda.event }}"
+            msg: "Event matched: {{ event }}"
 
     - name: print_event
       condition: event.action == "print_event"
@@ -60,7 +60,7 @@
         run_module:
           name: ansible.builtin.debug
           module_args:
-            msg: "Event matched in same ruleset: {{ ansible_eda.event.post_event_state }}"
+            msg: "Event matched in same ruleset: {{ event.post_event_state }}"
 
     - name: post_event different ruleset
       condition: event.action == "post_event" and event.rulebook_scope == "different_ruleset"
@@ -83,7 +83,7 @@
         run_module:
           name: ansible.builtin.debug
           module_args:
-            msg: "Fact matched in same ruleset: {{ ansible_eda.event.my_fact }}"
+            msg: "Fact matched in same ruleset: {{ event.my_fact }}"
 
     - name: set_fact different ruleset
       condition: event.action == "set_fact" and event.rulebook_scope == "different_ruleset"
@@ -130,7 +130,7 @@
         run_module:
           name: ansible.builtin.debug
           module_args:
-            msg: "Event matched in different ruleset: {{ ansible_eda.event.post_event_state }}"
+            msg: "Event matched in different ruleset: {{ event.post_event_state }}"
 
     - name: print set_fact different ruleset
       condition: event.my_fact == "sent"
@@ -138,4 +138,4 @@
         run_module:
           name: ansible.builtin.debug
           module_args:
-            msg: "Fact matched in different ruleset: {{ ansible_eda.event.my_fact }}"
+            msg: "Fact matched in different ruleset: {{ event.my_fact }}"

--- a/tests/e2e/files/rulebooks/actions/test_run_playbook.yml
+++ b/tests/e2e/files/rulebooks/actions/test_run_playbook.yml
@@ -18,7 +18,7 @@
           name: ./playbooks/run_playbook_test_playbook.yml
           post_events: true
           extra_vars:
-            target_host: "{{ ansible_eda.event.meta.hostname }}"
+            target_host: "{{ event.meta.hostname }}"
             remediation_required: true
           retry: true
           retries: 1
@@ -35,8 +35,7 @@
           var_root:
             results.remediation: results
           extra_vars:
-            # use var_root when bug resolved: https://issues.redhat.com/browse/AAP-8967
-            processed_host: "{{ ansible_eda.event.results.remediation.remediated_host }}"
+            processed_host: "{{ event.remediated_host }}"
             remediation_required: false
           json_mode: true
           verbosity: 4
@@ -53,4 +52,4 @@
             event.post_processing_host == "simba"
       action:
         echo:
-          message: "Post-processing complete on {{ ansible_eda.event.post_processing_host }}"
+          message: "Post-processing complete on {{ event.post_processing_host }}"

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -64,8 +64,7 @@ def test_actions_sanity():
  'ruleset': 'Test actions sanity',
  'source_rule_name': 'debug',
  'source_ruleset_name': 'Test actions sanity',
- 'variables': {'ansible_eda': {'event': {'action': 'debug'},
-                               'fact': {'action': 'debug'}}}}"""  # noqa: E501
+ 'variables': {'event': {'action': 'debug'}, 'fact': {'action': 'debug'}}}"""  # noqa: E501
 
     assert event_debug_expected_output in result.stdout, "debug action failed"
 
@@ -93,7 +92,7 @@ def test_actions_sanity():
     assert "Echo action executed" in result.stdout
 
     assert (
-        len(result.stdout.splitlines()) == 44
+        len(result.stdout.splitlines()) == 43
     ), "unexpected output from the rulebook"
 
 


### PR DESCRIPTION
Namespace ansible_eda in rulebook is implied. It should never be explictly referenced.

Also process var_root before Jinja substitution.

Resolves AAP-8967