### PR TITLE
[AAP-12529] When an action fails report all required attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Support .yaml and .yml extension for playbooks
 - Retract fact for partial and complete matches
 - Checking of controller url and token at startup
+- rule_uuid and ruleset_uuid provided even when an action fails
 
 ### Removed
 

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -15,7 +15,7 @@
 import asyncio
 import gc
 import logging
-from datetime import datetime
+import uuid
 from pprint import PrettyPrinter, pformat
 from types import MappingProxyType
 from typing import Dict, List, Optional, Union, cast
@@ -446,11 +446,16 @@ class RuleSetRunner:
                 dict(
                     type="Action",
                     action=action,
+                    action_uuid=str(uuid.uuid4()),
                     activation_id=settings.identifier,
                     playbook_name=action_args.get("name"),
                     status="failed",
-                    run_at=str(datetime.utcnow()),
+                    run_at=run_at(),
                     reason=dict(error=str(error)),
+                    rule=rule,
+                    ruleset=ruleset,
+                    rule_uuid=rule_uuid,
+                    ruleset_uuid=ruleset_uuid,
                 )
             )
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2145,6 +2145,21 @@ async def test_46_job_template_exception(err_msg, err):
 
             assert action["action"] == "run_job_template"
             assert action["reason"] == {"error": err_msg}
+            required_keys = {
+                "action",
+                "action_uuid",
+                "activation_id",
+                "reason",
+                "rule_run_at",
+                "run_at",
+                "rule",
+                "ruleset",
+                "rule_uuid",
+                "ruleset_uuid",
+                "status",
+                "type",
+            }
+            assert set(action.keys()).issuperset(required_keys)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When a job template fails we were not supplying the uuid's for rule, ruleset and action causing errors on server side.
The server would discard those actions coming in leading to rule audits missing.


There might be other JIRA issues related to the same error
https://issues.redhat.com/browse/AAP-12529