### PR TITLE
Enhance JobTemplateNotFoundException error message

### DIFF
--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -106,7 +106,10 @@ class JobTemplateRunner:
                     break
 
         raise JobTemplateNotFoundException(
-            f"Job template {name} in organization {organization} does not exist"  # noqa: E501
+            (
+                f"Job template {name} in organization "
+                f"{organization} does not exist"
+            )
         )
 
     async def run_job_template(

--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -106,7 +106,7 @@ class JobTemplateRunner:
                     break
 
         raise JobTemplateNotFoundException(
-            f"{name} in organization {organization}"
+            f"Job template {name} in organization {organization} does not exist"  # noqa: E501
         )
 
     async def run_job_template(


### PR DESCRIPTION
Fixes AAP-12047: It is not clear when a run_job_template fails due to wrong JT name