### PR TITLE
Update e2e tests to increase coverage

### DIFF
--- a/tests/e2e/files/extra_vars/test_variables_extra_vars.yml
+++ b/tests/e2e/files/extra_vars/test_variables_extra_vars.yml
@@ -4,3 +4,4 @@ notify_police: true
 lockdown_enabled: true
 lockdown_threshold: 7.5
 zones: [1, 3, 5, 7, 11]
+intruder_status: null

--- a/tests/e2e/files/rulebooks/operators/test_logical_operators.yml
+++ b/tests/e2e/files/rulebooks/operators/test_logical_operators.yml
@@ -124,7 +124,14 @@
             device_type: "switch"
             tap_state: null
             span_state: "mirroring"
-
+          - id: "Testcase #9"
+            location: "new york"
+            link_state: "down"
+          - id: "Testcase #9"
+            location: "addis ababa"
+            link_state: "down"
+          - id: "Testcase #10"
+            ids_state: null
 
   rules:
     - name: "Testcase #1"
@@ -180,3 +187,26 @@
       action:
         debug:
           msg: "Testcase #08 passes"
+
+    - name: "Testcase #9"
+      condition:
+        all:
+          - events.ny << event.location == "new york"
+          - events.ab << event.location == "addis ababa"
+      action:
+        debug:
+          msg: >
+            Testcase #09 passes, output:
+            Status: {{ events.ny.location }} {{ events.ny.link_state }},
+            {{ events.ab.location }} {{ events.ab.link_state }}
+
+    - name: "Testcase #10"
+      condition:
+        any:
+          - events.status << event.ids_state == "disabled"
+          - events.status << event.ids_state == null
+      action:
+        debug:
+          msg: >
+            Testcase #10 passes, output:
+            IDS state: {{ events.status.ids_state }}

--- a/tests/e2e/files/rulebooks/variables/test_variables_sanity.yml
+++ b/tests/e2e/files/rulebooks/variables/test_variables_sanity.yml
@@ -12,6 +12,7 @@
             meta:
               lockdown_level: 9.0
               lockdown_zone: 5
+          - intruder_status: null
 
   rules:
     - name: "Intruder detected in {{ alarm_location }}"
@@ -27,17 +28,17 @@
               agent_name: "Maxwell Smart"
         - set_fact:
             fact:
-              agent_id: "86"
+              agent_id: "{{ E2E_AGENT_ID }}"
         - post_event:
             event:
-              notify_police: true
+              notify_police: "{{ notify_police }}"
         - run_playbook:
             name: ./playbooks/print_rule_name.yml
 
     - name: Notify agent 86
       condition:
         all:
-          - event.agent_id == vars.E2E_AGENT_ID
+          - event.agent_id == 86
           - event.agent_name == vars.E2E_AGENT_NAME
       action:
         debug:
@@ -46,7 +47,7 @@
             ID {{ E2E_AGENT_ID }}
 
     - name: Ping law enforcement
-      condition: event.notify_police == vars.notify_police
+      condition: event.notify_police == true
       action:
         debug:
           msg: "Notifying law enforcement"
@@ -60,3 +61,9 @@
       action:
         debug:
           msg: "Lockdown level {{ event.meta.lockdown_level }} initiated"
+
+    - name: Intruder neutralized
+      condition: event.intruder_status == vars.intruder_status
+      action:
+        debug:
+          msg: "Intruder neutralized"

--- a/tests/e2e/test_operators.py
+++ b/tests/e2e/test_operators.py
@@ -480,6 +480,17 @@ def test_logical_operators(update_environment):
     with check:
         assert "Testcase #08 passes" in result.stdout, "Testcase #8 failed"
 
+    with check:
+        assert (
+            "Testcase #09 passes, "
+            "output: Status: new york down, addis ababa down" in result.stdout
+        ), "Testcase #9 failed"
+
+    with check:
+        assert (
+            "Testcase #10 passes, output: IDS state: None" in result.stdout
+        ), "Testcase #10 failed"
+
 
 @pytest.mark.e2e
 def test_string_match():

--- a/tests/e2e/test_variables.py
+++ b/tests/e2e/test_variables.py
@@ -77,3 +77,8 @@ def test_variables_sanity(update_environment):
         assert (
             "Lockdown level 9.0 initiated" in result.stdout
         ), "Failure parsing multi-condition variables from file"
+
+    with check:
+        assert (
+            "Intruder neutralized" in result.stdout
+        ), "Failure parsing null value from variables file"


### PR DESCRIPTION
This PR adds coverage for some bugs that were ON_QA.

- AAP-9186: variable type not preserved in set_fact/post_event
- AAP-9325: variables file contains null
- AAP-6910: assignment condition with any/all condition