### PR TITLE
[AAP-10253] Use plural form for filters and sources

### DIFF
--- a/ansible_rulebook/collection.py
+++ b/ansible_rulebook/collection.py
@@ -107,7 +107,7 @@ def has_source(collection, source):
     return has_object(
         collection,
         source,
-        [f"{EDA_PATH_PREFIX}/plugins/event_source", "plugins/event_source"],
+        [f"{EDA_PATH_PREFIX}/plugins/event_sources", "plugins/event_source"],
         ".py",
     )
 
@@ -116,7 +116,7 @@ def find_source(collection, source):
     return find_object(
         collection,
         source,
-        [f"{EDA_PATH_PREFIX}/plugins/event_source", "plugins/event_source"],
+        [f"{EDA_PATH_PREFIX}/plugins/event_sources", "plugins/event_source"],
         ".py",
     )
 
@@ -125,7 +125,7 @@ def has_source_filter(collection, source_filter):
     return has_object(
         collection,
         source_filter,
-        [f"{EDA_PATH_PREFIX}/plugins/event_filter", "plugins/event_filter"],
+        [f"{EDA_PATH_PREFIX}/plugins/event_filters", "plugins/event_filter"],
         ".py",
     )
 
@@ -134,7 +134,7 @@ def find_source_filter(collection, source_filter):
     return find_object(
         collection,
         source_filter,
-        [f"{EDA_PATH_PREFIX}/plugins/event_filter", "plugins/event_filter"],
+        [f"{EDA_PATH_PREFIX}/plugins/event_filters", "plugins/event_filter"],
         ".py",
     )
 


### PR DESCRIPTION
In the new ansible.eda collection the
* event_source is called event_sources
* event_filter is called event_filters

Collection PR https://github.com/ansible/event-driven-ansible/pull/108

This PR still says backeard compatible with the old layout.

The singluar form changes were made in https://github.com/ansible/ansible-rulebook/pull/458