### PR TITLE
Fix broken links to collection

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,7 +38,7 @@ Installation via pip
 
 
 3. Install the ansible.eda collection which comes with various event source plugins and filters to get you started. Please refer to the instructions in the
-`collection repository <https://github.com/ansible/event-driven-ansible/blob/main/COLLECTION.md#install>`_.
+`collection repository <https://github.com/ansible/event-driven-ansible#install>`_.
 
 
 Installation examples

--- a/docs/sources.rst
+++ b/docs/sources.rst
@@ -6,7 +6,7 @@ Events come from event sources. Event driven automation supports many event
 sources using a plugin system. Event source plugins can be stored locally but
 are preferably distributed via collections.
 
-`Ansible.eda <https://github.com/ansible/event-driven-ansible/blob/main/COLLECTION.md>`_
+`Ansible.eda <https://github.com/ansible/event-driven-ansible>`_
 is the collection that includes our initial set of event source plugins.
 These include:
 


### PR DESCRIPTION
Docs in the collection were updated which broke these links in the ansible-rulebook docs. Updating the links to point to the base repo.