### PR TITLE
Do not place the whole exception object in event_log

### DIFF
--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -38,6 +38,7 @@ from .conf import settings
 from .event_filter.insert_meta_info import main as insert_meta
 from .exception import (
     ControllerApiException,
+    JobTemplateNotFoundException,
     PlaybookNotFoundException,
     PlaybookStatusNotFoundException,
     ShutdownException,
@@ -813,32 +814,34 @@ async def run_job_template(
             )
             if controller_job["status"] != "failed":
                 break
-    except ControllerApiException as ex:
+    except (ControllerApiException, JobTemplateNotFoundException) as ex:
         logger.error(ex)
         controller_job = {}
         controller_job["status"] = "failed"
         controller_job["created"] = run_at()
+        controller_job["error"] = str(ex)
 
-    await event_log.put(
-        dict(
-            type="Action",
-            action="run_job_template",
-            action_uuid=str(uuid.uuid4()),
-            activation_id=settings.identifier,
-            job_template_name=name,
-            organization=organization,
-            job_id=job_id,
-            ruleset=ruleset,
-            ruleset_uuid=source_ruleset_uuid,
-            rule=source_rule_name,
-            rule_uuid=source_rule_uuid,
-            status=controller_job["status"],
-            run_at=controller_job["created"],
-            url=_controller_job_url(controller_job),
-            matching_events=_get_events(variables),
-            rule_run_at=rule_run_at,
-        )
+    a_log = dict(
+        type="Action",
+        action="run_job_template",
+        action_uuid=str(uuid.uuid4()),
+        activation_id=settings.identifier,
+        job_template_name=name,
+        organization=organization,
+        job_id=job_id,
+        ruleset=ruleset,
+        ruleset_uuid=source_ruleset_uuid,
+        rule=source_rule_name,
+        rule_uuid=source_rule_uuid,
+        status=controller_job["status"],
+        run_at=controller_job["created"],
+        url=_controller_job_url(controller_job),
+        matching_events=_get_events(variables),
+        rule_run_at=rule_run_at,
     )
+    if "error" in controller_job:
+        a_log["reason"] = dict(error=controller_job["error"])
+    await event_log.put(a_log)
 
     if set_facts or post_events:
         logger.debug("set_facts")

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -141,3 +141,8 @@ class JobTemplateNotFoundException(Exception):
 class WebSocketExchangeException(Exception):
 
     pass
+
+
+class UnsupportedActionException(Exception):
+
+    pass


### PR DESCRIPTION
Exception object cannot be serialized and sent through websocket. Catch JobTemplateNotFoundException explicitly

Fixes AAP-11969: ansible-rulebook worker mode fails to handle JobTemplateNotFoundException