### PR TITLE
[AAP-11904] Added execution_strategy for rulesets in rulebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Sending heartbeat to the server with the session stats
 - Added command line option --execution-strategy
+- Rulesets in rulebook can have execution_strategy attribute
 
 ### Fixed
 - In a collection look for playbook in playbooks directory

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -166,7 +166,7 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--execution-strategy",
-        default="sequential",
+        default=settings.default_execution_strategy,
         choices=["sequential", "parallel"],
         help="Actions can be executed in sequential order or in parallel."
         "Default is sequential, actions will be run only after the "
@@ -239,6 +239,9 @@ def main(args: List[str] = None) -> int:
 
     if args.gc_after is not None:
         settings.gc_after = args.gc_after
+
+    if args.execution_strategy:
+        settings.default_execution_strategy = args.execution_strategy
 
     setup_logging(args)
 

--- a/ansible_rulebook/conf.py
+++ b/ansible_rulebook/conf.py
@@ -19,6 +19,7 @@ class _Settings:
     def __init__(self):
         self.identifier = str(uuid.uuid4())
         self.gc_after = 1000
+        self.default_execution_strategy = "sequential"
 
 
 settings = _Settings()

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -238,10 +238,12 @@ async def run_rulesets(
 
     hosts_facts = []
     ruleset_names = []
+    rulesets = {}
     for ruleset, _ in ruleset_queues:
         if ruleset.gather_facts and not hosts_facts:
             hosts_facts = collect_ansible_facts(inventory)
         ruleset_names.append(ruleset.name)
+        rulesets[ruleset.name] = ruleset
 
     ruleset_tasks = []
     reader, writer = await establish_async_channel()
@@ -262,6 +264,7 @@ async def run_rulesets(
             ruleset_queue_plan=ruleset_queue_plan,
             hosts_facts=hosts_facts,
             variables=variables,
+            rule_set=rulesets[ruleset_queue_plan.ruleset.name],
             project_data_file=project_data_file,
             parsed_args=parsed_args,
             broadcast_method=broadcast,

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -38,6 +38,7 @@ from ansible_rulebook.rule_types import (
     Action,
     ActionContext,
     EngineRuleSetQueuePlan,
+    ExecutionStrategy,
 )
 from ansible_rulebook.rules_parser import parse_hosts
 from ansible_rulebook.util import (
@@ -56,6 +57,7 @@ class RuleSetRunner:
         ruleset_queue_plan: EngineRuleSetQueuePlan,
         hosts_facts,
         variables,
+        rule_set,
         project_data_file: Optional[str] = None,
         parsed_args=None,
         broadcast_method=None,
@@ -64,6 +66,7 @@ class RuleSetRunner:
         self.event_log = event_log
         self.ruleset_queue_plan = ruleset_queue_plan
         self.name = ruleset_queue_plan.ruleset.name
+        self.rule_set = rule_set
         self.hosts_facts = hosts_facts
         self.variables = variables
         self.project_data_file = project_data_file
@@ -253,8 +256,8 @@ class RuleSetRunner:
                     )
 
                 if (
-                    self.parsed_args
-                    and self.parsed_args.execution_strategy == "sequential"
+                    self.rule_set.execution_strategy
+                    == ExecutionStrategy.SEQUENTIAL
                 ):
                     await task
         except asyncio.CancelledError:

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -16,11 +16,17 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 from drools.ruleset import Ruleset as EngineRuleSet
 
 import ansible_rulebook.condition_types as ct
+
+
+class ExecutionStrategy(Enum):
+    SEQUENTIAL = 1
+    PARALLEL = 2
 
 
 class EventSourceFilter(NamedTuple):
@@ -68,6 +74,7 @@ class RuleSet(NamedTuple):
     hosts: Union[str, List[str]]
     sources: List[EventSource]
     rules: List[Rule]
+    execution_strategy: ExecutionStrategy
     gather_facts: bool
     uuid: Optional[str] = None
     default_events_ttl: Optional[str] = None

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -19,6 +19,7 @@ import ansible_rulebook.rule_types as rt
 from ansible_rulebook.condition_parser import (
     parse_condition as parse_condition_value,
 )
+from ansible_rulebook.conf import settings
 from ansible_rulebook.util import substitute_variables
 
 from .exception import (
@@ -64,12 +65,21 @@ def parse_rule_sets(
         if variables is None:
             variables = {}
 
+        strategy = rule_set.get(
+            "execution_strategy", settings.default_execution_strategy
+        )
+        if strategy == "sequential":
+            execution_strategy = rt.ExecutionStrategy.SEQUENTIAL
+        elif strategy == "parallel":
+            execution_strategy = rt.ExecutionStrategy.PARALLEL
+
         rule_set_list.append(
             rt.RuleSet(
                 name=name,
                 hosts=parse_hosts(rule_set["hosts"]),
                 sources=parse_event_sources(rule_set["sources"]),
                 rules=parse_rules(rule_set.get("rules", {}), variables),
+                execution_strategy=execution_strategy,
                 gather_facts=rule_set.get("gather_facts", False),
                 uuid=str(uuid.uuid4()),
                 default_events_ttl=rule_set.get("default_events_ttl", None),

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -28,6 +28,11 @@
                 "name": {
                     "type": "string"
                 },
+                "execution_strategy": {
+                    "type": "string",
+                    "enum": ["sequential", "parallel"],
+                    "default": "sequential"
+                },
                 "sources": {
                     "type": "array",
                     "items": {

--- a/docs/rulebooks.rst
+++ b/docs/rulebooks.rst
@@ -16,6 +16,7 @@ A ruleset has the following properties:
 * hosts similar to Ansible playbook
 * gather_facts: boolean
 * default_events_ttl: time to keep the partially matched events around (default is 2 hours)
+* execution_strategy: How actions should be executed, sequential|parallel (default: sequential). For sequential strategy we wait for each action to finish before we kick off the next action.
 * sources: A list of sources
 * rules: a list of rules
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from ansible_rulebook.rule_types import (
     Condition,
     EventSource,
     EventSourceFilter,
+    ExecutionStrategy,
     Rule,
     RuleSet,
 )
@@ -84,6 +85,13 @@ def create_ruleset(create_event_source, create_rule, **kwargs):
         event_sources = kwargs.pop("event_sources", [create_event_source()])
         rules = kwargs.pop("rules", [create_rule()])
         gather_facts = kwargs.pop("gather_facts", False)
-        return RuleSet(name, hosts, event_sources, rules, gather_facts)
+        return RuleSet(
+            name,
+            hosts,
+            event_sources,
+            rules,
+            ExecutionStrategy.SEQUENTIAL,
+            gather_facts,
+        )
 
     return _ruleset


### PR DESCRIPTION
Continuation of PR #506
The rulesets in a rulebook can have an optional attribute called

* execution_strategy = sequential | parallel

Default is sequential

https://issues.redhat.com/browse/AAP-11904

This is still at the ruleset level and can't be configured at the rule level, which is a bit more challenging to implement.