### PR TITLE
If we can't find the inventory path, assume we should pass it through…

### DIFF
--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -81,11 +81,12 @@ def substitute_variables(
         return value
 
 
-def load_inventory(inventory_file: str) -> Any:
-
-    with open(inventory_file) as f:
-        inventory_data = f.read()
-    return inventory_data
+def load_inventory(inventory_spec: str) -> Any:
+    if os.path.exists(inventory_spec):
+        with open(inventory_spec) as f:
+            inventory_data = f.read()
+        return inventory_data
+    return inventory_spec
 
 
 def collect_ansible_facts(inventory: str) -> List[Dict]:


### PR DESCRIPTION
… verbatim to Runner

This isn't an exact solution to #344 but it allows ad-hoc hosts and maybe gets it a little closer. I wonder if it would be better to just let Runner do its own thing?