### PR TITLE
Fixed: inconsistent version of dpath

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
 	pyparsing >= 3.0
 	jsonschema
 	jinja2
-	dpath
+	dpath >= 2.1.4
 	janus
 	ansible-runner
 	websockets


### PR DESCRIPTION
ansible-rulebook needs dpath at version 2.1.4 or above otherwise it fails with the dpath.get error