### PR TITLE
[AAP-9324] Allow for variable names in select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Support for null type in conditions
 - Support Jinja2 substitution in rule names
 - Support booleans in lists, which can contain mixed data types
+- Support for identifiers in select and selectattr
 
 ### Fixed
 

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -157,7 +157,7 @@ def visit_condition(parsed_condition: ConditionTypes, variables: Dict):
                 variables,
             )
         elif parsed_condition.operator == "is":
-            if isinstance(parsed_condition.right, Identifier):
+            if isinstance(parsed_condition.right, String):
                 if parsed_condition.right.value == "defined":
                     return {
                         "IsDefinedExpression": visit_condition(
@@ -177,7 +177,7 @@ def visit_condition(parsed_condition: ConditionTypes, variables: Dict):
                     "SelectExpression", parsed_condition, variables
                 )
         elif parsed_condition.operator == "is not":
-            if isinstance(parsed_condition.right, Identifier):
+            if isinstance(parsed_condition.right, String):
                 if parsed_condition.right.value == "defined":
                     return {
                         "IsNotDefinedExpression": visit_condition(

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.2.5
+	drools_jpy == 0.2.6
 
 [options.packages.find]
 include = 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -463,6 +463,47 @@ def test_parse_condition():
         parse_condition('event.is_true is select("==", False)'), {}
     )
 
+    assert {
+        "SelectExpression": {
+            "lhs": {"Event": "my_list"},
+            "rhs": {
+                "operator": {"String": "=="},
+                "value": {"Event": "my_int"},
+            },
+        }
+    } == visit_condition(
+        parse_condition("event.my_list is select('==', event.my_int)"), {}
+    )
+
+    assert {
+        "SelectExpression": {
+            "lhs": {"Event": "my_list"},
+            "rhs": {
+                "operator": {"String": "=="},
+                "value": {"Integer": 42},
+            },
+        }
+    } == visit_condition(
+        parse_condition("event.my_list is select('==', vars.my_int)"),
+        dict(my_int=42),
+    )
+
+    assert {
+        "SelectAttrExpression": {
+            "lhs": {"Event": "persons"},
+            "rhs": {
+                "key": {"String": "person.age"},
+                "operator": {"String": ">"},
+                "value": {"Integer": 42},
+            },
+        }
+    } == visit_condition(
+        parse_condition(
+            "event.persons is selectattr('person.age', '>', vars.minimum_age)"
+        ),
+        dict(minimum_age=42),
+    )
+
 
 def test_invalid_select_operator():
     with pytest.raises(SelectOperatorException):


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-9324
Support identifiers in select and selectattr
upgraded to version 0.2.6 of drools_jpy