### PR TITLE
AAP-8657 sanity test for multiple actions

### DIFF
--- a/tests/e2e/config/default.yml
+++ b/tests/e2e/config/default.yml
@@ -1,6 +1,6 @@
 event_delay: 1
 operators_shutdown_after: 1
 run_playbook_shutdown_after: 5
-cmd_timeout: 15
+cmd_timeout: 20
 controller_url: http://localhost:8080
 controller_token: secret

--- a/tests/e2e/files/rulebooks/actions/test_actions_sanity.yml
+++ b/tests/e2e/files/rulebooks/actions/test_actions_sanity.yml
@@ -3,7 +3,8 @@
   hosts: all
   sources:
     - generic:
-        event_delay: 1
+        event_delay: "{{ DEFAULT_EVENT_DELAY }}"
+        shutdown_after: "{{ DEFAULT_SHUTDOWN_AFTER }}"
         payload:
           - action: "run_playbook"
           - action: "run_module"
@@ -21,6 +22,7 @@
             rulebook_scope: same_ruleset
           - action: "check_retract_fact"
             rulebook_scope: same_ruleset
+          - action: "multiple_actions"
   rules:
     - name: run_playbook
       condition: event.action == "run_playbook"
@@ -110,13 +112,27 @@
           module_args:
             msg: "Retracted fact in same ruleset, this should not be printed"
 
+    - name: Test multiple actions
+      condition: event.action == "multiple_actions"
+      actions:
+        - run_module:
+            name: ansible.builtin.debug
+            module_args:
+              msg: "Multiple action #1 triggered"
+        - debug:
+            msg: "Multiple action #2 triggered"
+
+
 
 - name: Second ruleset
   hosts: all
   sources:
-    - ansible.eda.range:
-        limit: 60
-        delay: 1
+    - generic:
+        shutdown_after: "{{ DEFAULT_SHUTDOWN_AFTER }}"
+        repeat_delay: 1
+        repeat_count: 20
+        payload:
+          - empty: true
   rules:
     - name: print post_event different ruleset
       condition: event.post_event_state == "sent"

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -4,6 +4,7 @@ Module with tests for operators
 import logging
 import subprocess
 
+import jinja2
 import pytest
 from pytest_check import check
 
@@ -13,10 +14,11 @@ from .settings import SETTINGS
 LOGGER = logging.getLogger(__name__)
 DEFAULT_CMD_TIMEOUT = SETTINGS["cmd_timeout"]
 DEFAULT_SHUTDOWN_AFTER = SETTINGS["run_playbook_shutdown_after"]
+DEFAULT_EVENT_DELAY = SETTINGS["event_delay"]
 
 
 @pytest.mark.e2e
-def test_actions_sanity():
+def test_actions_sanity(update_environment):
     """
     A rulebook that contains multiple rules with the following list of actions:
         * run_playbook
@@ -29,10 +31,19 @@ def test_actions_sanity():
     Each rule has specific logic to be executed only one time
     and each action produces a specific output to be verified.
     """
+    env = update_environment(
+        {
+            "DEFAULT_SHUTDOWN_AFTER": str(DEFAULT_SHUTDOWN_AFTER),
+            "DEFAULT_EVENT_DELAY": str(DEFAULT_EVENT_DELAY),
+        }
+    )
+
     rulebook = (
         utils.BASE_DATA_PATH / "rulebooks/actions/test_actions_sanity.yml"
     )
-    cmd = utils.Command(rulebook=rulebook)
+    cmd = utils.Command(
+        rulebook=rulebook, envvars="DEFAULT_SHUTDOWN_AFTER,DEFAULT_EVENT_DELAY"
+    )
 
     LOGGER.info(f"Running command: {cmd}")
     result = subprocess.run(
@@ -41,57 +52,88 @@ def test_actions_sanity():
         capture_output=True,
         cwd=utils.BASE_DATA_PATH,
         text=True,
+        env=env,
     )
 
     assert result.returncode == 0
     assert not result.stderr
-
-    # assert each expected output per action tested
-    assert (
-        "Event matched: {'action': 'run_playbook'}" in result.stdout
-    ), "run_playbook action failed"
-
-    assert (
-        "Event matched: {'action': 'run_module'}" in result.stdout
-    ), "run_module action failed"
-
-    assert (
-        "{'action': 'print_event'}" in result.stdout
-    ), "print_event action failed"
-
-    event_debug_expected_output = """{'hosts': ['all'],
+    event_debug_expected_output_tpl = """kwargs:
+{'hosts': ['all'],
  'inventory': {'all': {'hosts': {'localhost': {'ansible_connection': 'local'}}}},
  'project_data_file': None,
  'ruleset': 'Test actions sanity',
  'source_rule_name': 'debug',
  'source_ruleset_name': 'Test actions sanity',
- 'variables': {'event': {'action': 'debug'}}}"""  # noqa: E501
+ 'variables': {'DEFAULT_EVENT_DELAY': '{{DEFAULT_EVENT_DELAY}}',
+               'DEFAULT_SHUTDOWN_AFTER': '{{DEFAULT_SHUTDOWN_AFTER}}',
+               'event': {'action': 'debug'}}}"""  # noqa: E501
 
-    assert event_debug_expected_output in result.stdout, "debug action failed"
+    event_debug_expected_output = jinja2.Template(
+        event_debug_expected_output_tpl
+    ).render(
+        DEFAULT_SHUTDOWN_AFTER=DEFAULT_SHUTDOWN_AFTER,
+        DEFAULT_EVENT_DELAY=DEFAULT_EVENT_DELAY,
+    )
+
+    # assert each expected output per action tested
+    with check:
+        assert (
+            "Event matched: {'action': 'run_playbook'}" in result.stdout
+        ), "run_playbook action failed"
+
+    with check:
+        assert (
+            "Event matched: {'action': 'run_module'}" in result.stdout
+        ), "run_module action failed"
+
+    with check:
+        assert (
+            "{'action': 'print_event'}" in result.stdout
+        ), "print_event action failed"
+
+    with check:
+        assert (
+            event_debug_expected_output in result.stdout
+        ), "debug action failed"
+
+    with check:
+        assert (
+            "Event matched in same ruleset: sent" in result.stdout
+        ), "post_event action failed"
+
+    with check:
+        assert (
+            "Event matched in different ruleset: sent" in result.stdout
+        ), "post_event action across rulesets failed"
+
+    with check:
+        assert (
+            "Fact matched in same ruleset: sent" in result.stdout
+        ), "set_fact action failed"
+
+    with check:
+        assert (
+            "Fact matched in different ruleset: sent" in result.stdout
+        ), "set_fact action across rulesets failed"
+
+    with check:
+        assert (
+            "Retracted fact in same ruleset, this should not be printed"
+            not in result.stdout
+        ), "retract_fact action failed"
+
+    multiple_actions_expected_outputs = [
+        f"Multiple action #{n} triggered" for n in range(1, 3)
+    ]
+
+    with check:
+        assert all(
+            expected in result.stdout
+            for expected in multiple_actions_expected_outputs
+        ), "multiple actions failed"
 
     assert (
-        "Event matched in same ruleset: sent" in result.stdout
-    ), "post_event action failed"
-
-    assert (
-        "Event matched in different ruleset: sent" in result.stdout
-    ), "post_event action across rulesets failed"
-
-    assert (
-        "Fact matched in same ruleset: sent" in result.stdout
-    ), "set_fact action failed"
-
-    assert (
-        "Fact matched in different ruleset: sent" in result.stdout
-    ), "set_fact action across rulesets failed"
-
-    assert (
-        "Retracted fact in same ruleset, this should not be printed"
-        not in result.stdout
-    ), "retract_fact action failed"
-
-    assert (
-        len(result.stdout.splitlines()) == 42
+        len(result.stdout.splitlines()) == 48
     ), "unexpected output from the rulebook"
 
 


### PR DESCRIPTION
- Add test case for multiple actions
- Inject shutdown after from global config
- Remove range plugin in favor of generic, ensure second ruleset ends as expected
- Asserts with pytest-check

Closes https://issues.redhat.com/browse/AAP-8657