### PR TITLE
[AAP-11350] Added support for default_events_ttl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Added
+- Support for default_events_ttl at ruleset level and globally
 
 ### Fixed
 

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -297,16 +297,19 @@ def generate_condition(ansible_condition: RuleCondition, variables: Dict):
 
 def visit_ruleset(ruleset: RuleSet, variables: Dict):
     """Generate JSON compatible rules."""
-    return {
-        "RuleSet": {
-            "name": ruleset.name,
-            "hosts": ruleset.hosts,
-            "sources": [
-                visit_source(source, variables) for source in ruleset.sources
-            ],
-            "rules": [visit_rule(rule, variables) for rule in ruleset.rules],
-        }
+    data = {
+        "name": ruleset.name,
+        "hosts": ruleset.hosts,
+        "sources": [
+            visit_source(source, variables) for source in ruleset.sources
+        ],
+        "rules": [visit_rule(rule, variables) for rule in ruleset.rules],
     }
+
+    if ruleset.default_events_ttl:
+        data["default_events_ttl"] = ruleset.default_events_ttl
+
+    return {"RuleSet": data}
 
 
 def generate_dict_rulesets(ruleset: List[RuleSet], variables: Dict):

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -70,6 +70,7 @@ class RuleSet(NamedTuple):
     rules: List[Rule]
     gather_facts: bool
     uuid: Optional[str] = None
+    default_events_ttl: Optional[str] = None
 
 
 class ActionContext(NamedTuple):

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -72,6 +72,7 @@ def parse_rule_sets(
                 rules=parse_rules(rule_set.get("rules", {}), variables),
                 gather_facts=rule_set.get("gather_facts", False),
                 uuid=str(uuid.uuid4()),
+                default_events_ttl=rule_set.get("default_events_ttl", None),
             )
         )
     return rule_set_list

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -14,6 +14,10 @@
         "ruleset": {
             "type": "object",
             "properties": {
+                "default_events_ttl": {
+                    "type": "string",
+                    "pattern": "^\\d+\\s(seconds?|minutes?|hours?|days?)$"
+                },
                 "hosts": {
                     "type": "string"
                 },

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -531,7 +531,8 @@ Adding time constraints for rules with multiple conditions
 | conditions to be satisfied.
 | The timeout units are **milliseconds**, **seconds**, **minutes**, **hours**, **days**.
 | If the conditions are not met within 10 seconds in the above example the rule will be skipped.
-| The timer for the rule starts when any one of the conditions match.
+| The timer for the rule starts when any one of the conditions match. This timeout field overrides
+| any default_events_ttl that you have set at the ruleset level.
 
 
 Adding time constraints for rules when "not all" conditions matched

--- a/docs/rulebooks.rst
+++ b/docs/rulebooks.rst
@@ -15,6 +15,7 @@ A ruleset has the following properties:
 * name
 * hosts similar to Ansible playbook
 * gather_facts: boolean
+* default_events_ttl: time to keep the partially matched events around (default is 2 hours)
 * sources: A list of sources
 * rules: a list of rules
 
@@ -22,6 +23,12 @@ A ruleset has the following properties:
 | as a separate session in the Rules engine. The events and facts are kept separate
 | for each ruleset. At runtime, using **action** a ruleset can post events or facts
 | to itself or other rulesets in the rulebook.
+
+| The default_events_ttl takes time in the following format
+| default_events_ttl : nnn seconds|minutes|hours|days
+| e.g. default_events_ttl : 3 hours
+| If the rule set doesn't define this attribute the default events ttl that is 
+| enforced by the rule engine is 2 hours
 
 | When we start a rulebook we can optionally collect artifacts from the different hosts
 | if **gather_facts** is set to **true**. This host data is then uploaded to the Rules

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.3.0
+	drools_jpy == 0.3.1
 
 [options.packages.find]
 include = 

--- a/tests/examples/77_default_events_ttl.yml
+++ b/tests/examples/77_default_events_ttl.yml
@@ -1,0 +1,25 @@
+---
+- name: 77 default events ttl
+  hosts: all
+  default_events_ttl: 2 seconds
+  sources:
+     - generic:
+          event_delay: 4
+          payload:
+            - i: 1
+            - j: 2
+            - k: 3
+  rules:
+     - name: r1
+       condition:
+         all:
+           - event.i == 1
+           - event.j == 2
+       action:
+         print_event:
+           pretty: true
+     - name: r2
+       condition: event.k == 3
+       action:
+         print_event:
+           pretty: true

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2102,3 +2102,29 @@ async def test_46_job_template():
 
             assert action["url"] == job_url
             assert action["action"] == "run_job_template"
+
+
+@pytest.mark.asyncio
+async def test_77_default_events_ttl():
+    ruleset_queues, event_log = load_rulebook(
+        "examples/77_default_events_ttl.yml"
+    )
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    with SourceTask(rs.sources[0], "sources", {}, queue):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            dict(),
+            load_inventory("playbooks/inventory.yml"),
+        )
+
+        checks = {
+            "max_events": 2,
+            "shutdown_events": 1,
+            "actions": [
+                "77 default events ttl::r2::print_event",
+            ],
+        }
+        validate_events(event_log, **checks)


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-11350

The Drools default_events_ttl is 2 hours.
Each ruleset can specify its own value and it can
also be overridden at the individual rule level