### PR TITLE
[AAP-11904] Added execution-strategy command line option to prevent overloading controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - Sending heartbeat to the server with the session stats
+- Added command line option --execution-strategy
 
 ### Fixed
 

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -164,6 +164,14 @@ def get_parser() -> argparse.ArgumentParser:
         help="Send heartbeat to the server after every n seconds"
         "Default is 0, no heartbeat is sent",
     )
+    parser.add_argument(
+        "--execution-strategy",
+        default="sequential",
+        choices=["sequential", "parallel"],
+        help="Actions can be executed in sequential order or in parallel."
+        "Default is sequential, actions will be run only after the "
+        "previous one ends",
+    )
     return parser
 
 

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -247,9 +247,14 @@ class RuleSetRunner:
                     self.active_actions.add(task)
                     task.add_done_callback(self._handle_action_completion)
                 else:
-                    self._run_action(
+                    task = self._run_action(
                         action_item.actions[0], action_item, rule_run_at
                     )
+                    if (
+                        self.parsed_args
+                        and self.parsed_args.execution_strategy == "sequential"
+                    ):
+                        await task
         except asyncio.CancelledError:
             logger.debug(
                 "Action Plan Task Cancelled for ruleset %s", self.name

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,7 @@ The `ansible-rulebook` CLI supports the following options:
 .. code-block:: console
 
     usage: ansible-rulebook [-h] [-r RULEBOOK] [-e VARS] [-E ENV_VARS] [-v] [--version] [-S SOURCE_DIR] [-i INVENTORY] [-W WEBSOCKET_URL] [--id ID] [-w] [-T PROJECT_TARBALL] [--controller-url CONTROLLER_URL]
-                            [--controller-token CONTROLLER_TOKEN] [--controller-ssl-verify CONTROLLER_SSL_VERIFY] [--print-events]
+                            [--controller-token CONTROLLER_TOKEN] [--controller-ssl-verify CONTROLLER_SSL_VERIFY] [--print-events] [--heartbeat n] [--execution-strategy sequential|parallel]
 
     optional arguments:
     -h, --help            show this help message and exit
@@ -41,6 +41,8 @@ The `ansible-rulebook` CLI supports the following options:
     --shutdown-delay      Maximum number of seconds to wait after a graceful shutdown is issued, default is 60. Can also be set via an env var called EDA_SHUTDOWN_DELAY. The process will shutdown if all actions complete before this time period
 
     --heartbeat <n> Send heartbeat to the server after every n seconds. Default is 0, no heartbeat is sent
+
+    --execution-strategy sequential|parallel. The default execution strategy is sequential.
 
 To get help from `ansible-rulebook` run the following:
 


### PR DESCRIPTION
Added a new command line option called **--execution-strategy**

* sequential (default)
* parallel

This will help us from overloading the controller when a simple rulebook runs run_job_template with no throttling
This applies to **all actions** not just run_job_template or run_playbook or run_module.
A properly written rulebook that can handling throttling with either once_after or once_within can run things in parallel.

https://issues.redhat.com/browse/AAP-11904