### PR TITLE
[AAP-11110] Added status for internal actions

### DIFF
--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 tar = shutil.which("tar")
 
 KEY_EDA_VARS = "ansible_eda"
+INTERNAL_ACTION_STATUS = "successful"
 
 
 async def none(
@@ -77,6 +78,7 @@ async def none(
             rule_uuid=source_rule_uuid,
             activation_id=settings.identifier,
             run_at=_run_at(),
+            status=INTERNAL_ACTION_STATUS,
             matching_events=_get_events(variables),
         )
     )
@@ -117,6 +119,7 @@ async def debug(event_log, **kwargs):
             rule_uuid=kwargs.get("source_rule_uuid"),
             activation_id=settings.identifier,
             run_at=_run_at(),
+            status=INTERNAL_ACTION_STATUS,
             matching_events=_get_events(kwargs.get("variables")),
         )
     )
@@ -156,6 +159,7 @@ async def print_event(
             rule_uuid=source_rule_uuid,
             playbook_name=name,
             run_at=_run_at(),
+            status=INTERNAL_ACTION_STATUS,
             matching_events=_get_events(variables),
         )
     )
@@ -189,6 +193,7 @@ async def set_fact(
             rule_uuid=source_rule_uuid,
             playbook_name=name,
             run_at=_run_at(),
+            status=INTERNAL_ACTION_STATUS,
             matching_events=_get_events(variables),
         )
     )
@@ -221,6 +226,7 @@ async def retract_fact(
             activation_id=settings.identifier,
             playbook_name=name,
             run_at=_run_at(),
+            status=INTERNAL_ACTION_STATUS,
             matching_events=_get_events(variables),
         )
     )
@@ -252,6 +258,7 @@ async def post_event(
             rule_uuid=source_rule_uuid,
             activation_id=settings.identifier,
             run_at=_run_at(),
+            status=INTERNAL_ACTION_STATUS,
             matching_events=_get_events(variables),
         )
     )
@@ -854,6 +861,7 @@ async def shutdown(
             rule=source_rule_name,
             rule_uuid=source_rule_uuid,
             run_at=_run_at(),
+            status=INTERNAL_ACTION_STATUS,
             matching_events=_get_events(variables),
             delay=delay,
             message=message,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -68,6 +68,7 @@ async def test_01_noop():
     assert event["action"] == "noop", "2"
     assert event["action_uuid"] == DUMMY_UUID
     assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
+    assert event["status"] == "successful"
     assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
     assert event["matching_events"] == {"m": {"i": 1}}, "3"
     event = event_log.get_nowait()
@@ -95,6 +96,7 @@ async def test_02_debug():
     assert event["type"] == "Action", "1"
     assert event["action"] == "debug", "2"
     assert event["action_uuid"] == DUMMY_UUID
+    assert event["status"] == "successful"
     assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
     assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
     assert event["matching_events"] == {"m": {"i": 1}}, "3"
@@ -123,6 +125,7 @@ async def test_03_print_event():
     assert event["type"] == "Action", "1"
     assert event["action"] == "print_event", "2"
     assert event["action_uuid"] == DUMMY_UUID
+    assert event["status"] == "successful"
     assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
     assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
     assert event["matching_events"] == {"m": {"i": 1}}, "3"
@@ -151,6 +154,7 @@ async def test_04_set_fact():
     assert event["type"] == "Action", "1"
     assert event["action"] == "set_fact", "2"
     assert event["action_uuid"] == DUMMY_UUID
+    assert event["status"] == "successful"
     assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
     assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
     assert event["matching_events"] == {"m": {"i": 1}}, "3"
@@ -182,6 +186,7 @@ async def test_05_post_event():
     assert event["type"] == "Action", "1"
     assert event["action"] == "post_event", "2"
     assert event["action_uuid"] == DUMMY_UUID
+    assert event["status"] == "successful"
     assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
     assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
     assert event["matching_events"] == {"m": {"i": 1}}, "3"
@@ -214,6 +219,7 @@ async def test_06_retract_fact():
     assert event["type"] == "Action", "1"
     assert event["action"] == "set_fact", "2"
     assert event["action_uuid"] == DUMMY_UUID
+    assert event["status"] == "successful"
     assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
     assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
     assert event["matching_events"] == {"m": {"i": 1}}, "3"
@@ -1047,6 +1053,7 @@ async def test_38_shutdown_action():
         assert event["type"] == "Action", "1"
         assert event["action"] == "shutdown", "1"
         assert event["action_uuid"] == DUMMY_UUID
+        assert event["status"] == "successful"
         assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
         assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
         assert event["message"] == "My rule has triggered a shutdown"


### PR DESCRIPTION
We were setting the status only for external actions like
 * run_playbook
 * run_module
 * run_job_template

Now we have started setting the stats for internal actions like
 * none
 * debug
 * print_event
 * set_fact
 * post_event
 * retract_fact
 * shutdown

Once the internal action is executed successfully we set the status to successful

https://issues.redhat.com/browse/AAP-11110