### PR TITLE
[AAP-7661] Support inventory in ini/yaml formats

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -63,7 +63,7 @@ async def run(parsed_args: argparse.ArgumentParser) -> None:
             int(parsed_args.id), parsed_args.websocket_address
         )
     else:
-        inventory = {}
+        inventory = ""
         variables = load_vars(parsed_args)
         rulesets = load_rulebook(parsed_args, variables)
         if parsed_args.inventory:

--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -54,7 +54,7 @@ KEY_EDA_VARS = "ansible_eda"
 
 async def none(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,
@@ -114,7 +114,7 @@ async def debug(event_log, **kwargs):
 
 async def print_event(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,
@@ -148,7 +148,7 @@ async def print_event(
 
 async def set_fact(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,
@@ -176,7 +176,7 @@ async def set_fact(
 
 async def retract_fact(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,
@@ -203,7 +203,7 @@ async def retract_fact(
 
 async def post_event(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,
@@ -229,7 +229,7 @@ async def post_event(
 
 async def run_playbook(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,
@@ -326,7 +326,7 @@ async def run_playbook(
 
 async def run_module(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,
@@ -346,7 +346,6 @@ async def run_module(
     extra_vars: Optional[Dict] = None,
     **kwargs,
 ):
-
     temp_dir, module_name = await pre_process_runner(
         event_log,
         inventory,
@@ -523,7 +522,7 @@ async def untar_project(output_dir, project_data_file):
 
 async def pre_process_runner(
     event_log,
-    inventory: Dict,
+    inventory: str,
     variables: Dict,
     ruleset: str,
     rulename: str,
@@ -554,7 +553,7 @@ async def pre_process_runner(
         f.write(yaml.dump(playbook_extra_vars))
     os.mkdir(inventory_dir)
     with open(os.path.join(inventory_dir, "hosts"), "w") as f:
-        f.write(yaml.dump(inventory))
+        f.write(inventory)
     os.mkdir(project_dir)
 
     logger.debug("project_data_file: %s", project_data_file)
@@ -643,7 +642,7 @@ async def post_process_runner(
 
 async def run_job_template(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,
@@ -763,7 +762,7 @@ async def run_job_template(
 
 async def shutdown(
     event_log,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     variables: Dict,
     project_data_file: str,

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -185,7 +185,7 @@ async def run_rulesets(
     event_log: asyncio.Queue,
     ruleset_queues: List[RuleSetQueue],
     variables: Dict,
-    inventory: Dict,
+    inventory: str = "",
     parsed_args: argparse.ArgumentParser = None,
     project_data_file: Optional[str] = None,
 ):

--- a/ansible_rulebook/rule_generator.py
+++ b/ansible_rulebook/rule_generator.py
@@ -37,7 +37,7 @@ def add_to_plan(
     rule: str,
     actions: List[Action],
     variables: Dict,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     plan: Plan,
     rule_engine_results: Any,
@@ -59,7 +59,7 @@ def make_fn(
     ruleset,
     ansible_rule,
     variables: Dict,
-    inventory: Dict,
+    inventory: str,
     hosts: List,
     plan: Plan,
 ) -> Callable:
@@ -82,7 +82,7 @@ def make_fn(
 def generate_rulesets(
     ruleset_queues: List[RuleSetQueue],
     variables: Dict,
-    inventory: Dict,
+    inventory: str,
 ) -> List[EngineRuleSetQueuePlan]:
 
     rulesets = []

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -228,7 +228,7 @@ class RuleSetRunner:
         action: str,
         action_args: Dict,
         variables: Dict,
-        inventory: Dict,
+        inventory: str,
         hosts: List,
         rules_engine_result,
     ) -> None:

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -74,7 +74,7 @@ class ActionContext(NamedTuple):
     rule: str
     actions: List[Action]
     variables: Dict
-    inventory: Dict
+    inventory: str
     hosts: List[str]
     rule_engine_results: Any
 

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -25,7 +25,6 @@ from typing import Any, Dict, List, Union
 
 import ansible_runner
 import jinja2
-import yaml
 from jinja2.nativetypes import NativeTemplate
 from packaging import version
 
@@ -76,11 +75,11 @@ def substitute_variables(
 def load_inventory(inventory_file: str) -> Any:
 
     with open(inventory_file) as f:
-        inventory_data = yaml.safe_load(f.read())
+        inventory_data = f.read()
     return inventory_data
 
 
-def collect_ansible_facts(inventory: Dict) -> List[Dict]:
+def collect_ansible_facts(inventory: str) -> List[Dict]:
     hosts_facts = []
     with tempfile.TemporaryDirectory(
         prefix="gather_facts"
@@ -89,7 +88,7 @@ def collect_ansible_facts(inventory: Dict) -> List[Dict]:
         with open(
             os.path.join(private_data_dir, "inventory", "hosts"), "w"
         ) as f:
-            f.write(yaml.dump(inventory))
+            f.write(inventory)
 
         r = ansible_runner.run(
             private_data_dir=private_data_dir,

--- a/tests/e2e/files/inventories/default_inventory.ini
+++ b/tests/e2e/files/inventories/default_inventory.ini
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -2,6 +2,7 @@
 Module with tests for operators
 """
 import logging
+import pprint
 import subprocess
 
 import jinja2
@@ -41,9 +42,15 @@ def test_actions_sanity(update_environment):
     rulebook = (
         utils.BASE_DATA_PATH / "rulebooks/actions/test_actions_sanity.yml"
     )
+    inventory = utils.BASE_DATA_PATH / "inventories/default_inventory.ini"
     cmd = utils.Command(
-        rulebook=rulebook, envvars="DEFAULT_SHUTDOWN_AFTER,DEFAULT_EVENT_DELAY"
+        rulebook=rulebook,
+        inventory=inventory,
+        envvars="DEFAULT_SHUTDOWN_AFTER,DEFAULT_EVENT_DELAY",
     )
+
+    with open(inventory) as f:
+        inventory_data = pprint.pformat(f.read())
 
     LOGGER.info(f"Running command: {cmd}")
     result = subprocess.run(
@@ -59,7 +66,7 @@ def test_actions_sanity(update_environment):
     assert not result.stderr
     event_debug_expected_output_tpl = """kwargs:
 {'hosts': ['all'],
- 'inventory': {'all': {'hosts': {'localhost': {'ansible_connection': 'local'}}}},
+ 'inventory': {{INVENTORY_DATA}},
  'project_data_file': None,
  'ruleset': 'Test actions sanity',
  'source_rule_name': 'debug',
@@ -73,6 +80,7 @@ def test_actions_sanity(update_environment):
     ).render(
         DEFAULT_SHUTDOWN_AFTER=DEFAULT_SHUTDOWN_AFTER,
         DEFAULT_EVENT_DELAY=DEFAULT_EVENT_DELAY,
+        INVENTORY_DATA=inventory_data,
     )
 
     # assert each expected output per action tested

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -203,12 +203,7 @@ async def test_run_rules_simple():
     queue.put_nowait(dict(i=2))
     queue.put_nowait(Shutdown())
 
-    await run_rulesets(
-        event_log,
-        ruleset_queues,
-        dict(),
-        dict(),
-    )
+    await run_rulesets(event_log, ruleset_queues, dict(), "localhost")
 
     assert event_log.get_nowait()["type"] == "Action", "0"
     assert event_log.get_nowait()["type"] == "Action", "0.2"
@@ -217,7 +212,13 @@ async def test_run_rules_simple():
     assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.2"
     assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.3"
     assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.4"
-    assert event_log.get_nowait()["type"] == "Action", "1.5"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.5"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.6"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.7"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.8"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.9"
+    assert event_log.get_nowait()["type"] == "Action", "2.0"
+    assert event_log.get_nowait()["type"] == "Action", "2.1"
     assert event_log.get_nowait()["type"] == "Shutdown", "3"
     assert event_log.empty()
 
@@ -318,12 +319,7 @@ async def test_filters():
     queue.put_nowait(dict(i=2))
     queue.put_nowait(Shutdown())
 
-    await run_rulesets(
-        event_log,
-        ruleset_queues,
-        dict(),
-        dict(),
-    )
+    await run_rulesets(event_log, ruleset_queues, dict(), "localhost")
 
     assert event_log.get_nowait()["type"] == "Action", "0"
     assert event_log.get_nowait()["type"] == "Action", "0.2"
@@ -332,7 +328,13 @@ async def test_filters():
     assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.2"
     assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.3"
     assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.4"
-    assert event_log.get_nowait()["type"] == "Action", "1.5"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.5"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.6"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.7"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.8"
+    assert event_log.get_nowait()["type"] == "AnsibleEvent", "1.9"
+    assert event_log.get_nowait()["type"] == "Action", "2.0"
+    assert event_log.get_nowait()["type"] == "Action", "2.1"
     assert event_log.get_nowait()["type"] == "Shutdown", "3"
     assert event_log.empty()
 
@@ -381,7 +383,7 @@ async def test_run_assert_facts():
         event_log,
         ruleset_queues,
         dict(Naboo="naboo"),
-        inventory,
+        yaml.dump(inventory),
     )
 
     assert event_log.get_nowait()["type"] == "EmptyEvent", "0"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -779,7 +779,6 @@ async def test_29_run_module():
         event_log,
         ruleset_queues,
         dict(),
-        dict(),
     )
 
     event = event_log.get_nowait()
@@ -814,7 +813,6 @@ async def test_30_run_module_missing():
         event_log,
         ruleset_queues,
         dict(),
-        dict(),
     )
 
     event = event_log.get_nowait()
@@ -847,7 +845,6 @@ async def test_31_run_module_missing_args():
         event_log,
         ruleset_queues,
         dict(),
-        dict(),
     )
 
     event = event_log.get_nowait()
@@ -879,7 +876,6 @@ async def test_32_run_module_fail():
     await run_rulesets(
         event_log,
         ruleset_queues,
-        dict(),
         dict(),
     )
 
@@ -917,7 +913,6 @@ async def test_35_multiple_rulesets_1_fired():
     await run_rulesets(
         event_log,
         ruleset_queues,
-        dict(),
         dict(),
     )
 


### PR DESCRIPTION
ansible-rulebook doesn't do anything with the inventory data. It just reads it and writes into the inventory file for ansible_runner. So instead of treating every inventory as a yaml file and load it as a dictionary, this PR just loads the inventory data as a blob irrespective of the format and sends it to ansible-runner.

Fixes #241
Closes: https://issues.redhat.com/browse/AAP-7661