### PR TITLE
[AAP-11337] Send heartbeat on web socket channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Added
+- Sending heartbeat to the server with the session stats
 
 ### Fixed
 

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -157,6 +157,13 @@ def get_parser() -> argparse.ArgumentParser:
         help="Run the garbage collector after this number of events. "
         "It can be configured with the environment variable EDA_GC_AFTER",
     )
+    parser.add_argument(
+        "--heartbeat",
+        default=0,
+        type=int,
+        help="Send heartbeat to the server after every n seconds"
+        "Default is 0, no heartbeat is sent",
+    )
     return parser
 
 

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -36,7 +36,11 @@ from ansible_rulebook.rule_types import (
     EngineRuleSetQueuePlan,
 )
 from ansible_rulebook.rules_parser import parse_hosts
-from ansible_rulebook.util import run_at, substitute_variables
+from ansible_rulebook.util import (
+    run_at,
+    send_session_stats,
+    substitute_variables,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +131,8 @@ class RuleSetRunner:
                 )
             )
         stats = lang.end_session(self.name)
+        if self.parsed_args and self.parsed_args.heartbeat > 0:
+            await send_session_stats(self.event_log, stats)
         logger.info(pformat(stats))
 
     async def _handle_shutdown(self):

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import asyncio
 import glob
 import json
 import logging
@@ -31,6 +32,7 @@ from jinja2.nativetypes import NativeTemplate
 from packaging import version
 from packaging.version import InvalidVersion
 
+from ansible_rulebook.conf import settings
 from ansible_rulebook.exception import InvalidFilterNameException
 
 logger = logging.getLogger(__name__)
@@ -228,6 +230,17 @@ def find_builtin_filter(name: str) -> Optional[str]:
 
 def run_at() -> str:
     return f"{datetime.now(timezone.utc).isoformat()}".replace("+00:00", "Z")
+
+
+async def send_session_stats(event_log: asyncio.Queue, stats: Dict):
+    await event_log.put(
+        dict(
+            type="SessionStats",
+            activation_id=settings.identifier,
+            stats=stats,
+            reported_at=run_at(),
+        )
+    )
 
 
 def _builtin_filter_path(name: str) -> Tuple[bool, str]:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -40,6 +40,7 @@ The `ansible-rulebook` CLI supports the following options:
     --print-events        Print events to stdout, redundant and disabled with -vv
     --shutdown-delay      Maximum number of seconds to wait after a graceful shutdown is issued, default is 60. Can also be set via an env var called EDA_SHUTDOWN_DELAY. The process will shutdown if all actions complete before this time period
 
+    --heartbeat <n> Send heartbeat to the server after every n seconds. Default is 0, no heartbeat is sent
 
 To get help from `ansible-rulebook` run the following:
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -35,6 +35,7 @@ class Command:
     project_tarball: Optional[Path] = None
     worker_mode: bool = False
     verbosity: int = 0
+    heartbeat: int = 0
 
     def __post_init__(self):
         # verbosity overrides verbose and debug
@@ -77,6 +78,8 @@ class Command:
             result.append("-vv")
         if self.verbosity > 0:
             result.append(f"-{'v'*self.verbosity}")
+        if self.heartbeat > 0:
+            result.extend(["--heartbeat", str(self.heartbeat)])
 
         return result
 


### PR DESCRIPTION
If ansible-rulebook is invoked with --heartbeat nn, where nn is the seconds to wait between sending heartbeat, it will send session stats about all running ruleset sessions. This allows the server to monitor if the ansible-rulebook is responsive.

The payload coming in has the following structure
```
{'type': 'SessionStats', 
'activation_id': '42',
'stats': {'start': '2023-04-25T17:02:03.736195Z', 'end': '2023-04-25T17:02:04.856004Z', 'numberOfRules': 1, 'numberOfDisabledRules': 0, 'rulesTriggered': 1, 'eventsProcessed': 2000, 'eventsMatched': 1, 'eventsSuppressed': 1999, 'permanentStorageSize': 0, 'asyncResponses': 0, 'bytesSentOnAsync': 0, 'sessionId': 1, 'ruleSetName': 'Test websocket range events'}, 
'reported_at': '2023-04-25T17:02:04.857362Z'}

```
The end is sent only when the ruleset session has ended

The stats can be used to update the stats in this screen
<img width="1228" alt="Screenshot 2023-04-25 at 3 35 49 PM" src="https://user-images.githubusercontent.com/6452699/234385163-71c3ab42-b09d-4369-83ac-0d08f547b788.png">
