### PR TITLE
In an ansible collection playbooks are in playbooks directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Added command line option --execution-strategy
 
 ### Fixed
+- In a collection look for playbook in playbooks directory
+- Support .yaml and .yml extension for playbooks
 
 ### Removed
 

--- a/ansible_rulebook/collection.py
+++ b/ansible_rulebook/collection.py
@@ -34,6 +34,11 @@ EDA_SOURCE_PATHS = [
     f"{EDA_PATH_PREFIX}/plugins/event_sources",
     "plugins/event_source",
 ]
+
+EDA_PLAYBOOKS_PATHS = [".", "playbooks"]
+
+EDA_YAML_EXTENSIONS = [".yml", ".yaml"]
+
 logger = logging.getLogger(__name__)
 
 
@@ -68,30 +73,38 @@ def find_collection(name):
     return None
 
 
-def has_object(collection, name, object_types, extension):
+def has_object(collection, name, object_types, extensions):
     if find_collection(collection) is None:
         return False
 
+    if not isinstance(extensions, list):
+        extensions = [extensions]
+
     for object_type in object_types:
-        if os.path.exists(
-            os.path.join(find_collection(collection), object_type, name)
-            + extension
-        ):
-            return True
+        for extension in extensions:
+            if os.path.exists(
+                os.path.join(find_collection(collection), object_type, name)
+                + extension
+            ):
+                return True
     return False
 
 
-def find_object(collection, name, object_types, extension):
+def find_object(collection, name, object_types, extensions):
     if find_collection(collection) is None:
         return False
 
+    if not isinstance(extensions, list):
+        extensions = [extensions]
+
     for object_type in object_types:
-        location = (
-            os.path.join(find_collection(collection), object_type, name)
-            + extension
-        )
-        if os.path.exists(location):
-            return location
+        for extension in extensions:
+            location = (
+                os.path.join(find_collection(collection), object_type, name)
+                + extension
+            )
+            if os.path.exists(location):
+                return location
 
     raise FileNotFoundError(
         f"Cannot find {object_type} {name} in {collection} at {location}"
@@ -157,9 +170,13 @@ def find_source_filter(collection, source_filter):
     )
 
 
-def has_playbook(collection, source_filter):
-    return has_object(collection, source_filter, "", ".yml")
+def has_playbook(collection, playbook):
+    return has_object(
+        collection, playbook, EDA_PLAYBOOKS_PATHS, EDA_YAML_EXTENSIONS
+    )
 
 
-def find_playbook(collection, source_filter):
-    return find_object(collection, source_filter, "", ".yml")
+def find_playbook(collection, playbook):
+    return find_object(
+        collection, playbook, EDA_PLAYBOOKS_PATHS, EDA_YAML_EXTENSIONS
+    )

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -12,9 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import pytest
+
 from ansible_rulebook.collection import (
     find_collection,
+    find_playbook,
     find_source,
+    has_playbook,
+    has_rulebook,
     load_rulebook,
     split_collection_name,
 )
@@ -23,6 +28,10 @@ from ansible_rulebook.collection import (
 def test_find_collection():
     location = find_collection("community.general")
     assert location is not None
+
+
+def test_find_collection_missing():
+    assert find_collection("community.missing") is None
 
 
 def test_find_collection_eda():
@@ -38,3 +47,36 @@ def test_find_source():
 def test_load_rulebook():
     rules = load_rulebook(*split_collection_name("ansible.eda.hello_events"))
     assert rules is not None
+
+
+def test_load_rulebook_missing():
+    assert not load_rulebook(
+        *split_collection_name("missing.eda.hello_events")
+    )
+
+
+def test_has_rulebook():
+    assert has_rulebook(*split_collection_name("ansible.eda.hello_events"))
+
+
+def test_find_playbook():
+    assert (
+        find_playbook(*split_collection_name("ansible.eda.hello")) is not None
+    )
+
+
+def test_find_playbook_missing():
+    with pytest.raises(FileNotFoundError):
+        find_playbook(*split_collection_name("ansible.eda.missing"))
+
+
+def test_has_playbook():
+    assert has_playbook(*split_collection_name("ansible.eda.hello"))
+
+
+def test_has_playbook_missing():
+    assert not has_playbook(*split_collection_name("ansible.eda.missing"))
+
+
+def test_has_playbook_missing_collection():
+    assert not has_playbook(*split_collection_name("missing.eda.missing"))


### PR DESCRIPTION
We were only checking for playbooks in the root directory of the collection. This PR looks for the playbook in the root as well as the playbooks directory

https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html

Fixes #514

Supports .yaml or .yml extensions for rulebooks

https://issues.redhat.com/browse/AAP-9191
