### PR TITLE
Added ansible_eda_date_time to use in action arguments

### DIFF
--- a/ansible_rulebook/eda_times.py
+++ b/ansible_rulebook/eda_times.py
@@ -1,0 +1,66 @@
+#  Copyright 2022 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import time
+from datetime import datetime
+
+
+def get_eda_times():
+    epoch = time.time()
+    return dict(
+        ansible_eda_date_time_local=_get_ansible_eda_date_time_local(epoch),
+        ansible_eda_date_time_utc=_get_ansible_eda_date_time_utc(epoch),
+    )
+
+
+def _get_ansible_eda_date_time_local(epoch):
+    dt = datetime.fromtimestamp(epoch)
+    return dict(
+        date=dt.strftime("%Y-%m-%d"),
+        day=dt.day,
+        epoch=int(epoch),
+        hour=dt.hour,
+        iso8601=dt.astimezone().isoformat(),
+        iso8601_micro=f"{dt.isoformat()}",
+        minute=dt.minute,
+        month=dt.month,
+        second=dt.second,
+        time=dt.strftime("%H:%M:%S"),
+        tz=dt.astimezone().tzname(),
+        weekday=dt.strftime("%A"),
+        weekday_number=dt.weekday(),
+        weeknumber=dt.isocalendar()[1],
+        year=dt.year,
+    )
+
+
+def _get_ansible_eda_date_time_utc(epoch):
+    dt = datetime.utcfromtimestamp(epoch)
+    return dict(
+        date=dt.strftime("%Y-%m-%d"),
+        day=dt.day,
+        epoch=int(epoch),
+        hour=dt.hour,
+        iso8601=dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        iso8601_micro=f"{dt.isoformat()}Z",
+        minute=dt.minute,
+        month=dt.month,
+        second=dt.second,
+        time=dt.strftime("%H:%M:%S"),
+        tz="UTC",
+        weekday=dt.strftime("%A"),
+        weekday_number=dt.weekday(),
+        weeknumber=dt.isocalendar()[1],
+        year=dt.year,
+    )

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -50,6 +50,8 @@ from ansible_rulebook.rule_types import (
 from ansible_rulebook.rules_parser import parse_hosts
 from ansible_rulebook.util import collect_ansible_facts, substitute_variables
 
+from .eda_times import get_eda_times
+
 logger = logging.getLogger(__name__)
 
 
@@ -410,6 +412,7 @@ class RuleSetRunner:
                     )
                     _update_variables(variables_copy, var_root)
 
+                variables_copy.update(get_eda_times())
                 logger.info(
                     "substitute_variables [%s] [%s]",
                     action_args,

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -47,6 +47,32 @@ The data type is of great importance for the rules engine. The following types a
 * booleans
 * floats (dot notation and scientific notation)
 
+
+Auto generated variables
+************************
+Before an action is executed we generate 2 attributes
+* ansible_eda_date_time_local
+* ansible_eda_date_time_utc
+
+The attributes are for each of the fields are
+* date  e.g. '2023-02-19'
+* time  e.g. '12:19:58'
+* year  e.g. 2023
+* month e.g. 02
+* day   e.g. 19
+* hour  e.g. 12
+* minute e.g. 19
+* second e.g. 58
+* epoch  e.g. 1676827198
+* iso8601 e.g. '2023-02-19T12:19:58.321434-05:00'
+* iso8601_micro e.g. '2023-02-19T12:19:58.321434'
+* weekday e.g. 'Sunday'
+* weekday_number e.g. 6
+* weeknumber e.g. 7
+* tz e.g. 'EST'
+
+This data can be used in action arguments
+
 Supported Operators
 *******************
 

--- a/tests/examples/71_eda_times.yml
+++ b/tests/examples/71_eda_times.yml
@@ -1,0 +1,44 @@
+---
+- name: 71 eda times
+  hosts: all
+  sources:
+    - name: generic
+      generic:
+        payload:
+          - url1: "https://example.com/users/foo/resources/bar"
+          - url2: "https://example.com/groups/foo/resources/bar"
+          - url3: "https://example.com/others/foo/resources/bar"
+          - url4: "https://redhat.com/users/foo/resources/bar"
+          - url5: "https://redhat.com/abc/foo/resources/bar"
+          - url6: "https://redhat.com/xyz/foo/resources/bar"
+  rules:
+    - name: r1
+      condition: event.url1 is match("https://example.com/users/.*/resources",ignorecase=true,multiline=true)
+      action:
+        debug:
+            first : "{{ ansible_eda_date_time_local.iso8601_micro }} match works"
+    - name: r2
+      condition: event.url2 is search("groups/.*/resources/.*")
+      action:
+        debug:
+            first : "{{ ansible_eda_date_time_local.date }} search works"
+    - name: r3
+      condition: event.url3 is regex("example\.com/others/foo")
+      action:
+        debug:
+            first : "{{ ansible_eda_date_time_local.time }} regex works"
+    - name: r4
+      condition: event.url4 is not match("https://example.com/users/.*/resources",ignorecase=true,multiline=true)
+      action:
+        debug:
+            first : "{{ ansible_eda_date_time_utc.time }} not match works"
+    - name: r5
+      condition: event.url5 is not search("groups/.*/resources/.*")
+      action:
+        debug:
+            first : "{{ ansible_eda_date_time_utc.date }} not search works"
+    - name: r6
+      condition: event.url6 is not regex("example\.com/others/foo")
+      action:
+        debug:
+            first : "{{ ansible_eda_date_time_utc.iso8601_micro }} not regex works"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1723,3 +1723,32 @@ async def test_68_disabled_rule():
             ],
         }
         validate_events(event_log, **checks)
+
+
+@pytest.mark.asyncio
+async def test_71_eda_times():
+    ruleset_queues, event_log = load_rulebook("examples/71_eda_times.yml")
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    with SourceTask(rs.sources[0], "sources", {}, queue):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            dict(),
+            dict(),
+        )
+
+        checks = {
+            "max_events": 7,
+            "shutdown_events": 1,
+            "actions": [
+                "71 eda times::r1::debug",
+                "71 eda times::r2::debug",
+                "71 eda times::r3::debug",
+                "71 eda times::r4::debug",
+                "71 eda times::r5::debug",
+                "71 eda times::r6::debug",
+            ],
+        }
+        validate_events(event_log, **checks)


### PR DESCRIPTION
Added 2 new variables
* ansible_eda_date_time_local   - Stores Local time when the action ran
* ansible_eda_date_time_utc     - Stores UTC time when the action ran

This is similar to the **ansible_date_time** that is used in ansible-playbooks. In our use case it is generated for every action and stores the date time in local and UTC format in 2 different variables. This can be used in action args and also allows us to add a time component to internal events like set_fact and post_event actions.
e.g.

```
    - name: r3
      condition: event.url3 is regex("example\.com/others/foo")
      action:
        debug:
            first : "{{ ansible_eda_date_time_local.time }} regex works"
```