### PR TITLE
Fixed worker mode and activation id in parse args

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -145,7 +145,10 @@ def load_vars(parsed_args) -> Dict[str, str]:
 def load_rulebook(
     parsed_args: argparse.ArgumentParser, variables: Optional[Dict] = None
 ) -> List[RuleSet]:
-    if os.path.exists(parsed_args.rulebook):
+    if not parsed_args.rulebook:
+        logger.debug("Loading no rules")
+        return []
+    elif os.path.exists(parsed_args.rulebook):
         logger.debug(
             "Loading rules from the file system %s", parsed_args.rulebook
         )

--- a/tests/e2e/test_websocket.py
+++ b/tests/e2e/test_websocket.py
@@ -24,7 +24,7 @@ async def test_websocket_messages():
     # variables
     host = "localhost"
     endpoint = "/api/ws2"
-    proc_id = 42
+    proc_id = "42"
     port = 31415
     rulebook = (
         utils.BASE_DATA_PATH / "rulebooks/websockets/test_websocket_range.yml"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -66,17 +67,16 @@ def test_check_jvm_java_version(mock, mocked_version):
 
 
 def test_main_no_args():
-    with pytest.raises(SystemExit) as excinfo:
-        main([])
-        assert excinfo.value.code == 1
+    with patch.object(sys, "argv", ["ansible-rulebook"]):
+        with pytest.raises(SystemExit) as excinfo:
+            main([])
+            assert excinfo.value.code == 1
 
 
 all_args = [
     "-r",
     "rulebook.yml",
     "-vv",
-    "--id",
-    "12345",
     "--controller-url",
     "https://www.example.com",
     "--controller-token",
@@ -88,6 +88,7 @@ test_data = [
     (KeyboardInterrupt("Bail"), 0, ["-r", "rulebook.yml", "-v"], True),
     (Exception("Kaboom"), 1, ["-r", "rulebook.yml"], True),
     (None, 1, ["-r", "rulebook.yml", "--controller-url", "abc"], False),
+    (None, 0, ["-w", "--id", "123", "-W", "example.com"], True),
     (None, 0, all_args, True),
 ]
 
@@ -97,6 +98,20 @@ test_data = [
 def test_main_raise_exception(mock, ex, expected_rc, args, called):
     if ex:
         mock.side_effect = ex
-    rc = main(args)
-    assert mock.called == called
-    assert rc == expected_rc
+    with patch.object(sys, "argv", args):
+        rc = main(args)
+        assert mock.called == called
+        assert rc == expected_rc
+
+
+test_data = [
+    (["-r", "helloworld.yml", "-w"]),
+    (["-vv", "--id", "10"]),
+]
+
+
+@pytest.mark.parametrize("args", test_data)
+def test_main_invalid_args(args):
+    with patch.object(sys, "argv", args):
+        with pytest.raises(ValueError):
+            main(args)


### PR DESCRIPTION
In an earlier fix we had made -r a required parameter which breaks when used in worker mode. In worker mode there is no rulebook the rulebook comes in as a payload on the websocket channel.

Undoes the changes from PR #431

the --id parameter is a string since it can be a GUID. Previously it was an integer