### PR TITLE
[AAP-8337] Make inventory optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - selectattr operator with negation using greater/less than operators
 - select operator and comparing ints and floats
 - preserve native types when doing jinja substitution
+- inventory argument to the CLI is optional
 
 ### Removed
 

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -36,6 +36,8 @@ from ansible_rulebook.websocket import (
     send_event_log_to_websocket,
 )
 
+from .exception import InventoryNeededException
+
 
 class NullQueue:
     async def put(self, _data):
@@ -43,6 +45,7 @@ class NullQueue:
 
 
 logger = logging.getLogger(__name__)
+INVENTORY_ACTIONS = ("run_playbook", "run_module")
 
 
 # FIXME(cutwater): Replace parsed_args with clear interface
@@ -154,18 +157,21 @@ def load_rulebook(
             Validate.rulebook(data)
             if variables is None:
                 variables = {}
-            return rules_parser.parse_rule_sets(data, variables)
+            rulesets = rules_parser.parse_rule_sets(data, variables)
     elif has_rulebook(*split_collection_name(parsed_args.rulebook)):
         logger.debug(
             "Loading rules from a collection %s", parsed_args.rulebook
         )
-        return rules_parser.parse_rule_sets(
+        rulesets = rules_parser.parse_rule_sets(
             collection_load_rulebook(
                 *split_collection_name(parsed_args.rulebook)
             )
         )
     else:
         raise Exception(f"Could not find ruleset {parsed_args.rulebook}")
+
+    validate_actions(rulesets, parsed_args)
+    return rulesets
 
 
 def spawn_sources(
@@ -191,3 +197,19 @@ def spawn_sources(
             tasks.append(task)
         ruleset_queues.append(RuleSetQueue(ruleset, source_queue))
     return tasks, ruleset_queues
+
+
+def validate_actions(
+    rulesets: List[RuleSet], parsed_args: argparse.ArgumentParser
+) -> None:
+    for ruleset in rulesets:
+        for rule in ruleset.rules:
+            for action in rule.actions:
+                if (
+                    action.action in INVENTORY_ACTIONS
+                    and parsed_args.inventory is None
+                ):
+                    raise InventoryNeededException(
+                        f"Rule {rule.name} has an action {action.action} "
+                        "which needs inventory to be defined"
+                    )

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -177,10 +177,6 @@ def main(args: List[str] = None) -> int:
         parser.print_help()
         sys.exit(0)
 
-    if args.rulebook and not args.inventory:
-        print("Error: inventory is required")
-        return 1
-
     if args.controller_url:
         if args.controller_token:
             job_template_runner.host = args.controller_url

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -91,3 +91,8 @@ class PlaybookStatusNotFoundException(Exception):
 class PlaybookNotFoundException(Exception):
 
     pass
+
+
+class InventoryNeededException(Exception):
+
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,89 @@
+import pytest
+
+from ansible_rulebook.condition_types import Condition as Conditions
+from ansible_rulebook.rule_types import (
+    Action,
+    Condition,
+    EventSource,
+    EventSourceFilter,
+    Rule,
+    RuleSet,
+)
+
+
+@pytest.fixture
+def create_conditions(**kwargs):
+    def _conditions(**kwargs):
+        return Conditions(kwargs.pop("value", "2 > 1"))
+
+    return _conditions
+
+
+@pytest.fixture
+def create_condition(create_conditions, **kwargs):
+    def _condition(**kwargs):
+        when = kwargs.pop("when", "all")
+        value = kwargs.pop("value", [create_conditions()])
+        return Condition(when, value)
+
+    return _condition
+
+
+@pytest.fixture
+def create_event_source_filter(**kwargs):
+    def _event_source_filter(**kwargs):
+        filter_name = kwargs.pop("filter_name", "test")
+        filter_args = kwargs.pop("filter_args", dict(arg1=1))
+        return EventSourceFilter(filter_name, filter_args)
+
+    return _event_source_filter
+
+
+@pytest.fixture
+def create_event_source(create_event_source_filter, **kwargs):
+    def _event_source(**kwargs):
+        name = kwargs.pop("name", "es")
+        source_name = kwargs.pop("source_name", "sample_source_name")
+        source_args = kwargs.pop("source_args", dict(arg1=1))
+        source_filters = kwargs.pop(
+            "source_filters", [create_event_source_filter()]
+        )
+        return EventSource(name, source_name, source_args, source_filters)
+
+    return _event_source
+
+
+@pytest.fixture
+def create_action(**kwargs):
+    def _action(**kwargs):
+        action = kwargs.pop("action", "debug")
+        action_args = kwargs.pop("action_args", dict(msg="Hello World"))
+        return Action(action, action_args)
+
+    return _action
+
+
+@pytest.fixture
+def create_rule(create_condition, create_action, **kwargs):
+    def _rule(**kwargs):
+        name = kwargs.pop("name", "r1")
+        cond = kwargs.pop("condition", create_condition())
+        actions = kwargs.pop("actions", [create_action()])
+        enabled = kwargs.pop("enabled", True)
+        throttle = kwargs.pop("throttle", None)
+        return Rule(name, cond, actions, enabled, throttle)
+
+    return _rule
+
+
+@pytest.fixture
+def create_ruleset(create_event_source, create_rule, *kwargs):
+    def _ruleset(**kwargs):
+        name = kwargs.pop("name", "ruleset1")
+        hosts = kwargs.pop("hosts", ["host1"])
+        event_sources = kwargs.pop("event_sources", [create_event_source()])
+        rules = kwargs.pop("rules", [create_rule()])
+        gather_facts = kwargs.pop("gather_facts", False)
+        return RuleSet(name, hosts, event_sources, rules, gather_facts)
+
+    return _ruleset

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,29 @@
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ansible_rulebook.app import validate_actions
+from ansible_rulebook.cli import get_parser
+from ansible_rulebook.exception import InventoryNeededException
+
+TEST_ACTIONS = [
+    ("debug", does_not_raise()),
+    ("print_event", does_not_raise()),
+    ("set_fact", does_not_raise()),
+    ("post_event", does_not_raise()),
+    ("run_playbook", pytest.raises(InventoryNeededException)),
+    ("run_module", pytest.raises(InventoryNeededException)),
+]
+
+
+@pytest.mark.parametrize("action,expectation", TEST_ACTIONS)
+def test_validate_action(
+    create_ruleset, create_action, create_rule, action, expectation
+):
+    actions = [create_action(**dict(action=action))]
+    rules = [create_rule(**dict(actions=actions))]
+    rulesets = [create_ruleset(**dict(rules=rules))]
+    parser = get_parser()
+    cmdline_args = parser.parse_args(["-r", "dummy.yml"])
+    with expectation:
+        validate_actions(rulesets, cmdline_args)


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-8337

Since ansible-rulebook can be used with Automation Controller we don't need to make inventory mandatory. This is needed for the eda-server to launch the ansible-rulebook and execute a job on the Automation Controller.

Check if the rulebook contains any actions with run_module or run_playbook and raise an exception
```
ansible_rulebook.exception.InventoryNeededException: Rule r1 has an action run_playbook which needs inventory to be defined
```