### PR TITLE
Temporarily pin urllib3 version to fix failing tests

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -18,3 +18,4 @@ dynaconf==3.1.11
 freezegun
 oauthlib>=3.2.0
 kubernetes
+urllib3<2


### PR DESCRIPTION
Tests are currently failing due to https://github.com/kevin1024/vcrpy/issues/688. This PR temporarily pins the urllib3 version to <2 until there is a new release of vcrpy.