### PR TITLE
The heartbeat may produce more than 2 stats.

### DIFF
--- a/tests/e2e/test_websocket.py
+++ b/tests/e2e/test_websocket.py
@@ -108,6 +108,6 @@ async def test_websocket_messages():
                 assert stats["eventsSuppressed"] == 1999
 
     assert ansible_event_counter == 9
-    assert session_stats_counter == 2
+    assert session_stats_counter >= 2
     assert job_counter == 1
     assert action_counter == 1


### PR DESCRIPTION
Since the stats are sent every 2 seconds its possible that we might have more than 2 stats records we would see

This leads to intermittent failures

https://github.com/ansible/ansible-rulebook/actions/runs/5081433799/jobs/9130122539