### PR TITLE
Switch JSON schema to draft-7

### DIFF
--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -1,9 +1,10 @@
 {
-    "$schema": "https://json-schema.org/draft-04/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/ansible_rulebook/schema/ruleset_schema.json",
     "type": "array",
     "items": {"$ref": "#/$defs/ruleset"},
     "minItems": 1,
+    "examples": ["rulebooks/*.yml", "rulebooks/*.yaml"],
     "$defs": {
         "ruleset": {
             "type": "object",
@@ -312,7 +313,7 @@
                     },
                     "required": [
                        "fact"
-                    ], 
+                    ],
                     "additionalProperties": false
                 }
             },
@@ -329,7 +330,7 @@
                     "properties": {
                         "var_root": {"type": ["string","object"] },
                         "pretty": {"type": "boolean" }
-                    }, 
+                    },
                     "additionalProperties": false
                 }
             },

--- a/ansible_rulebook/validators.py
+++ b/ansible_rulebook/validators.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 9):
 else:
     import importlib_resources as resources
 
-from jsonschema import Draft4Validator, validate
+from jsonschema import Draft7Validator, validate
 from jsonschema.exceptions import SchemaError, ValidationError
 
 DEFAULT_RULEBOOK_SCHEMA = "ruleset_schema"
@@ -29,7 +29,7 @@ class Validate:
         data = path.read_text(encoding="utf-8")
         try:
             cls.schema = json.loads(data)
-            Draft4Validator.check_schema(cls.schema)
+            Draft7Validator.check_schema(cls.schema)
         except json.JSONDecodeError:
             logger.exception("Can not deserialize JSON schema")
             raise


### PR DESCRIPTION
As the support for the very old draft-4 was removed from at least
one critical tool (ajv), we switch to draft-7 which also happens to
be the version used by [all the other](https://github.com/ansible/ansible-lint/tree/main/src/ansiblelint/schemas) Ansible related schemas.

Related: https://github.com/ajv-validator/ajv/issues/472
Related: https://github.com/ansible/ansible-lint/issues/3079
Related: https://github.com/ansible/ansible-rulebook/issues/397
