### PR TITLE
doc updage debug: action to comply with schema

### DIFF
--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -429,9 +429,10 @@ You can optionally alias these attribute(s) using the **<<** operator. For examp
             - events.third << event.i == events.first.i + 2
         action:
           debug:
-            first: "{{ events.first }}"
-            second: "{{ events.second }}"
-            third: "{{ events.third }}"
+            msg:
+              - "first: {{ events.first }}"
+              - "second: {{ events.second }}"
+              - "third: {{ events.third }}"
 
 | When using the assignment operator the attribute names should have the
 | **events.** or **facts.** prefix. In the above example we are saving the
@@ -452,9 +453,10 @@ You can optionally alias these attribute(s) using the **<<** operator. For examp
             - event.i == events.m_0.i + 2
         action:
           debug:
-            first: "{{ events.m_0 }}"
-            second: "{{ events.m_1 }}"
-            third: "{{ events.m_2 }}"
+            msg:
+              - "first: {{ events.m_0 }}"
+              - "second: {{ events.m_1 }}"
+              - "third: {{ events.m_2 }}"
 
 Multiple condition with default assignments
 -------------------------------------------
@@ -469,9 +471,10 @@ Multiple condition with default assignments
             - event.i == events.m.i + 3
         action:
           debug:
-            first: "{{events.m}}"
-            second: "{{events.m_1}}"
-            third: "{{events.m_2}}"
+            msg:
+              - "first: {{ events.m_0 }}"
+              - "second: {{ events.m_1 }}"
+              - "third: {{ events.m_2 }}"
 
 The first match is stored as **m**, and the subsequent ones are stored as **m_1**, **m_2** ...
 
@@ -484,7 +487,8 @@ Single condition assignment (Not supported)
         condition: event.first << event.i == 0
         action:
           debug:
-            event: "{{event}}"
+            msg:
+              - "event: {{event}}"
 
 | Assignment **cannot** be used for rules that have a single condition, the
 | matching event will always be called **event**. In the above example **event.first**


### PR DESCRIPTION
According to my understanding, the `debug:` action schema is defined to accept only `msg` or `var`.

Per the schema:

https://github.com/ansible/ansible-rulebook/blob/5c57c8a59be6a0d9410e06352bfe28dba9d33a76/ansible_rulebook/schema/ruleset_schema.json#L567-L588

Per the `debug:` action doc: 

https://github.com/ansible/ansible-rulebook/blob/5c57c8a59be6a0d9410e06352bfe28dba9d33a76/docs/actions.rst?plain=1#L373-L378

Thus making these changed snippet in the same documentation, invalid.

I'm therefore suggesting correcting the example snippets in the documentation in this PR, according to the schema: