### PR TITLE
Fix generic plugin to manage delays with floats

### DIFF
--- a/tests/sources/generic.py
+++ b/tests/sources/generic.py
@@ -56,11 +56,11 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
     time_format = args.get("time_format", "local")
     create_index = args.get("create_index", "")
 
-    startup_delay = int(args.get("startup_delay", 0))
-    event_delay = int(args.get("event_delay", 0))
-    repeat_delay = int(args.get("repeat_delay", 0))
-    loop_delay = int(args.get("loop_delay", 0))
-    shutdown_after = int(args.get("shutdown_after", 0))
+    startup_delay = float(args.get("startup_delay", 0))
+    event_delay = float(args.get("event_delay", 0))
+    repeat_delay = float(args.get("repeat_delay", 0))
+    loop_delay = float(args.get("loop_delay", 0))
+    shutdown_after = float(args.get("shutdown_after", 0))
 
     loop_count = int(args.get("loop_count", 1))  # -1 infinite
     repeat_count = int(args.get("repeat_count", 1))

--- a/tests/sources/generic.py
+++ b/tests/sources/generic.py
@@ -30,15 +30,15 @@ from typing import Any, Dict
     time_format   local|iso8601|epoch  The time format of event timestamp,
                   default local
     create_index str   The index to create for each event starts at 0
-    startup_delay int  Number of seconds to wait before injecting events
+    startup_delay float  Number of seconds to wait before injecting events
                        into the queue. Default 0
-    event_delay int    Number of seconds to wait before injecting the next
+    event_delay float    Number of seconds to wait before injecting the next
                        event from the payload. Default 0
-    repeat_delay int   Number of seconds to wait before injecting a repeated
+    repeat_delay float   Number of seconds to wait before injecting a repeated
                        event from the payload. Default 0
-    loop_delay int     Number of seconds to wait before inserting the
+    loop_delay float     Number of seconds to wait before inserting the
                        next set of events. Default 0
-    shutdown_after int Number of seconds to wait before shutting down the
+    shutdown_after float Number of seconds to wait before shutting down the
                        plugin. Default 0
     loop_count int     Number of times the set of events in the playload
                        should be repeated. Default 0


### PR DESCRIPTION
We need to use floats for more precision in delays. 