### PR TITLE
[AAP-10398] Use env var controller params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Support Jinja2 substitution in rule names
 - Support booleans in lists, which can contain mixed data types
 - Support for identifiers in select and selectattr
+- Support for controller url via env var EDA_CONTROLLER_URL
+- Support for controller token via env var EDA_CONTROLLER_TOKEN
+- Support for controller token ssl verify via env var EDA_CONTROLLER_SSL_VERIFY
 
 ### Fixed
 

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -111,17 +111,23 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--controller-url",
-        help="Controller API base url, e.g. https://host1:8080",
+        help="Controller API base url, e.g. https://host1:8080 can also be "
+        "passed via the env var EDA_CONTROLLER_URL",
+        default=os.environ.get("EDA_CONTROLLER_URL", ""),
     )
     parser.add_argument(
         "--controller-token",
-        help="Controller API authentication token",
+        help="Controller API authentication token, can also be passed "
+        "via env var EDA_CONTROLLER_TOKEN",
+        default=os.environ.get("EDA_CONTROLLER_TOKEN", ""),
     )
     parser.add_argument(
         "--controller-ssl-verify",
         help="How to verify SSL when connecting to the "
         "controller, yes|no|<path to a CA bundle>, "
-        "default to yes for https connection",
+        "default to yes for https connection."
+        "can also be passed via env var EDA_CONTROLLER_SSL_VERIFY",
+        default=os.environ.get("EDA_CONTROLLER_SSL_VERIFY", "yes"),
     )
     parser.add_argument(
         "--print-events",

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,11 +29,11 @@ The `ansible-rulebook` CLI supports the following options:
     -T PROJECT_TARBALL, --project-tarball PROJECT_TARBALL
                             A tarball of the project
     --controller-url CONTROLLER_URL
-                            Controller API base url, e.g. https://host1:8080
+                            Controller API base url, e.g. https://host1:8080, can also be passed in via env var EDA_CONTROLLER_URL
     --controller-token CONTROLLER_TOKEN
-                            Controller API authentication token
+                            Controller API authentication token, can also be passed in via env var EDA_CONTROLLER_TOKEN
     --controller-ssl-verify CONTROLLER_SSL_VERIFY
-                            How to verify SSL when connecting to the controller, yes|no|<path to a CA bundle>, default to yes for https connection
+                            How to verify SSL when connecting to the controller, yes|no|<path to a CA bundle>, default to yes for https connection. Can also be passed via env var EDA_CONTROLLER_SSL_VERIFY
     --print-events        Print events to stdout, redundant and disabled with -vv
     --shutdown-delay      Maximum number of seconds to wait after a graceful shutdown is issued, default is 60. Can also be set via an env var called EDA_SHUTDOWN_DELAY. The process will shutdown if all actions complete before this time period
 


### PR DESCRIPTION
The controller parameters can also be passed in via env var
* EDA_CONTROLLER_TOKEN
* EDA_CONTROLLER_URL
* EDA_CONTROLLER_SSL_VERIFY (default=yes)

https://issues.redhat.com/browse/AAP-10398