### PR TITLE
Add utils to deploy k8s + awx in docker/podman for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 # IDE settings
 .vscode/
 .idea/
+
+# awx provision
+tests/e2e/utils/awx/artifacts

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,3 +16,5 @@ pytest-vcr
 pytest-check
 dynaconf==3.1.11
 freezegun
+oauthlib>=3.2.0
+kubernetes

--- a/tests/e2e/utils/awx/ansible.cfg
+++ b/tests/e2e/utils/awx/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+# Disable warnings about localhost
+localhost_warning = False
+
+# Disable warnings about unparsed inventory
+[inventory]
+inventory_unparsed_warning = False

--- a/tests/e2e/utils/awx/create-cluster.yml
+++ b/tests/e2e/utils/awx/create-cluster.yml
@@ -1,0 +1,21 @@
+- name: Create kind cluster
+  hosts: localhost
+  connection: local
+  tasks:
+  - name: Create kind cluster
+    ansible.builtin.command:
+      cmd: kind create cluster --config kind-config.yml
+
+  - name: Deploy ingress controller
+    kubernetes.core.k8s:
+      apply: true
+      src: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+  - name: Wait for controller
+    kubernetes.core.k8s_info:
+      namespace: ingress-nginx
+      kind: pod
+      label_selectors:
+        - app.kubernetes.io/component=controller
+      wait: yes
+      wait_sleep: 1

--- a/tests/e2e/utils/awx/install-awx.yml
+++ b/tests/e2e/utils/awx/install-awx.yml
@@ -1,0 +1,27 @@
+---
+- name: Install AWX to Kubernetes Cluster
+  hosts: localhost
+  connection: local
+  roles:
+    - install-awx
+  tasks:
+    - name: Wait for controller
+      kubernetes.core.k8s_info:
+        namespace: ingress-nginx
+        kind: pod
+        label_selectors:
+          - app.kubernetes.io/component=controller
+        wait: yes
+        wait_sleep: 3
+
+    - name: Wait for http response
+      uri:
+        url: https://localhost:9443/api/v2/ping/
+        return_content: no
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 1
+      register: uri_output

--- a/tests/e2e/utils/awx/kind-config.yml
+++ b/tests/e2e/utils/awx/kind-config.yml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: awx-kind-cluster
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 9080
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 9443
+        protocol: TCP

--- a/tests/e2e/utils/awx/readme.md
+++ b/tests/e2e/utils/awx/readme.md
@@ -1,0 +1,38 @@
+# E2E test for AWX integration
+
+This subproject allows to run a k8s cluster for testing using kind and install AWX in it.
+Kind is a tool for running local k8s clusters using docker/podman containers as nodes.
+
+# Create a k8s cluster with kind
+
+Requirements:
+
+* docker/podman
+* ansible
+* kind <https://kind.sigs.k8s.io/docs/user/quick-start/#installation>
+* kubernetes ansible collection `ansible-galaxy collection install kubernetes.core`
+
+You may need to install the requirements with `pip install -r requirements.txt`
+if you are not using the ansible-rulebook dev environment.
+
+# Steps
+
+1. Create the cluster
+
+```
+ansible-playbook create-cluster.yml
+```
+
+2. Install AWX
+
+```
+ansible-playbook install-awx.yml
+```
+
+You should be able to reach awx in <https://localhost:9443> with admin/password
+
+# Cleanup
+
+```
+kind delete cluster -n awx-kind-cluster
+```

--- a/tests/e2e/utils/awx/requirements.txt
+++ b/tests/e2e/utils/awx/requirements.txt
@@ -1,0 +1,2 @@
+oauthlib>=3.2.0
+kubernetes

--- a/tests/e2e/utils/awx/roles/install-awx/defaults/main.yaml
+++ b/tests/e2e/utils/awx/roles/install-awx/defaults/main.yaml
@@ -1,0 +1,9 @@
+---
+awx_name: awx
+awx_image: quay.io/ansible/awx
+awx_image_tag: latest
+awx_operator_image: quay.io/ansible/awx-operator
+awx_operator_image_tag: "1.2.0"
+awx_namespace: awx
+awx_hostname: "localhost"
+awx_admin_password: password

--- a/tests/e2e/utils/awx/roles/install-awx/tasks/main.yaml
+++ b/tests/e2e/utils/awx/roles/install-awx/tasks/main.yaml
@@ -1,0 +1,46 @@
+---
+- name: Create Artifacts Directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - artifacts
+    - artifacts/{{ awx_hostname }}
+    - artifacts/{{ awx_hostname }}/kustomization
+
+- name: Create manifests from templates
+  ansible.builtin.template:
+    src: templates/{{ item }}.j2
+    dest: artifacts/{{ awx_hostname }}/{{ item }}
+  loop:
+    - awx.yaml
+    - kustomization/kustomization.yaml
+
+- name: Create Operator Deployment from kustomization
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('kubernetes.core.kustomize', dir='artifacts/'+awx_hostname+'/kustomization') }}"
+    wait: yes
+
+- name: Deploy admin password secret
+  kubernetes.core.k8s:
+    definition: "{{ lookup('template', 'admin-password-secret.yml.j2') }}"
+    state: present
+
+- name: Create AWX - {{ awx_hostname }}
+  kubernetes.core.k8s:
+    state: present
+    src: artifacts/{{ awx_hostname }}/awx.yaml
+    wait: yes
+    wait_condition:
+      type: Running
+      status: "True"
+
+- name: Wait for app
+  kubernetes.core.k8s_info:
+    namespace: "{{ awx_namespace }}"
+    kind: pod
+    label_selectors:
+      - app.kubernetes.io/component=awx
+    wait: yes
+    wait_sleep: 3

--- a/tests/e2e/utils/awx/roles/install-awx/templates/admin-password-secret.yml.j2
+++ b/tests/e2e/utils/awx/roles/install-awx/templates/admin-password-secret.yml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ awx_name }}-admin-password
+  namespace: {{ awx_namespace }}
+stringData:
+  password: {{ awx_admin_password }}

--- a/tests/e2e/utils/awx/roles/install-awx/templates/awx.yaml.j2
+++ b/tests/e2e/utils/awx/roles/install-awx/templates/awx.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: {{ awx_name }}
+  namespace: {{ awx_namespace }}
+spec:
+  hostname: {{ awx_hostname }}
+  image: {{ awx_image }}
+  image_version: {{ awx_image_tag }}
+  service_type: nodeport
+  ingress_type: ingress

--- a/tests/e2e/utils/awx/roles/install-awx/templates/kustomization/kustomization.yaml.j2
+++ b/tests/e2e/utils/awx/roles/install-awx/templates/kustomization/kustomization.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Find the latest tag here: https://github.com/ansible/awx-operator/releases
+  - github.com/ansible/awx-operator/config/default?ref={{ awx_operator_image_tag }}
+
+# Set the image tags to match the git version from above
+images:
+  - name: {{ awx_operator_image }}
+    newTag: {{ awx_operator_image_tag }}
+
+# Specify a custom namespace in which to install AWX
+namespace: {{ awx_namespace }}


### PR DESCRIPTION
Provides an easy, relatively fast way to deploy a cluster of k8s + awx for testing. This can be taken from other EDA projects that might require it as well. It's based on kind, a project from the kubernetes community to deploy a cluster for testing in docker, a requirement to run integration tests in Github Actions 

This follows the guide here: https://github.com/ansible/awx-operator/blob/devel/README.md

Closes AAP-10773