### PR TITLE
[AAP-9610] Fixed: Pass correct rulename in extra_vars

### DIFF
--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -254,7 +254,8 @@ async def run_playbook(
         event_log,
         inventory,
         variables,
-        ruleset,
+        source_ruleset_name,
+        source_rule_name,
         name,
         "run_playbook",
         copy_files,
@@ -350,7 +351,8 @@ async def run_module(
         event_log,
         inventory,
         variables,
-        ruleset,
+        source_ruleset_name,
+        source_rule_name,
         name,
         "run_module",
         copy_files,
@@ -524,6 +526,7 @@ async def pre_process_runner(
     inventory: Dict,
     variables: Dict,
     ruleset: str,
+    rulename: str,
     name: str,
     action: str,
     copy_files: Optional[bool] = False,
@@ -537,7 +540,7 @@ async def pre_process_runner(
     logger.debug("private data dir %s", private_data_dir)
 
     playbook_extra_vars = _collect_extra_vars(
-        variables, extra_vars, ruleset, name
+        variables, extra_vars, ruleset, rulename
     )
 
     env_dir = os.path.join(private_data_dir, "env")
@@ -672,7 +675,10 @@ async def run_job_template(
     job_args["limit"] = hosts_limit
 
     job_args["extra_vars"] = _collect_extra_vars(
-        variables, job_args.get("extra_vars", {}), ruleset, name
+        variables,
+        job_args.get("extra_vars", {}),
+        source_ruleset_name,
+        source_rule_name,
     )
 
     job_id = str(uuid.uuid4())

--- a/tests/playbooks/validate_args_playbook.yml
+++ b/tests/playbooks/validate_args_playbook.yml
@@ -3,6 +3,14 @@
   hosts: localhost
   gather_facts: false
   tasks:
+    - name: Validate rule name
+      ansible.builtin.fail:
+        msg: "Rule name did not match"
+      when: ansible_eda.rule != "r2"
+    - name: Validate ruleset name
+      ansible.builtin.fail:
+        msg: "Rule name did not match"
+      when: ansible_eda.ruleset != "Test Assert Fact of different data types"
     - name: Convert vars to json so we can use nested keys
       ansible.builtin.set_fact:
         vars_json: "{{ ansible_eda | to_json }}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -387,7 +387,7 @@ async def test_run_assert_facts():
     assert event_log.get_nowait()["type"] == "EmptyEvent", "0"
     assert event_log.get_nowait()["type"] == "Action", "0.1"
     assert event_log.get_nowait()["type"] == "Job", "1.0"
-    for i in range(41):
+    for i in range(47):
         assert event_log.get_nowait()["type"] == "AnsibleEvent", f"1.{i}"
 
     event = event_log.get_nowait()


### PR DESCRIPTION
We were incorectly passing the playbook name as rulename. Fixed the code to pass in the correct ruleset and rule name.

https://issues.redhat.com/browse/AAP-9610

Fixed the test case to validate the rule name and ruleset name.