### PR TITLE
[AAP-7240] Validate is not defined in conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed the echo command in favor of debug with msg
 - Support for null type in conditions
 - Support Jinja2 substitution in rule names
+- Fix the usage of is not defined
 
 ### Fixed
 

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -91,3 +91,8 @@ class PlaybookStatusNotFoundException(Exception):
 class PlaybookNotFoundException(Exception):
 
     pass
+
+
+class InvalidIsNotDefinedException(Exception):
+
+    pass

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -84,7 +84,7 @@ Conditions support the following operators:
    * - is defined
      - To check if a variable is defined
    * - is not defined
-     - To check if a variable is not defined
+     - To check if a variable is not defined can only be used in conjunction with an and expression
    * - is match(pattern,ignorecase=true)
      - To check if the pattern exists in the beginning of the string. Regex supported
    * - is not match(pattern,ignorecase=true)
@@ -736,13 +736,17 @@ Example:
 
 | **Q:** How do I check if an attribute in an object referred in a condition does not exist?
 
-| **Ans:** Use the is not defined
+| **Ans:** Usually you don't have to check if an attribute in the object exists, if its missing the 
+| condition will evaluate to false. In the rare case that you want to check for just the presence of
+| an attribute you can use an is not defined along with an and expression that checks for the presence
+| of another attribute in the object. A plain is not defined causes the rule engine to misinterpret the
+| rules in the ruleset, since an absence could be ambiguous.
 
 Example:
     .. code-block:: yaml
 
       name: rule2
-      condition: fact.msg is not defined
+      condition: fact.msg is not defined and fact.level is defined
       action:
         set_fact:
           fact:

--- a/tests/asts/rules_with_timestamp.yml
+++ b/tests/asts/rules_with_timestamp.yml
@@ -29,10 +29,13 @@
               lhs:
                 Facts: time
               rhs:
-                IsDefinedExpression:
-                  Fact: current_time
-          - IsNotDefinedExpression:
-              Event: initial_time
+                AndExpression:
+                  lhs:
+                    IsDefinedExpression:
+                      Fact: current_time
+                  rhs:
+                    IsNotDefinedExpression:
+                      Event: initial_time
         enabled: true
         name: set the initial time
     - Rule:

--- a/tests/examples/06_retract_fact.yml
+++ b/tests/examples/06_retract_fact.yml
@@ -12,6 +12,7 @@
         set_fact:
           fact:
             msg: hello world
+            level: 5
     - name: r2
       condition: event.msg == "hello world"
       action:
@@ -19,7 +20,7 @@
           fact:
             msg: hello world
     - name: r3
-      condition: event.msg is not defined
+      condition: event.level == 5 and event.msg is not defined
       action:
         debug:
 

--- a/tests/examples/20_is_not_defined.yml
+++ b/tests/examples/20_is_not_defined.yml
@@ -11,6 +11,7 @@
         set_fact:
           fact:
             msg: hello
+            level: 5
     - name: r2
       condition: event.msg is defined
       action:
@@ -18,7 +19,7 @@
           fact:
             msg: hello
     - name: r3
-      condition: event.msg is not defined
+      condition: event.level == 5 and event.msg is not defined
       action:
         debug:
 

--- a/tests/examples/71_invalid_is_not_defined.yml
+++ b/tests/examples/71_invalid_is_not_defined.yml
@@ -1,0 +1,19 @@
+---
+- name: 71 invalid is not defined
+  hosts: all
+  sources:
+    - generic:
+        payload:
+          - x: 1
+
+  rules:
+    - name: r1
+      condition: event.x == 1 and event.y is not defined
+      action:
+        print_event:
+          pretty: true
+    - name: raise an error
+      condition: event.z is not defined
+      action:
+        print_event:
+          pretty: true

--- a/tests/rules/rules_with_timestamp.yml
+++ b/tests/rules/rules_with_timestamp.yml
@@ -13,8 +13,7 @@
     - name: set the initial time
       condition:
         all:
-          - facts.time << fact.current_time is defined
-          - event.initial_time is not defined
+          - facts.time << fact.current_time is defined and event.initial_time is not defined
       action:
         set_fact:
           fact:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,7 +17,10 @@ import json
 import pytest
 
 from ansible_rulebook.engine import run_rulesets, start_source
-from ansible_rulebook.exception import VarsKeyMissingException
+from ansible_rulebook.exception import (
+    InvalidIsNotDefinedException,
+    VarsKeyMissingException,
+)
 from ansible_rulebook.messages import Shutdown
 from ansible_rulebook.util import load_inventory
 
@@ -561,11 +564,11 @@ async def test_20_is_not_defined():
     event = event_log.get_nowait()
     assert event["type"] == "Action", "3"
     assert event["action"] == "retract_fact", "4"
-    assert event["matching_events"] == {"m": {"msg": "hello"}}
+    assert event["matching_events"] == {"m": {"level": 5, "msg": "hello"}}
     event = event_log.get_nowait()
     assert event["type"] == "Action", "5"
     assert event["action"] == "debug", "6"
-    assert event["matching_events"] == {"m": {"msg": "hello"}}
+    assert event["matching_events"] == {"m": {"level": 5, "msg": "hello"}}
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "8"
     assert event_log.empty()
@@ -1844,6 +1847,12 @@ async def test_70_null():
             ],
         }
         validate_events(event_log, **checks)
+
+
+@pytest.mark.asyncio
+async def test_71_invalid_is_not_defined():
+    with pytest.raises(InvalidIsNotDefinedException):
+        load_rulebook("examples/71_invalid_is_not_defined.yml")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-7240
A condition cannot just contain is not defined
```
    - event.x is not defined
```
The above will raise a Validation Error

A valid use of is not defined is alongside an **and** condition
```
    - event.x is not defined and event.y == 5
```