### PR TITLE
[AAP-9301] Added msg/var support in debug action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Support multiple actions for a rule
 - Support for search/match/regex 
 - Support for graceful shutdown, timeout to allow actions to complete
+- Removed the echo command in favor of debug with msg
 
 ### Fixed
 

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -109,8 +109,7 @@
                                 {"$ref": "#/$defs/print-event-action"},
                                 {"$ref": "#/$defs/debug-action"},
                                 {"$ref": "#/$defs/none-action"},
-                                {"$ref": "#/$defs/shutdown-action"},
-                                {"$ref": "#/$defs/echo-action"}
+                                {"$ref": "#/$defs/shutdown-action"}
                          ]
                      }
                 },
@@ -125,8 +124,7 @@
                         {"$ref": "#/$defs/print-event-action"},
                         {"$ref": "#/$defs/debug-action"},
                         {"$ref": "#/$defs/none-action"},
-                        {"$ref": "#/$defs/shutdown-action"},
-                        {"$ref": "#/$defs/echo-action"}
+                        {"$ref": "#/$defs/shutdown-action"}
                     ]
                 }
             },
@@ -340,36 +338,46 @@
             ],
             "additionalProperties": false
         },
+	"debug-msg": {
+		"type": "object",
+                "properties": {
+			    "msg": {
+				    "anyOf": [
+					    {"type": "string"},
+					    {"type": "array",
+					     "items": {"type": "string"}
+					    }
+				    ]
+			    }
+		},
+                "additionalProperties": false
+
+	},
+	"debug-var": {
+		"type": "object",
+                "properties": {
+			    "var": { "type": "string" }
+		},
+                "additionalProperties": false
+	},
+
         "debug-action": {
             "type": "object",
             "properties": {
                 "debug": {
-                    "type": ["object","null"]
-                }
+                    "anyOf": [
+                        {"$ref": "#/$defs/debug-msg"},
+                        {"$ref": "#/$defs/debug-var"},
+			{"type": "null" }
+                    ]
+		}
             },
+            "additionalProperties": false,
             "required": [
                 "debug"
             ]
         },
