### PR TITLE
[AAP-12513] Upgraded to newer version of drools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Retract fact for partial and complete matches
 - Checking of controller url and token at startup
 - rule_uuid and ruleset_uuid provided even when an action fails
+- Drools intermittently misses firing of rules
 
 ### Removed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.3.3
+	drools_jpy == 0.3.4
 
 [options.packages.find]
 include = 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-12513
Drools was missing triggering rules intermittently New version of drools_jpy 0.3.4