### PR TITLE
Drools changes to debug intermittent test failures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.3.1
+	drools_jpy == 0.3.2
 
 [options.packages.find]
 include = 


### PR DESCRIPTION
Drools is logging extra clock times when timer based tests fail intermittently
Switches to 0.3.2 of drools