### PR TITLE
To aid in debugging log rule engine stats

### DIFF
--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -113,7 +113,8 @@ class RuleSetRunner:
                     kind=self.shutdown.kind,
                 )
             )
-        lang.end_session(self.name)
+        stats = lang.end_session(self.name)
+        logger.info(pformat(stats))
 
     async def _handle_shutdown(self):
         logger.info(


### PR DESCRIPTION
The Drools rule engine maintains stats about the session, when the session ends it returns a dictionary with all the salient stats. This stats is only logged when run in debug or verbose mode (-v or -vv)

```
2023-02-23 11:10:20,309 - ansible_rulebook.rule_set_runner - INFO - {'asyncResponses': 0,
 'bytesSentOnAsync': 0,
 'end': '2023-02-23T16:10:20.296302Z',
 'eventsMatched': 3,
 'eventsProcessed': 3,
 'eventsSuppressed': 0,
 'numberOfRules': 4,
 'permanentStorageSize': 0,
 'ruleSetName': 'Test actions sanity',
 'rulesTriggered': 4,
 'sessionId': 1,
 'start': '2023-02-23T16:10:17.270232Z'}
```