### PR TITLE
Added rule_run_at to group multiple actions in a single rule

### DIFF
--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import tempfile
 import typing
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import ansible_runner
@@ -223,6 +224,10 @@ def find_builtin_filter(name: str) -> Optional[str]:
     if found:
         return path
     return None
+
+
+def run_at() -> str:
+    return f"{datetime.now(timezone.utc).isoformat()}".replace("+00:00", "Z")
 
 
 def _builtin_filter_path(name: str) -> Tuple[bool, str]:

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -177,7 +177,7 @@ def test_actions_sanity(update_environment):
         ), "multiple_action action failed"
 
     assert (
-        len(result.stdout.splitlines()) == 58
+        len(result.stdout.splitlines()) == 59
     ), "unexpected output from the rulebook"
 
 


### PR DESCRIPTION
A single rule can fire multiple actions, when these actions are sent to the aap-server, it doesn't know if the rule has 1 action or more than 1 actions. The rule_run_at allows us to group all the actions into a single rule. This also helps on the server side since we are capturing when the rule engine, Drools tells us that a rule has matched and we should fire the actions. 