### PR TITLE
Fixes handling of activation payload from eda-server

### DIFF
--- a/ansible_rulebook/common.py
+++ b/ansible_rulebook/common.py
@@ -1,0 +1,29 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from ansible_rulebook.rule_types import RuleSet
+
+
+@dataclass
+class StartupArgs:
+    rulesets: List[RuleSet] = field(default_factory=list)
+    variables: Dict = field(default_factory=dict)
+    controller_url: str = field(default="")
+    controller_token: str = field(default="")
+    controller_ssl_verify: str = field(default="")
+    project_data_file: str = field(default="")
+    inventory: str = field(default="")

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -121,3 +121,8 @@ class SourcePluginMainMissingException(Exception):
 class SourcePluginNotAsyncioCompatibleException(Exception):
 
     pass
+
+
+class ControllerNeededException(Exception):
+
+    pass

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -18,7 +18,6 @@ import ansible_rulebook.rule_types as rt
 from ansible_rulebook.condition_parser import (
     parse_condition as parse_condition_value,
 )
-from ansible_rulebook.job_template_runner import job_template_runner
 from ansible_rulebook.util import substitute_variables
 
 from .exception import (
@@ -163,10 +162,6 @@ def parse_actions(rule: Dict) -> List[rt.Action]:
 
 def parse_action(action: Dict) -> rt.Action:
     action_name = list(action.keys())[0]
-    if action_name == "run_job_template":
-        if not job_template_runner.host or not job_template_runner.token:
-            raise Exception("No controller is configured to run job templates")
-
     if action[action_name]:
         action_args = {k: v for k, v in action[action_name].items()}
     else:


### PR DESCRIPTION
1. Handle EndOfResponse Message
2.  Removed Inventory from Payload
3. Make Project Data optional
4. Activation ID is a string
5. Share common args between worker mode and non worker mode
6. Fixed tests