### PR TITLE
[AAP-8921] Add support for Jinja2 substitution in rule names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Support for graceful shutdown, timeout to allow actions to complete
 - Removed the echo command in favor of debug with msg
 - Support for null type in conditions
+- Support Jinja2 substitution in rule names
 
 ### Fixed
 

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -18,7 +18,7 @@ A rule comprises:
      - Description
      - Required
    * - name
-     - The name is a string to identify the rule. This field is mandatory. Each rule in a ruleset must have an unique name across the rulebook.
+     - The name is a string to identify the rule. This field is mandatory. Each rule in a ruleset must have an unique name across the rulebook. You can use Jinja2 substitution in the name.
      - Yes
    * - condition
      - See :doc:`conditions`

--- a/tests/rules/rule_names_with_substitution.yml
+++ b/tests/rules/rule_names_with_substitution.yml
@@ -1,0 +1,15 @@
+---
+- name: Rules with names being substituted
+  hosts: localhost
+  sources:
+    - range:
+        limit: 5
+  rules:
+    - name: "{{ custom.name1 }}"
+      condition: event.i == 1
+      action:
+        debug:
+    - name: "{{ custom.name2 }}"
+      condition: event.i == 2
+      action:
+        debug:


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-8921
Allows for rule names to be substituted from vars passed into ansible-rulebook.