### PR TITLE
Update tests to use default_startup_delay from config

### DIFF
--- a/tests/e2e/config/default.yml
+++ b/tests/e2e/config/default.yml
@@ -1,7 +1,8 @@
 default_event_delay: 1
 default_shutdown_after: 5
-default_startup_delay: 1
+default_startup_delay: 30
 operators_shutdown_after: 1
+shutdown_now_startup_delay: 1
 cmd_timeout: 25
 controller_url: http://localhost:8080
 controller_token: secret

--- a/tests/e2e/files/rulebooks/actions/test_run_playbook.yml
+++ b/tests/e2e/files/rulebooks/actions/test_run_playbook.yml
@@ -67,7 +67,7 @@
   hosts: all
   sources:
     - generic:
-        startup_delay: 30  # never start, only triggered by Ruleset 1
+        startup_delay: "{{ DEFAULT_STARTUP_DELAY }}"  # never start, only triggered by Ruleset 1
   rules:
     - name: Validate the set_facts from ruleset 1
       condition: >

--- a/tests/e2e/files/rulebooks/actions/test_shutdown_now.yml
+++ b/tests/e2e/files/rulebooks/actions/test_shutdown_now.yml
@@ -30,7 +30,7 @@
   hosts: all
   sources:
     - generic:
-        startup_delay: "{{ DEFAULT_STARTUP_DELAY }}"
+        startup_delay: "{{ SHUTDOWN_NOW_STARTUP_DELAY }}"
         payload:
           - action: "trigger_shutdown"
 

--- a/tests/e2e/files/rulebooks/test_disabled_rules.yml
+++ b/tests/e2e/files/rulebooks/test_disabled_rules.yml
@@ -42,7 +42,7 @@
   hosts: all
   sources:
     - generic:
-        startup_delay: 30  # never start, only triggered by Ruleset 1
+        startup_delay: "{{ DEFAULT_STARTUP_DELAY }}"  # never start, only triggered by Ruleset 1
 
   rules:
     - name: Disabled rule (from post_event)

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -17,6 +17,7 @@ DEFAULT_CMD_TIMEOUT = SETTINGS["cmd_timeout"]
 DEFAULT_SHUTDOWN_AFTER = SETTINGS["default_shutdown_after"]
 DEFAULT_EVENT_DELAY = SETTINGS["default_event_delay"]
 DEFAULT_STARTUP_DELAY = SETTINGS["default_startup_delay"]
+SHUTDOWN_NOW_STARTUP_DELAY = SETTINGS["shutdown_now_startup_delay"]
 
 
 @pytest.mark.e2e
@@ -161,10 +162,16 @@ def test_run_playbook(update_environment):
 
     rulebook = utils.BASE_DATA_PATH / "rulebooks/actions/test_run_playbook.yml"
     env = update_environment(
-        {"DEFAULT_SHUTDOWN_AFTER": str(DEFAULT_SHUTDOWN_AFTER)}
+        {
+            "DEFAULT_SHUTDOWN_AFTER": str(DEFAULT_SHUTDOWN_AFTER),
+            "DEFAULT_STARTUP_DELAY": str(DEFAULT_STARTUP_DELAY),
+        }
     )
 
-    cmd = utils.Command(rulebook=rulebook, envvars="DEFAULT_SHUTDOWN_AFTER")
+    cmd = utils.Command(
+        rulebook=rulebook,
+        envvars="DEFAULT_SHUTDOWN_AFTER,DEFAULT_STARTUP_DELAY",
+    )
 
     LOGGER.info(f"Running command: {cmd}")
     result = subprocess.run(
@@ -284,10 +291,12 @@ def test_shutdown_action_now(update_environment):
 
     rulebook = utils.BASE_DATA_PATH / "rulebooks/actions/test_shutdown_now.yml"
     env = update_environment(
-        {"DEFAULT_STARTUP_DELAY": str(DEFAULT_STARTUP_DELAY)}
+        {"SHUTDOWN_NOW_STARTUP_DELAY": str(SHUTDOWN_NOW_STARTUP_DELAY)}
     )
 
-    cmd = utils.Command(rulebook=rulebook, envvars="DEFAULT_STARTUP_DELAY")
+    cmd = utils.Command(
+        rulebook=rulebook, envvars="SHUTDOWN_NOW_STARTUP_DELAY"
+    )
 
     LOGGER.info(f"Running command: {cmd}")
     result = subprocess.run(

--- a/tests/e2e/test_runtime.py
+++ b/tests/e2e/test_runtime.py
@@ -14,6 +14,7 @@ from .settings import SETTINGS
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_CMD_TIMEOUT = SETTINGS["cmd_timeout"]
+DEFAULT_STARTUP_DELAY = SETTINGS["default_startup_delay"]
 
 
 @pytest.mark.e2e
@@ -76,14 +77,18 @@ def test_program_return_code(
 
 
 @pytest.mark.e2e
-def test_disabled_rules():
+def test_disabled_rules(update_environment):
     """
     Execute a rulebook that has disabled rules and
     ensure they do not execute
     """
 
     rulebook = utils.BASE_DATA_PATH / "rulebooks/test_disabled_rules.yml"
-    cmd = utils.Command(rulebook=rulebook)
+    env = update_environment(
+        {"DEFAULT_STARTUP_DELAY": str(DEFAULT_STARTUP_DELAY)}
+    )
+
+    cmd = utils.Command(rulebook=rulebook, envvars="DEFAULT_STARTUP_DELAY")
 
     LOGGER.info(f"Running command: {cmd}")
     result = subprocess.run(
@@ -92,6 +97,7 @@ def test_disabled_rules():
         capture_output=True,
         cwd=utils.BASE_DATA_PATH,
         text=True,
+        env=env,
     )
 
     with check:


### PR DESCRIPTION
Depends on #450 

- default_startup_delay set to 30 in the config
- Tests that use this value now take it from the config
- Previously value was only used by shutdown_now test which now has its own key