-        "echo-action": {
-            "type": "object",
-            "properties": {
-                "echo": {
-                    "type": ["object"],
-                    "properties": {
-                        "message": {"type": "string" }
-                    }, 
-                    "additionalProperties": false
-                },
-		"required": [
-			"message"
-		]
-            },
-            "required": [
-                "echo"
-            ],
-            "additionalProperties": false
-        },
+
         "none-action": {
             "type": "object",
             "properties": {

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -15,7 +15,6 @@ The following actions are supported:
 - `shutdown`_
 - `debug`_
 - `none`_
-- `echo`_
 
 run_playbook
 ************
@@ -364,31 +363,57 @@ When a rule's condition(s) are satisfied we get the results back as:
 
 debug
 *****
-  Write the event to stdout
-  It accepts an arbitrary dict that it's injected into the event to be printed
-
-none
-****
-  No action, useful when writing tests
-  No arguments needed
-
-echo
-****
-.. list-table:: Write a user specified message to stdout
+.. list-table:: debug ansible-rulebook
    :widths: 25 150 10
    :header-rows: 1
 
    * - Name
      - Description
      - Required
-   * - message
-     - A terse message to display to stdout
-     - Yes
+   * - msg
+     - A simple string or an array of strings, which can have references to event or events
+     - No
+   * - var
+     - The variable to print, which can have references to event or events. Using {{ }} is optional.
+     - No
+
+| The debug action tries to mimic the debug command in ansible.
+| If no arguments are provided it prints the matching events along with other important properties
+| **msg** and **var** are mutually exclusive, you can have only 1 of them in the debug
+| msg can be a single string or an array of strings, with references to event or events.
+| With var using the Jinja style braces is optional like shown in the example below
 
 Example:
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-    action:
-      echo:
-        message: Hello World
+       name: debug with single message
+       condition: event.i >= 5
+       action:
+          debug:
+            msg: Simple debug message
+
+
+    .. code-block:: yaml
+
+       name: debug with multiple messages
+       condition: event.i >= 5
+       action:
+          debug:
+            msg: 
+               - "Message 1 {{ event }}"
+               - Second Message
+
+    .. code-block:: yaml
+
+       name: debug with var
+       condition: event.i >= 5
+       action:
+          debug:
+            var: event.i
+
+
+none
+****
+  No action, useful when writing tests
+  No arguments needed

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -616,8 +616,8 @@ Check if an item exists in a list based on a test
         name: check if an item exist in list
         condition: event.levels is select('>=', 10)
         action:
-          echo:
-            message: The list has an item with the value greater than or equal to 10
+          debug:
+            msg: The list has an item with the value greater than or equal to 10
 
 | In the above example "levels" is a list of integers e.g. [1,2,3,20], the test says
 | check if any item exists in the list with a value >= 10. This test passes because
@@ -632,8 +632,8 @@ Check if an item does not exist in a list based on a test
         name: check if an item does not exist in list
         condition: event.levels is not select('>=', 10)
         action:
-          echo:
-            message: The list does not have item with the value greater than or equal to 10
+          debug:
+            msg: The list does not have item with the value greater than or equal to 10
 
 | In the above example "levels" is a list of integers e.g. [1,2,3], the test says
 | check if *no* item exists with a value >= 10. This test passes because none of the items
@@ -654,8 +654,8 @@ Checking if an object exists in a list based on a test
         name: check if an object exist in list
         condition: event.objects is selectattr('age', '>=', 20)
         action:
-          echo:
-            message: An object with age greater than 20 found
+          debug:
+            msg: An object with age greater than 20 found
 
 | In the above example "objects" is a list of object's, with multiple properties. One of the
 | properties is age, the test says check if any object exists in the list with an age >= 20.
@@ -668,8 +668,8 @@ Checking if an object does not exist in a list based on a test
         name: check if an object does not exist in list
         condition: event.objects is not selectattr('age', '>=', 20)
         action:
-          echo:
-            message: No object with age greater than 20 found
+          debug:
+            msg: No object with age greater than 20 found
 
 | In the above example "objects" is a list of object's, with multiple properties. One of the
 | properties is age, the test says check if *no* object exists in the list with an age >= 20.

--- a/docs/variables.rst
+++ b/docs/variables.rst
@@ -46,8 +46,8 @@ Let's take the following example rulebook:
             - name: Say Hello
               condition: event.i == vars.match_this_int
               action:
-                echo:
-                  message: "Hi, I'm {{ MY_NAME }}."
+                debug:
+                  msg: "Hi, I'm {{ MY_NAME }}."
 
 In this rulebook we use three different variables. One, **MY_NAME**, we will supply using an environment variable.
 The other two will be supplied in a file called `vars.yml` which looks like this:

--- a/tests/asts/rules_with_assignment.yml
+++ b/tests/asts/rules_with_assignment.yml
@@ -8,7 +8,7 @@
         - Action:
             action: debug
             action_args:
-              events_event: '{{events.first}}'
+              var: events.first
         condition:
           AllCondition:
           - AssignmentExpression:

--- a/tests/asts/rules_with_assignment2.yml
+++ b/tests/asts/rules_with_assignment2.yml
@@ -8,7 +8,7 @@
         - Action:
             action: debug
             action_args:
-              events_event: '{{events.first}}'
+              var: events.first
         condition:
           AllCondition:
           - AssignmentExpression:

--- a/tests/e2e/files/rulebooks/actions/test_actions_sanity.yml
+++ b/tests/e2e/files/rulebooks/actions/test_actions_sanity.yml
@@ -21,7 +21,6 @@
             rulebook_scope: same_ruleset
           - action: "check_retract_fact"
             rulebook_scope: same_ruleset
-          - action: "echo"
   rules:
     - name: run_playbook
       condition: event.action == "run_playbook"
@@ -111,11 +110,6 @@
           module_args:
             msg: "Retracted fact in same ruleset, this should not be printed"
 
-    - name: echo
-      condition: event.action == "echo"
-      action:
-        echo:
-          message: "Echo action executed"
 
 - name: Second ruleset
   hosts: all

--- a/tests/e2e/files/rulebooks/actions/test_run_playbook.yml
+++ b/tests/e2e/files/rulebooks/actions/test_run_playbook.yml
@@ -51,5 +51,5 @@
             event.post_processing_state == "Complete" and
             event.post_processing_host == "simba"
       action:
-        echo:
-          message: "Post-processing complete on {{ event.post_processing_host }}"
+        debug:
+          msg: "Post-processing complete on {{ event.post_processing_host }}"

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -24,7 +24,6 @@ def test_actions_sanity():
         * post_event
         * set_fact
         * retract_fact
-        * echo
     Each rule has specific logic to be executed only one time
     and each action produces a specific output to be verified.
     """
@@ -89,10 +88,8 @@ def test_actions_sanity():
         not in result.stdout
     ), "retract_fact action failed"
 
-    assert "Echo action executed" in result.stdout
-
     assert (
-        len(result.stdout.splitlines()) == 43
+        len(result.stdout.splitlines()) == 42
     ), "unexpected output from the rulebook"
 
 

--- a/tests/examples/48_echo.yml
+++ b/tests/examples/48_echo.yml
@@ -9,5 +9,5 @@
     - name: r1
       condition: event.i == 1
       action:
-        echo:
-          message: Hurray it works
+        debug:
+          msg: Hurray it works

--- a/tests/examples/51_vars_namespace.yml
+++ b/tests/examples/51_vars_namespace.yml
@@ -33,25 +33,25 @@
     - name: str_test
       condition: event.address.street == vars.person.address.street
       action:
-        echo:
-          message: String comparison works
+        debug:
+          msg: String comparison works
     - name: list_test
       condition: event.year in vars.person.address.years_active
       action:
-        echo:
-          message: List in works
+        debug:
+          msg: List in works
     - name: bool_test
       condition: event.active == vars.person.active
       action:
-        echo:
-          message: Boolean works
+        debug:
+          msg: Boolean works
     - name: int_test
       condition: event.age == vars.person.age
       action:
-        echo:
-          message: Int works
+        debug:
+          msg: Int works
     - name: float_test
       condition: event.threshold < vars.person.reliability
       action:
-        echo:
-          message: Float works
+        debug:
+          msg: Float works

--- a/tests/examples/55_not_all.yml
+++ b/tests/examples/55_not_all.yml
@@ -23,5 +23,5 @@
            - event.alert.code == 1002
          timeout: 10 seconds
       action:
-        echo:
-          message: "Not all conditions met"
+        debug:
+          msg: "Not all conditions met"

--- a/tests/examples/56_once_after.yml
+++ b/tests/examples/56_once_after.yml
@@ -23,8 +23,8 @@
     - name: r1
       condition: event.alert.level == "warning" or event.alert.level == "error"
       action:
-        echo:
-          message: Once after 10 seconds
+        debug:
+          msg: Once after 10 seconds
       throttle:
          once_after: 10 seconds
          group_by_attributes:

--- a/tests/examples/57_once_after_multi.yml
+++ b/tests/examples/57_once_after_multi.yml
@@ -43,8 +43,8 @@
     - name: r1
       condition: event.r1.level == "warning" or event.r1.level == "error"
       action:
-        echo:
-          message: r1 works
+        debug:
+          msg: r1 works
       throttle:
          once_after: 15 seconds
          group_by_attributes:
@@ -53,8 +53,8 @@
     - name: r2
       condition: event.r2.level == "warning" or event.r2.level == "error"
       action:
-        echo:
-          message: r2 works
+        debug:
+          msg: r2 works
       throttle:
          once_after: 30 seconds
          group_by_attributes:
@@ -63,8 +63,8 @@
     - name: r3
       condition: event.r3.level == "warning" or event.r3.level == "error"
       action:
-        echo:
-          message: r3 works
+        debug:
+          msg: r3 works
       throttle:
          once_after: 45 seconds
          group_by_attributes:

--- a/tests/examples/58_string_search.yml
+++ b/tests/examples/58_string_search.yml
@@ -15,30 +15,30 @@
     - name: match
       condition: event.url1 is match("https://example.com/users/.*/resources",ignorecase=true,multiline=true)
       action:
-        echo:
-          message: match works
+        debug:
+          msg: match works
     - name: search
       condition: event.url2 is search("groups/.*/resources/.*")
       action:
-        echo:
-          message: search works
+        debug:
+          msg: search works
     - name: regex
       condition: event.url3 is regex("example\.com/others/foo")
       action:
-        echo:
-          message: Regex works
+        debug:
+          msg: Regex works
     - name: not match
       condition: event.url4 is not match("https://example.com/users/.*/resources",ignorecase=true,multiline=true)
       action:
-        echo:
-          message: not match works
+        debug:
+          msg: not match works
     - name: not search
       condition: event.url5 is not search("groups/.*/resources/.*")
       action:
-        echo:
-          message: not search works
+        debug:
+          msg: not search works
     - name: not regex
       condition: event.url6 is not regex("example\.com/others/foo")
       action:
-        echo:
-          message: not regex works
+        debug:
+          msg: not regex works

--- a/tests/examples/59_multiple_actions.yml
+++ b/tests/examples/59_multiple_actions.yml
@@ -11,12 +11,12 @@
       - debug:
       - print_event:
            pretty: true
-      - echo:
-           message: "Multiple Action Message1"
-      - echo:
-           message: "Multiple Action Message2"
+      - debug:
+           msg: "Multiple Action Message1"
+      - debug:
+           msg: "Multiple Action Message2"
   - name: r2
     condition: event.i == 2
     action:
-      echo:
-        message: Single Action
+      debug:
+        msg: Single Action

--- a/tests/examples/60_json_filter.yml
+++ b/tests/examples/60_json_filter.yml
@@ -25,10 +25,10 @@
     - name: r1
       condition: event.key3.key4.f_use_1 == 42
       action:
-        echo:
-          message: Hurray filtering works
+        debug:
+          msg: Hurray filtering works
     - name: r2
       condition: event.key1.key2.f_ignore_1 == 1
       action:
-        echo:
-          message: Should never fire
+        debug:
+          msg: Should never fire

--- a/tests/examples/61_select_1.yml
+++ b/tests/examples/61_select_1.yml
@@ -26,5 +26,5 @@
     - name: r1
       condition: event.levels is select('>', 25)
       action:
-        echo:
-          message: Found a player with level greater than 25
+        debug:
+          msg: Found a player with level greater than 25

--- a/tests/examples/62_select_2.yml
+++ b/tests/examples/62_select_2.yml
@@ -24,10 +24,10 @@
     - name: r1
       condition: event.addresses is select('regex', 'Main St')
       action:
-        echo:
-          message: Some one lives on Main Street
+        debug:
+          msg: Some one lives on Main Street
     - name: r2
       condition: event.addresses is not select('regex', 'Major St')
       action:
-        echo:
-          message: No one lives on Major St
+        debug:
+          msg: No one lives on Major St

--- a/tests/examples/63_selectattr_1.yml
+++ b/tests/examples/63_selectattr_1.yml
@@ -30,10 +30,10 @@
     - name: r1
       condition: event.people is selectattr('person.age', '>', 30)
       action:
-        echo:
-          message: Has a person greater than 30
+        debug:
+          msg: Has a person greater than 30
     - name: r2
       condition: event.friends is selectattr('person.name', 'regex', 'Barney|Fred')
       action:
-        echo:
-          message: Barney or Fred in friends list
+        debug:
+          msg: Barney or Fred in friends list

--- a/tests/examples/64_selectattr_2.yml
+++ b/tests/examples/64_selectattr_2.yml
@@ -21,5 +21,5 @@
     - name: r1
       condition: event.people is selectattr('person.age', 'in', [55,25])
       action:
-        echo:
-          message: Found person who is either 55 or 25
+        debug:
+          msg: Found person who is either 55 or 25

--- a/tests/examples/65_selectattr_3.yml
+++ b/tests/examples/65_selectattr_3.yml
@@ -13,5 +13,5 @@
       # we convert it to an array of 1 
       condition: event.person is selectattr('age', '>', 30)
       action:
-        echo:
-          message: Has a person greater than 30
+        debug:
+          msg: Has a person greater than 30

--- a/tests/examples/66_sleepy_playbook.yml
+++ b/tests/examples/66_sleepy_playbook.yml
@@ -31,8 +31,8 @@
     - name: r11
       condition: event.j == 0
       action:
-        echo:
-          message: Next issuing shutdown 
+        debug:
+          msg: Next issuing shutdown 
     - name: r12
       condition: event.j == 1
       action:

--- a/tests/examples/67_shutdown_now.yml
+++ b/tests/examples/67_shutdown_now.yml
@@ -31,8 +31,8 @@
     - name: r11
       condition: event.j == 0
       action:
-        echo:
-          message: Next issuing ungraceful shutdown 
+        debug:
+          msg: Next issuing ungraceful shutdown 
     - name: r12
       condition: event.j == 1
       action:

--- a/tests/examples/68_disabled_rule.yml
+++ b/tests/examples/68_disabled_rule.yml
@@ -9,11 +9,11 @@
     - name: r1
       condition: event.i == 1
       action:
-        echo:
-          message: Should get fired
+        debug:
+          msg: Should get fired
     - name: r2
       enabled: false
       condition: event.i == 2
       action:
-        echo:
-          message: Should not get fired
+        debug:
+          msg: Should not get fired

--- a/tests/examples/69_enhanced_debug.yml
+++ b/tests/examples/69_enhanced_debug.yml
@@ -1,0 +1,35 @@
+---
+- name: 69 enhanced debug
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 0
+      action:
+        debug:
+    - name: r2
+      condition: event.i == 1
+      action:
+        debug:
+          msg: "This is a sample message with {{ event.i }}"
+    - name: r3
+      condition: event.i == 2
+      action:
+        debug:
+          msg: 
+            - "Hello World {{ event }}"
+            - "Hello Java"
+            - "Hello Java again {{ event }}"
+    - name: r4
+      condition: event.i == 3
+      action:
+        debug:
+          var: event.does_not_exist
+    - name: r5
+      condition: event.i == 4
+      action:
+        debug:
+          var: event.i

--- a/tests/rules/rules_with_assignment.yml
+++ b/tests/rules/rules_with_assignment.yml
@@ -10,4 +10,4 @@
       condition: events.first << event.i == 0
       action:
         debug:
-          events_event: "{{events.first}}"
+          var: events.first

--- a/tests/rules/rules_with_assignment2.yml
+++ b/tests/rules/rules_with_assignment2.yml
@@ -10,4 +10,4 @@
       condition: facts.first << fact.i == 0
       action:
         debug:
-          events_event: "{{events.first}}"
+          var: events.first

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1189,7 +1189,7 @@ async def test_48_echo():
             "max_events": 2,
             "shutdown_events": 1,
             "actions": [
-                "48 echo::r1::echo",
+                "48 echo::r1::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1295,11 +1295,11 @@ async def test_51_vars_namespace():
             "max_events": 6,
             "shutdown_events": 1,
             "actions": [
-                "51 vars namespace::str_test::echo",
-                "51 vars namespace::list_test::echo",
-                "51 vars namespace::bool_test::echo",
-                "51 vars namespace::int_test::echo",
-                "51 vars namespace::float_test::echo",
+                "51 vars namespace::str_test::debug",
+                "51 vars namespace::list_test::debug",
+                "51 vars namespace::bool_test::debug",
+                "51 vars namespace::int_test::debug",
+                "51 vars namespace::float_test::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1443,8 +1443,8 @@ async def test_55_not_all():
             "max_events": 3,
             "shutdown_events": 1,
             "actions": [
-                "55 not all::maint failed::echo",
-                "55 not all::maint failed::echo",
+                "55 not all::maint failed::debug",
+                "55 not all::maint failed::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1469,7 +1469,7 @@ async def test_56_once_after():
             "max_events": 2,
             "shutdown_events": 1,
             "actions": [
-                "56 once after::r1::echo",
+                "56 once after::r1::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1516,12 +1516,12 @@ async def test_58_string_search():
             "max_events": 7,
             "shutdown_events": 1,
             "actions": [
-                "58 String search::match::echo",
-                "58 String search::search::echo",
-                "58 String search::regex::echo",
-                "58 String search::not match::echo",
-                "58 String search::not search::echo",
-                "58 String search::not regex::echo",
+                "58 String search::match::debug",
+                "58 String search::search::debug",
+                "58 String search::regex::debug",
+                "58 String search::not match::debug",
+                "58 String search::not search::debug",
+                "58 String search::not regex::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1548,9 +1548,9 @@ async def test_59_multiple_actions():
             "actions": [
                 "59 Multiple Actions::r1::debug",
                 "59 Multiple Actions::r1::print_event",
-                "59 Multiple Actions::r1::echo",
-                "59 Multiple Actions::r1::echo",
-                "59 Multiple Actions::r2::echo",
+                "59 Multiple Actions::r1::debug",
+                "59 Multiple Actions::r1::debug",
+                "59 Multiple Actions::r2::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1574,7 +1574,7 @@ async def test_60_json_filter():
             "max_events": 2,
             "shutdown_events": 1,
             "actions": [
-                "60 json filter::r1::echo",
+                "60 json filter::r1::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1598,7 +1598,7 @@ async def test_61_select_1():
             "max_events": 2,
             "shutdown_events": 1,
             "actions": [
-                "61 select 1::r1::echo",
+                "61 select 1::r1::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1622,9 +1622,9 @@ async def test_62_select_2():
             "max_events": 4,
             "shutdown_events": 1,
             "actions": [
-                "62 select 2::r1::echo",
-                "62 select 2::r2::echo",
-                "62 select 2::r1::echo",
+                "62 select 2::r1::debug",
+                "62 select 2::r2::debug",
+                "62 select 2::r1::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1648,8 +1648,8 @@ async def test_63_selectattr_1():
             "max_events": 3,
             "shutdown_events": 1,
             "actions": [
-                "63 selectattr 1::r1::echo",
-                "63 selectattr 1::r2::echo",
+                "63 selectattr 1::r1::debug",
+                "63 selectattr 1::r2::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1673,7 +1673,7 @@ async def test_64_selectattr_2():
             "max_events": 2,
             "shutdown_events": 1,
             "actions": [
-                "64 selectattr 2::r1::echo",
+                "64 selectattr 2::r1::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1697,7 +1697,7 @@ async def test_65_selectattr_3():
             "max_events": 2,
             "shutdown_events": 1,
             "actions": [
-                "65 selectattr 3::r1::echo",
+                "65 selectattr 3::r1::debug",
             ],
         }
         validate_events(event_log, **checks)
@@ -1730,7 +1730,7 @@ async def test_66_sleepy_playbook():
                 "shutdown_events": 2,
                 "actions": [
                     "66 sleepy playbook::r1::print_event",
-                    "terminate gracefully::r11::echo",
+                    "terminate gracefully::r11::debug",
                     "terminate gracefully::r12::shutdown",
                 ],
             }
@@ -1762,7 +1762,7 @@ async def test_67_shutdown_now():
                 "shutdown_events": 2,
                 "actions": [
                     "67 shutdown now::r1::print_event",
-                    "terminate now::r11::echo",
+                    "terminate now::r11::debug",
                     "terminate now::r12::shutdown",
                 ],
             }
@@ -1787,7 +1787,34 @@ async def test_68_disabled_rule():
             "max_events": 2,
             "shutdown_events": 1,
             "actions": [
-                "68 disabled rule::r1::echo",
+                "68 disabled rule::r1::debug",
+            ],
+        }
+        validate_events(event_log, **checks)
+
+
+@pytest.mark.asyncio
+async def test_69_enhanced_debug():
+    ruleset_queues, event_log = load_rulebook("examples/69_enhanced_debug.yml")
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    with SourceTask(rs.sources[0], "sources", {}, queue):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            dict(),
+            load_inventory("playbooks/inventory.yml"),
+        )
+
+        checks = {
+            "max_events": 5,
+            "shutdown_events": 1,
+            "actions": [
+                "69 enhanced debug::r1::debug",
+                "69 enhanced debug::r2::debug",
+                "69 enhanced debug::r3::debug",
+                "69 enhanced debug::r5::debug",
             ],
         }
         validate_events(event_log, **checks)


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-9301

The debug action supports msg and var attributes to display single/multiple messages or variables akin to ansible debug builtin. The msg supports an array of messages.
This removes the need for a separate echo command. The echo is equivalent to
```
action:
   debug:
     msg: .....
```