### PR TITLE
Fix $id in schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,15 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
+  - repo: local
+    language: javascript
+    hooks:
+      - id: ajv
+        name: ajv
+        description: Validate JSON schema
+        language: node
+        types: [json]
+        files: ^ansible_rulebook/schema/ruleset_schema.json$
+        additional_dependencies:
+          - ajv-cli
+        entry: ajv compile -s

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/ansible_rulebook/schema/ruleset_schema.json",
     "type": "array",
     "items": {"$ref": "#/$defs/ruleset"},


### PR DESCRIPTION
- corrects wrong $id in schema
- adds pre-commit hook that validates schema using ajv library as
  in order to prevent future regression. Note that AJV was able to
  detect $id bug while python-jsonschema was not.
