### PR TITLE
Fix intermittently failing run_playbook test

### DIFF
--- a/tests/e2e/config/default.yml
+++ b/tests/e2e/config/default.yml
@@ -1,5 +1,6 @@
 event_delay: 1
 operators_shutdown_after: 1
+run_playbook_shutdown_after: 5
 cmd_timeout: 15
 controller_url: http://localhost:8080
 controller_token: secret

--- a/tests/e2e/files/rulebooks/actions/test_run_playbook.yml
+++ b/tests/e2e/files/rulebooks/actions/test_run_playbook.yml
@@ -3,14 +3,30 @@
   hosts: all
   sources:
     - generic:
-        shutdown_after: "{{ SOURCE_SHUTDOWN_AFTER }}"
+        shutdown_after: "{{ DEFAULT_SHUTDOWN_AFTER }}"
         payload:
+          - alert:
+              message: "upgrade complete"
+            meta:
+              hostname: "nala"
           - alert:
               message: "upgrade failure"
             meta: 
               hostname: "simba"
 
   rules:
+    - name: Run post_processing playbook and set_facts to Ruleset 2
+      condition: event.alert.message == "upgrade complete"
+      action:
+        run_playbook:
+          name: ./playbooks/run_playbook_test_playbook.yml
+          set_facts: true
+          ruleset: "Ruleset 2"
+          extra_vars:
+            processed_host: "{{ event.meta.hostname }}"
+            remediation_required: false
+          json_mode: true
+
     - name: Run post_processing playbook and post_events to same ruleset
       condition: event.alert.message == "upgrade failure"
       action:
@@ -25,13 +41,12 @@
           delay: 1
           json_mode: true
 
-    - name: Verify the remediation and set_facts to Ruleset 2
+    - name: Verify the remediation and set_facts to same ruleset
       condition: event.results.remediation.remediation_result == "Success"
       action:
         run_playbook:
           name: ./playbooks/run_playbook_test_playbook.yml
           set_facts: true
-          ruleset: "Ruleset 2"
           var_root:
             results.remediation: results
           extra_vars:
@@ -40,16 +55,24 @@
           json_mode: true
           verbosity: 4
 
+    - name: Validate set_facts from same ruleset
+      condition: >
+        event.post_processing_state == "Complete" and
+        event.post_processing_host == "simba"
+      action:
+        debug:
+          msg: "Post-processing complete on {{ event.post_processing_host }}"
+
 - name: Ruleset 2
   hosts: all
   sources:
     - generic:
         startup_delay: 30  # never start, only triggered by Ruleset 1
   rules:
-    - name: Validate the set_facts operation
+    - name: Validate the set_facts from ruleset 1
       condition: >
-            event.post_processing_state == "Complete" and
-            event.post_processing_host == "simba"
+        event.post_processing_state == "Complete" and
+        event.post_processing_host == "nala"
       action:
         debug:
           msg: "Post-processing complete on {{ event.post_processing_host }}"


### PR DESCRIPTION
Depends on #358.

With the introduction of ordered shutdown in PR 358, an intermittent race condition arose with the run_playbook test due to Ruleset 2 bailing before it received the set_fact from ruleset 1. PR 358 adds ordered shutdown, but if there are no pending items in the action queue then the ruleset will end immediately. In this test, once the time specified under `shutdown_after` in ruleset 1 has expired then a shutdown command will be issued to all rulesets, and since ruleset 2 does not have any pending items it will end immediately, sometimes before the `set_fact` from ruleset 1 has had a chance to run. Increasing `shutdown_after` is an option, but this increases the test time unnecessarily. 

This change moves the condition that performs the set_fact so that it occurs at the beginning of the run, so we can be sure that ruleset 2 will not end before the set_fact and therefore avoid the race condition. We may run into a race condition with other arch's, such as ppc, in which case we would need to increase `SOURCE_SHUTDOWN_AFTER` for that particular arch.