### PR TITLE
[AAP-12600] Synchronize creation of job request

### DIFF
--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -31,6 +31,8 @@ from ansible_rulebook.exception import (
 
 logger = logging.getLogger(__name__)
 
+request_create_lock = asyncio.Lock()
+
 
 class JobTemplateRunner:
     JOB_TEMPLATE_SLUG = "/api/v2/job_templates"
@@ -118,7 +120,8 @@ class JobTemplateRunner:
         organization: str,
         job_params: dict,
     ) -> dict:
-        job = await self.launch(name, organization, job_params)
+        async with request_create_lock:
+            job = await self.launch(name, organization, job_params)
 
         url = job["url"]
         params = {}


### PR DESCRIPTION
We create 1 job request at a time with an asyncio lock. Once the request has been created we can create other requests. Once the requests are created we monitor them separately. The controller can accept hundreds of requests serially.