### PR TITLE
[AAP-9299] Fixes stack trace when a playbook is not found

### DIFF
--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -76,3 +76,13 @@ class ConditionParsingException(Exception):
 class InvalidTypeException(Exception):
 
     pass
+
+
+class PlaybookStatusNotFoundException(Exception):
+
+    pass
+
+
+class PlaybookNotFoundException(Exception):
+
+    pass


### PR DESCRIPTION
When a playbook cannot be found, we throw an index error
```
Traceback (most recent call last):
  File "/Users/madhukanoor/devsrc/ansible-rulebook/ansible_rulebook/engine.py", line 522, in execute
    await action_method(**action_args)
  File "/Users/madhukanoor/devsrc/ansible-rulebook/ansible_rulebook/builtin.py", line 328, in run_playbook
    await post_process_runner(
  File "/Users/madhukanoor/devsrc/ansible-rulebook/ansible_rulebook/builtin.py", line 635, in post_process_runner
    fact_folder = _get_latest_artifact(
  File "/Users/madhukanoor/devsrc/ansible-rulebook/ansible_rulebook/builtin.py", line 845, in _get_latest_artifact
    return files[0]
IndexError: list index out of range
```
Throw an exception if the runner results file can't be found. Also prevent looking for the facts file when the runner has failed to execute the playbook.

https://issues.redhat.com/browse/AAP-9299

- Add a log info message to always report the **rc** and **status**
- If rc is not 0, read the stderr or stdout in the private_data_dir and report it as an error
- If the playbook has syntax error it would be visible in the error log. Previously this was getting suppressed
- if the rc is not 0 then we should not post_event to set_fact