### PR TITLE
Performance test playbook was missing the ansible_eda prefix

### DIFF
--- a/performance_test/hello_playbook1.yml
+++ b/performance_test/hello_playbook1.yml
@@ -5,5 +5,5 @@
   tasks:
     - name:
       debug:
-        msg: 'Hello event {{event}}'
+        msg: 'Hello event {{ansible_eda.event}}'
 ...


### PR DESCRIPTION
The rules.yml rulebook used for performance testing was missing the ansible_eda prefix in the playbook it calls.

Missed from PR # https://github.com/ansible/ansible-rulebook/pull/282