### PR TITLE
fix invalid yaml in doc

### DIFF
--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -195,15 +195,15 @@ Multiple conditions where **all** of them have to match with internal references
               - request:
                   type: Delete
                   friend_name: fred
-      rules:
-        - name: r1
-          condition:
-            all:
-              - event.request.type == "Delete"
-              - event.friend_list.names is select("search",  events.m_0.request.friend_name)
-          action:
-            print_event:
-              pretty: true
+        rules:
+          - name: r1
+            condition:
+              all:
+                - event.request.type == "Delete"
+                - event.friend_list.names is select("search",  events.m_0.request.friend_name)
+            action:
+              print_event:
+                pretty: true
 
 
 


### PR DESCRIPTION
wrong indentation in yaml snippet in doc would make it fail to be valid yaml.

Current doc:

![image](https://user-images.githubusercontent.com/1699252/234775531-3b4d5b07-15d5-4d5c-9c04-0d3d1236da73.png)

After this change:

![image](https://user-images.githubusercontent.com/1699252/234775654-501e2333-f605-43cd-ae37-7d9786ad7b5c.png)
