### PR TITLE
[AAP-11109] Support for complete and partial retract facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - In a collection look for playbook in playbooks directory
 - Support .yaml and .yml extension for playbooks
+- Retract fact for partial and complete matches
 
 ### Removed
 

--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -219,9 +219,16 @@ async def retract_fact(
     rule_run_at: str,
     ruleset: str,
     fact: Dict,
+    partial: bool = True,
     name: Optional[str] = None,
 ):
-    lang.retract_fact(ruleset, _embellish_internal_event(fact, "retract_fact"))
+
+    if not partial:
+        exclude_keys = ["meta"]
+    else:
+        exclude_keys = []
+
+    lang.retract_matching_facts(ruleset, fact, partial, exclude_keys)
     await event_log.put(
         dict(
             type="Action",

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -496,6 +496,10 @@
                         },
                         "fact": {
                             "type": "object"
+                        },
+                        "partial": {
+                            "type": "boolean",
+                            "default": true
                         }
                     },
                     "required": [

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -153,12 +153,11 @@ def test_actions_sanity(update_environment):
             "Fact matched in different ruleset: sent" in result.stdout
         ), "set_fact action across rulesets failed"
 
-    # TODO: Retract fact doesn't work in Drools with the presence of meta data
-    # with check:
-    #    assert (
-    #        "Retracted fact in same ruleset, this should not be printed"
-    #        not in result.stdout
-    #    ), "retract_fact action failed"
+    with check:
+        assert (
+            "Retracted fact in same ruleset, this should not be printed"
+            not in result.stdout
+        ), "retract_fact action failed"
 
     multiple_actions_expected_output = (
         "Ruleset: Test actions sanity rule: Test multiple actions in "
@@ -178,7 +177,7 @@ def test_actions_sanity(update_environment):
         ), "multiple_action action failed"
 
     assert (
-        len(result.stdout.splitlines()) == 59
+        len(result.stdout.splitlines()) == 56
     ), "unexpected output from the rulebook"
 
 

--- a/tests/examples/78_complete_retract_fact.yml
+++ b/tests/examples/78_complete_retract_fact.yml
@@ -1,0 +1,29 @@
+---
+- name: 78 complete retract fact
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 1
+      action:
+        set_fact:
+          fact:
+            msg: hello world
+            creator: Kernighan
+    - name: r2
+      condition: event.msg == "hello world"
+      action:
+        retract_fact:
+          fact:
+            msg: hello world
+            creator: Kernighan
+          partial: false
+    - name: r3
+      condition: event.msg is not defined
+      action:
+        debug:
+          msg: Complete retract works
+

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -203,7 +203,6 @@ async def test_05_post_event():
     assert event_log.empty()
 
 
-@pytest.mark.skip(reason="with meta data the retract fact never matches")
 @pytest.mark.asyncio
 async def test_06_retract_fact():
     ruleset_queues, event_log = load_rulebook("examples/06_retract_fact.yml")
@@ -579,7 +578,6 @@ async def test_19_is_defined():
     assert event_log.empty()
 
 
-@pytest.mark.skip(reason="with meta data the retract fact never matches")
 @pytest.mark.asyncio
 async def test_20_is_not_defined():
     ruleset_queues, event_log = load_rulebook("examples/20_is_not_defined.yml")
@@ -604,13 +602,15 @@ async def test_20_is_not_defined():
     assert event["action"] == "retract_fact", "4"
     matching_events = event["matching_events"]
     meta = matching_events["m"].pop("meta")
-    assert meta["source"]["name"] == "internal"
+    assert meta["source"]["name"] == "set_fact"
     assert meta["source"]["type"] == "internal"
     assert matching_events == {"m": {"msg": "hello"}}
     event = event_log.get_nowait()
     assert event["type"] == "Action", "5"
     assert event["action"] == "debug", "6"
-    assert event["matching_events"] == {"m": {"msg": "hello"}}
+    matching_events = event["matching_events"]
+    meta = matching_events["m"].pop("meta")
+    assert matching_events == {"m": {"msg": "hello"}}
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "8"
     assert event_log.empty()
@@ -2171,3 +2171,40 @@ async def test_77_default_events_ttl():
             ],
         }
         await validate_events(event_log, **checks)
+
+
+@pytest.mark.asyncio
+async def test_78_complete_retract_fact():
+    ruleset_queues, event_log = load_rulebook(
+        "examples/78_complete_retract_fact.yml"
+    )
+
+    queue = ruleset_queues[0][1]
+    queue.put_nowait(dict(i=1))
+    queue.put_nowait(Shutdown())
+
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            dict(),
+            dict(),
+        )
+
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "1"
+    assert event["action"] == "set_fact", "2"
+    assert event["action_uuid"] == DUMMY_UUID
+    assert event["status"] == "successful"
+    assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
+    assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
+    assert event["matching_events"] == {"m": {"i": 1}}, "3"
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "3"
+    assert event["action"] == "retract_fact", "4"
+    event = event_log.get_nowait()
+    assert event["type"] == "Action", "4"
+    assert event["action"] == "debug", "5"
+    event = event_log.get_nowait()
+    assert event["type"] == "Shutdown", "7"
+    assert event_log.empty()


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-11109

We always use partial match but if for some reason the user wants to use a complete match they can set partial : False