### PR TITLE
[AAP-12513] Fix intermittent test failures because of missing events in drools

### DIFF
--- a/.github/actions/all-tests/action.yml
+++ b/.github/actions/all-tests/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - name: Long-running tests
       shell: bash
-      run: pytest -m "long_run" -vv -n auto --cov=./ --cov-report=xml
+      run: pytest -m "long_run" -vv -n auto --cov=./ --cov-report=xml --cov-append
 
     - name: e2e tests
       uses: ./.github/actions/e2e-tests

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -6,4 +6,4 @@ runs:
   steps:
     - name: Run e2e tests
       shell: bash
-      run: pytest -m "e2e" -n auto
+      run: pytest -m "e2e" -n auto --cov=./ --cov-report=xml --cov-append

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.3.2
+	drools_jpy == 0.3.3
 
 [options.packages.find]
 include = 

--- a/tests/examples/33_run_playbook_retry.yml
+++ b/tests/examples/33_run_playbook_retry.yml
@@ -12,3 +12,5 @@
           name: playbooks/fail_and_succeed.yml
           retry: True
           delay: 1
+          extra_vars:
+            rulebook_file_path: /tmp/33_demo.txt

--- a/tests/examples/34_run_playbook_retries.yml
+++ b/tests/examples/34_run_playbook_retries.yml
@@ -11,3 +11,5 @@
         run_playbook:
           name: playbooks/fail_and_succeed.yml
           retries: 1
+          extra_vars:
+            rulebook_file_path: /tmp/34_demo.txt

--- a/tests/playbooks/fail_and_succeed.yml
+++ b/tests/playbooks/fail_and_succeed.yml
@@ -5,7 +5,7 @@
   tasks:
     - name: Define a temp file
       ansible.builtin.set_fact:
-        my_path: "/tmp/ansible_event-fail_and_succeed"
+        my_path: "{{ rulebook_file_path }}"
 
     - name: Check that the temp file exists
       ansible.builtin.stat:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -260,7 +260,7 @@ async def test_run_rulesets():
         "ansible_events": 9,
         "action_events": 6,
     }
-    validate_events(event_log, **checks)
+    await validate_events(event_log, **checks)
 
 
 @pytest.mark.asyncio
@@ -368,7 +368,7 @@ async def test_run_multiple_hosts():
         "ansible_events": 13,
         "action_events": 6,
     }
-    validate_events(event_log, **checks)
+    await validate_events(event_log, **checks)
 
 
 @pytest.mark.asyncio
@@ -482,7 +482,7 @@ async def test_run_rulesets_on_hosts():
         "ansible_events": 9,
         "action_events": 6,
     }
-    validate_events(event_log, **checks)
+    await validate_events(event_log, **checks)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Upgraded to drools_jpy 0.3.3 which had a missing event 
Fixed code coverage which was getting overwritten
Fixed a test that was using same file name in 2 different tests when run in parallel they used to fail.

https://issues.redhat.com/browse/AAP-12513

Hopefully this fixes the intermittent test failures.