### PR TITLE
[AAP-12909] Validate Controller URL and Token at Startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - In a collection look for playbook in playbooks directory
 - Support .yaml and .yml extension for playbooks
 - Retract fact for partial and complete matches
+- Checking of controller url and token at startup
 
 ### Removed
 

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -87,7 +87,7 @@ async def run(parsed_args: argparse.ArgumentParser) -> None:
         startup_args.controller_ssl_verify = parsed_args.controller_ssl_verify
 
     validate_actions(startup_args)
-    set_controller_params(startup_args)
+    await validate_controller_params(startup_args)
 
     if parsed_args.websocket_address:
         event_log = asyncio.Queue()
@@ -245,9 +245,12 @@ def validate_actions(startup_args: StartupArgs) -> None:
                     )
 
 
-def set_controller_params(startup_args: StartupArgs) -> None:
+async def validate_controller_params(startup_args: StartupArgs) -> None:
     if startup_args.controller_url:
         job_template_runner.host = startup_args.controller_url
         job_template_runner.token = startup_args.controller_token
         if startup_args.controller_ssl_verify:
             job_template_runner.verify_ssl = startup_args.controller_ssl_verify
+
+        data = await job_template_runner.get_config()
+        logger.info("AAP Version %s", data["version"])

--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 class JobTemplateRunner:
     JOB_TEMPLATE_SLUG = "/api/v2/job_templates"
+    CONFIG_SLUG = "/api/v2/config"
     VALID_POST_CODES = [200, 201, 202]
     JOB_COMPLETION_STATUSES = ["successful", "failed", "error", "canceled"]
 
@@ -67,6 +68,19 @@ class JobTemplateRunner:
                 )
             )
         return response_text
+
+    async def get_config(self) -> dict:
+        try:
+            logger.info("Attempting to connect to Controller %s", self.host)
+            async with aiohttp.ClientSession(
+                raise_for_status=True, headers=self._auth_headers()
+            ) as session:
+                url = urljoin(self.host, self.CONFIG_SLUG)
+                async with session.get(url, ssl=self._sslcontext) as response:
+                    return json.loads(await response.text())
+        except aiohttp.ClientError as e:
+            logger.error("Error connecting to controller %s", str(e))
+            raise ControllerApiException(str(e))
 
     def _auth_headers(self) -> dict:
         return dict(Authorization=f"Bearer {self.token}")

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -19,3 +19,4 @@ freezegun
 oauthlib>=3.2.0
 kubernetes
 urllib3<2
+aioresponses

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 import os
 from contextlib import nullcontext as does_not_raise
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
@@ -157,12 +158,14 @@ async def test_run_with_websocket(create_ruleset):
                     controller_token="token",
                     controller_ssl_verify="no",
                 )
-
-                await run(cmdline_args)
-
-                assert mock_start_source.call_count == 1
-                assert mock_run_rulesets.call_count == 1
-                assert mock_request_workload.call_count == 1
+                with patch(
+                    "ansible_rulebook.app.job_template_runner.get_config",
+                    return_value=dict(version="4.4.1"),
+                ):
+                    await run(cmdline_args)
+                    assert mock_start_source.call_count == 1
+                    assert mock_run_rulesets.call_count == 1
+                    assert mock_request_workload.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
If the caller has provided a controller URL and token we validate that it is correct at startup so we dont have to fail when the events arrive if the url or token is invalid.

At startup we get the config information from the Controller using /api/v2/config and log the version of the controller we are using.

https://issues.redhat.com/browse/AAP-12909

The issue mentions failing on audit_rule, with this PR we fail as soon as the process starts. The Activation is marked as failed and the history has the details for bad url or bad token. This doesn't have to be replicated for every rule and event. If the URL and token is bad it will stay bad for the entire run of the activation since the URL and token cannot be changed when the activation is running.