### PR TITLE
Fix intermittent test failures

### DIFF
--- a/tests/examples/57_once_after_multi.yml
+++ b/tests/examples/57_once_after_multi.yml
@@ -4,7 +4,7 @@
   sources:
     - generic:
         loop_count: 3
-        loop_delay: 15
+        loop_delay: 18
         shutdown_after: 60
         timestamp: true
         create_index: event_index


### PR DESCRIPTION
In the once_after testcase I had the event burst every 15 seconds and the time window was also 15 seconds so once in a while the new event burst would get caught in the earlier time window and get suppressed. Now I have changed the loop delay to 18 seconds so the event burst happens after 18 seconds.