### PR TITLE
[AAP-11677] Fixes web socket connection issues

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -42,6 +42,7 @@ from .exception import (
     ControllerNeededException,
     InventoryNeededException,
     RulebookNotFoundException,
+    WebSocketExchangeException,
 )
 
 
@@ -67,6 +68,11 @@ async def run(parsed_args: argparse.ArgumentParser) -> None:
             parsed_args.websocket_address,
             parsed_args.websocket_ssl_verify,
         )
+        if not startup_args:
+            logger.error("Error communicating with web socket server")
+            raise WebSocketExchangeException(
+                "Error communicating with web socket server"
+            )
     else:
         startup_args = StartupArgs()
         startup_args.variables = load_vars(parsed_args)

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -136,3 +136,8 @@ class InvalidFilterNameException(Exception):
 class JobTemplateNotFoundException(Exception):
 
     pass
+
+
+class WebSocketExchangeException(Exception):
+
+    pass


### PR DESCRIPTION
Due to recent changes in the backend, the web socket connection is closed prematurely from the server side leading to a misleading error on the ansible-rulebook side.
With this PR we are logging an error and adding an exception to help the user understand where the issue is.

https://issues.redhat.com/browse/AAP-11677