### PR TITLE
Update e2e tests to use scientific notation

### DIFF
--- a/tests/e2e/files/extra_vars/operator_variables.yml
+++ b/tests/e2e/files/extra_vars/operator_variables.yml
@@ -46,7 +46,7 @@ pluto_moons: 5
 eris_moon: "dysnomia"
 total_moons:
   - 50
-  - 62
+  - 6.2e+1
   - 79.99
 best_moons:
   - "deimos"

--- a/tests/e2e/files/rulebooks/operators/test_membership_operators.yml
+++ b/tests/e2e/files/rulebooks/operators/test_membership_operators.yml
@@ -84,7 +84,7 @@
           - id: "Testcase #10"
             value: 4
           - id: "Testcase #10"
-            value: 2.7182
+            value: 2.7182e+0
           - id: "Testcase #10"
             value: -6000
           - id: "Testcase #10"
@@ -181,7 +181,7 @@
           msg: "Output for Testcase #07"
 
     - name: "Testcase #8"
-      condition: event.some_numbers not contains -6000
+      condition: event.some_numbers not contains -6e3
       action:
         debug:
           msg: "Output for Testcase #08"
@@ -199,7 +199,7 @@
           msg: "Output for Testcase #10"
 
     - name: "Testcase #11-1"
-      condition: events.mylist contains "jon" or events.mylist contains 45
+      condition: events.mylist contains "jon" or events.mylist contains 4.5e+1
       action:
         debug:
           msg: "Output for Testcase #11"

--- a/tests/e2e/files/rulebooks/operators/test_select_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_select_operator.yml
@@ -75,7 +75,7 @@
       condition: >
         event.type is select("match", "comet") and
         event.radius is select("<=", 3) and
-        event.orbital_period is select(">=", 2020)
+        event.orbital_period is select(">=", 2.02e+3)
       action:
         debug:
           msg: "Output for testcase #03"

--- a/tests/e2e/files/rulebooks/operators/test_selectattr_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_selectattr_operator.yml
@@ -28,7 +28,7 @@
               - planet:
                   name: "jupiter"
                   radius: 142984
-                  orbital_period: 4311.86
+                  orbital_period: 4.31186e+3
           - id: "testcase 03"
             planets:
               - planet:
@@ -104,6 +104,15 @@
                         gases:
                           hydrogen: 73.46
                           helium: 24.85
+          - id: "testcase 11"
+            spacecraft:
+              - craft:
+                  name: "voyager 1"
+                  detections:
+                    - 15
+                    - 8121.99
+                    - 1111
+
 
   rules:
     - name: Single condition selectattr, case insensitive
@@ -151,7 +160,7 @@
     - name: Multi condition selectattr with negation and vars
       condition: >
         event.planets is not selectattr("planet.is_planet", "==", true) and
-        event.planets is selectattr("planet.radius", ">=", vars.pluto_radius) and
+        event.planets is selectattr("planet.radius", ">=", 1.18830e+3) and
         (event.planets is selectattr("planet.total_moons", "!=", null) or
         event.planets is not selectattr("planet.total_moons", ">", vars.pluto_moons))
       action:
@@ -198,3 +207,9 @@
       action:
         debug:
           msg: "Output for testcase #10"
+
+    - name: Single condition selectattr nested list contains number
+      condition: event.spacecraft is selectattr("craft.detections", "contains", 8.12199e+3)
+      action:
+        debug:
+          msg: "Output for testcase #11"

--- a/tests/e2e/test_operators.py
+++ b/tests/e2e/test_operators.py
@@ -773,3 +773,15 @@ def test_selectattr_operator():
         assert (
             "Output for testcase #10" in result.stdout
         ), "testcase #10 failed"
+
+    with check:
+        assert (
+            len(
+                [
+                    line
+                    for line in result.stdout.splitlines()
+                    if "Output for testcase #11" in line
+                ]
+            )
+            == 1
+        ), "testcase #11 failed"


### PR DESCRIPTION
Extending test cases to cover scientific notation. Closes [AAP-9362](https://issues.redhat.com/browse/AAP-9362).