### PR TITLE
[AAP-12374] Var root was only getting honored for first trigger

### DIFF
--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -17,6 +17,7 @@ import gc
 import logging
 from datetime import datetime
 from pprint import PrettyPrinter, pformat
+from types import MappingProxyType
 from typing import Dict, List, Optional, Union, cast
 
 import dpath
@@ -289,7 +290,7 @@ class RuleSetRunner:
                 action_item.rule_uuid,
                 rule_run_at,
                 action.action,
-                action.action_args,
+                MappingProxyType(action.action_args),
                 action_item.variables,
                 action_item.inventory,
                 action_item.hosts,
@@ -309,14 +310,14 @@ class RuleSetRunner:
         rule_uuid: str,
         rule_run_at: str,
         action: str,
-        action_args: Dict,
+        immutable_action_args: MappingProxyType,
         variables: Dict,
         inventory: str,
         hosts: List,
         rules_engine_result,
     ) -> None:
-
         logger.info("call_action %s", action)
+        action_args = immutable_action_args.copy()
 
         error = None
         if action in builtin_actions:

--- a/tests/examples/27_var_root.yml
+++ b/tests/examples/27_var_root.yml
@@ -13,6 +13,14 @@
               message:
                 topic: testing
                 channel: red
+          - webhook:
+              payload:
+                url: http://www.example.com
+                action: merge
+          - kafka:
+              message:
+                topic: testing
+                channel: red
   rules:
     - name: r1
       condition:
@@ -24,4 +32,3 @@
           var_root:
             webhook.payload: webhook
             kafka.message: kafka
-

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -779,15 +779,20 @@ async def test_27_var_root():
             dict(),
             load_inventory("playbooks/inventory.yml"),
         )
+
+        for _ in range(2):
+            event = event_log.get_nowait()
+            assert event["type"] == "Action", "1"
+            assert event["action"] == "print_event", "2"
+            assert event["matching_events"] == {
+                "webhook": {
+                    "url": "http://www.example.com",
+                    "action": "merge",
+                },
+                "kafka": {"topic": "testing", "channel": "red"},
+            }, "3"
         event = event_log.get_nowait()
-        assert event["type"] == "Action", "1"
-        assert event["action"] == "print_event", "2"
-        assert event["matching_events"] == {
-            "webhook": {"url": "http://www.example.com", "action": "merge"},
-            "kafka": {"topic": "testing", "channel": "red"},
-        }
-        event = event_log.get_nowait()
-        assert event["type"] == "Shutdown", "7"
+        assert event["type"] == "Shutdown", "4"
         assert event_log.empty()
 
 
@@ -2088,7 +2093,6 @@ async def test_46_job_template():
     job_template_runner.host = "https://examples.com"
     job_url = "https://examples.com/#/jobs/945/details"
     with SourceTask(rs.sources[0], "sources", {}, queue):
-
         with patch(
             "ansible_rulebook.builtin.job_template_runner.run_job_template",
             return_value=response_obj,


### PR DESCRIPTION
We use callbacks coming from Drools which use a closure to store the action args, that should be immutable since it affects subsequent calls. we were modifying the action_args causing the var_root issue

https://issues.redhat.com/browse/AAP-12374
Fixes #508 