### PR TITLE
Fix ansible-galaxy temp directory when running in openshift.

### DIFF
--- a/ansible_rulebook/collection.py
+++ b/ansible_rulebook/collection.py
@@ -12,11 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
 import os
 import shutil
 import subprocess
 from functools import lru_cache
-import logging
 
 import yaml
 
@@ -47,9 +47,12 @@ def find_collection(name):
     if ANSIBLE_GALAXY is None:
         raise Exception("ansible-galaxy is not installed")
     try:
+        env = os.environ.copy()
+        env["ANSIBLE_LOCAL_TEMP"] = "/tmp"
         output = subprocess.check_output(
             [ANSIBLE_GALAXY, "collection", "list", name],
             stderr=subprocess.STDOUT,
+            env=env,
         )
     except subprocess.CalledProcessError as e:
         logger.error("Error listing collections: %s", e.output)

--- a/ansible_rulebook/collection.py
+++ b/ansible_rulebook/collection.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 from functools import lru_cache
+import logging
 
 import yaml
 
@@ -33,6 +34,7 @@ EDA_SOURCE_PATHS = [
     f"{EDA_PATH_PREFIX}/plugins/event_sources",
     "plugins/event_source",
 ]
+logger = logging.getLogger(__name__)
 
 
 def split_collection_name(collection_resource):
@@ -49,7 +51,8 @@ def find_collection(name):
             [ANSIBLE_GALAXY, "collection", "list", name],
             stderr=subprocess.STDOUT,
         )
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as e:
+        logger.error("Error listing collections: %s", e.output)
         return None
     output = output.decode()
     parts = name.split(".")


### PR DESCRIPTION
ansible-galaxy fails in openshift because of the user-changing security scheme because it tries to make a temporary file in a directory that is write protected.  This is a fix to get ansible-galaxy working in openshift by writing the temp files to /tmp.