### PR TITLE
[AAP-10248] Fixed: Running jobs on controller

### DIFF
--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -120,7 +120,7 @@ class JobTemplateRunner:
                     counter = event["counter"]
                     if counter not in counters:
                         counters.append(counter)
-                        print(event["stdout"])
+                        logger.debug(event["stdout"])
                     if event_handler:
                         await event_handler(event)
 


### PR DESCRIPTION
1. If in debug mode we will log progress messages otherwise we only report the last status
    https://issues.redhat.com/browse/AAP-10248

2. Handles API errors when calling Controller (ControllerAPIException)
3. The run_at date time stamp is compatible with controller it uses the UTC iso8601 with micro seconds


We still would be fetching the job events every 10 seconds since we want to know when the job ends except they won't be sent to the aap server.