### PR TITLE
[AAP-9186] Use NativeTemple in Jinja2 to preserve types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - get_java_version, add compatibility with macs and tests for check_jvm
 - selectattr operator with negation using greater/less than operators
 - select operator and comparing ints and floats
+- preserve native types when doing jinja substitution
 
 ### Removed
 

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Union
 import ansible_runner
 import jinja2
 import yaml
+from jinja2.nativetypes import NativeTemplate
 from packaging import version
 
 logger = logging.getLogger(__name__)
@@ -39,9 +40,12 @@ def get_horizontal_rule(character):
 
 
 def render_string(value: str, context: Dict) -> str:
-    return jinja2.Template(value, undefined=jinja2.StrictUndefined).render(
-        context
-    )
+    if "{{" in value and "}}" in value:
+        return NativeTemplate(value, undefined=jinja2.StrictUndefined).render(
+            context
+        )
+
+    return value
 
 
 def render_string_or_return_value(value: Any, context: Dict) -> Any:

--- a/tests/e2e/files/rulebooks/operators/test_relational_operators.yml
+++ b/tests/e2e/files/rulebooks/operators/test_relational_operators.yml
@@ -57,7 +57,7 @@
             pi_for_engineers: 3
 
           - id: "testcase #11"
-            stark_motto: |
+            stark_motto: |-
               Winter
               is
               coming

--- a/tests/examples/72_set_fact_with_type.yml
+++ b/tests/examples/72_set_fact_with_type.yml
@@ -1,0 +1,48 @@
+---
+- name: 72 set fact with type
+  hosts: all
+  sources:
+    - generic:
+        shutdown_after: 1
+        payload:
+          - action: "go"
+  rules:
+    - name: r1
+      condition: event.action == "go"
+      action:
+        set_fact:
+          fact:
+            var_bool: "{{ my_bool }}"
+            var_int: "{{ my_int }}"
+            var_float: "{{ my_float }}"
+            literal_int: 5
+            string_int: "5"
+
+    - name: Match the bool
+      condition: event.var_bool
+      action:
+        debug:
+          msg: "The var bool matches"
+
+    - name: Match the int
+      condition: event.var_int == 2
+      action:
+        debug:
+          msg: "The var int matches"
+
+    - name: Match the float
+      condition: event.var_float == 3.123
+      action:
+        debug:
+          msg: "The var int matches"
+
+    - name: Match the literal int
+      condition: event.literal_int == 5
+      action:
+        debug:
+          msg: "The literal int matches"
+    - name: Match the string int
+      condition: event.string_int == "5"
+      action:
+        debug:
+          msg: "The string int matches"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1844,3 +1844,34 @@ async def test_70_null():
             ],
         }
         validate_events(event_log, **checks)
+
+
+@pytest.mark.asyncio
+async def test_72_set_fact_with_type():
+    ruleset_queues, event_log = load_rulebook(
+        "examples/72_set_fact_with_type.yml",
+    )
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    with SourceTask(rs.sources[0], "sources", {}, queue):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            dict(my_bool=True, my_int=2, my_float=3.123),
+            load_inventory("playbooks/inventory.yml"),
+        )
+
+        checks = {
+            "max_events": 7,
+            "shutdown_events": 1,
+            "actions": [
+                "72 set fact with type::r1::set_fact",
+                "72 set fact with type::Match the bool::debug",
+                "72 set fact with type::Match the int::debug",
+                "72 set fact with type::Match the float::debug",
+                "72 set fact with type::Match the literal int::debug",
+                "72 set fact with type::Match the string int::debug",
+            ],
+        }
+        validate_events(event_log, **checks)


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-9186

https://jinja.palletsprojects.com/en/3.0.x/nativetypes/ 

Jinja2 support native types if we use NativeTemplate instead of regular template. 
This helps us preserve the data type in action args and source args.

When using native template it uses ast.literal_eval to convert it to native type. This is problematic for us if we blindly send every string into Jinja to evaluate.

```
import ast
x = ast.literal_eval("78")
type(x)
<class 'int'>
```
As shown above it converts integers wrapped as strings into integers which will cause issues for us. So I only pass it to Jinja if the string has a {{ and }} otherwise we don't pass it into jinja for evaluation.