### PR TITLE
[AAP-12600] Limit the number of concurrent connections to controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - rule_uuid and ruleset_uuid provided even when an action fails
 - Drools intermittently misses firing of rules
 - Resend events lost during websocket disconnect
+- limits the number of simultaneously open connection to controller to 30
 
 ### Removed
 

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -139,6 +139,7 @@ async def run(parsed_args: argparse.ArgumentParser) -> None:
 
     logger.info("Main complete")
     await event_log.put(dict(type="Exit"))
+    await job_template_runner.close_session()
     if error_found:
         raise Exception("One of the source plugins failed")
 

--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -35,7 +35,6 @@ logger = logging.getLogger(__name__)
 class JobTemplateRunner:
     JOB_TEMPLATE_SLUG = "/api/v2/job_templates"
     CONFIG_SLUG = "/api/v2/config"
-    VALID_POST_CODES = [200, 201, 202]
     JOB_COMPLETION_STATUSES = ["successful", "failed", "error", "canceled"]
 
     def __init__(
@@ -47,40 +46,36 @@ class JobTemplateRunner:
         self.refresh_delay = int(
             os.environ.get("EDA_JOB_TEMPLATE_REFRESH_DELAY", 10)
         )
+        self._session = None
 
-    async def _get_page(
-        self, session: aiohttp.ClientSession, href_slug: str, params: dict
-    ) -> dict:
-        url = urljoin(self.host, href_slug)
-        async with session.get(
-            url, params=params, ssl=self._sslcontext
-        ) as response:
-            response_text = dict(
-                status=response.status, body=await response.text()
-            )
-        if response_text["status"] != 200:
-            raise ControllerApiException(
-                "Failed to get from %s. Status: %s, Body: %s"
-                % (
-                    url,
-                    response_text["status"],
-                    response_text.get("body", "empty"),
-                )
-            )
-        return response_text
+    async def close_session(self):
+        if self._session and not self._session.closed:
+            await self._session.close()
 
-    async def get_config(self) -> dict:
+    def _create_session(self):
+        if self._session is None:
+            limit = int(os.getenv("EDA_CONTROLLER_CONNECTION_LIMIT", "30"))
+            self._session = aiohttp.ClientSession(
+                connector=aiohttp.TCPConnector(limit=limit),
+                headers=self._auth_headers(),
+                raise_for_status=True,
+            )
+
+    async def _get_page(self, href_slug: str, params: dict) -> dict:
         try:
-            logger.info("Attempting to connect to Controller %s", self.host)
-            async with aiohttp.ClientSession(
-                raise_for_status=True, headers=self._auth_headers()
-            ) as session:
-                url = urljoin(self.host, self.CONFIG_SLUG)
-                async with session.get(url, ssl=self._sslcontext) as response:
-                    return json.loads(await response.text())
+            url = urljoin(self.host, href_slug)
+            self._create_session()
+            async with self._session.get(
+                url, params=params, ssl=self._sslcontext
+            ) as response:
+                return json.loads(await response.text())
         except aiohttp.ClientError as e:
             logger.error("Error connecting to controller %s", str(e))
             raise ControllerApiException(str(e))
+
+    async def get_config(self) -> dict:
+        logger.info("Attempting to connect to Controller %s", self.host)
+        return await self._get_page(self.CONFIG_SLUG, {})
 
     def _auth_headers(self) -> dict:
         return dict(Authorization=f"Bearer {self.token}")
@@ -98,26 +93,20 @@ class JobTemplateRunner:
         slug = f"{self.JOB_TEMPLATE_SLUG}/"
         params = {"name": name}
 
-        async with aiohttp.ClientSession(
-            headers=self._auth_headers()
-        ) as session:
-            while True:
-                response = await self._get_page(session, slug, params)
-                json_body = json.loads(response["body"])
-                for jt in json_body["results"]:
-                    if (
-                        jt["name"] == name
-                        and dpath.get(
-                            jt, "summary_fields.organization.name", "."
-                        )
-                        == organization
-                    ):
-                        return jt["id"]
+        while True:
+            json_body = await self._get_page(slug, params)
+            for jt in json_body["results"]:
+                if (
+                    jt["name"] == name
+                    and dpath.get(jt, "summary_fields.organization.name", ".")
+                    == organization
+                ):
+                    return jt["id"]
 
-                if json_body.get("next", None):
-                    params["page"] = params.get("page", 1) + 1
-                else:
-                    break
+            if json_body.get("next", None):
+                params["page"] = params.get("page", 1) + 1
+            else:
+                break
 
         raise JobTemplateNotFoundException(
             (
@@ -137,18 +126,14 @@ class JobTemplateRunner:
         url = job["url"]
         params = {}
 
-        async with aiohttp.ClientSession(
-            headers=self._auth_headers()
-        ) as session:
-            while True:
-                # fetch and process job status
-                response = await self._get_page(session, url, params)
-                json_body = json.loads(response["body"])
-                job_status = json_body["status"]
-                if job_status in self.JOB_COMPLETION_STATUSES:
-                    return json_body
+        while True:
+            # fetch and process job status
+            json_body = await self._get_page(url, params)
+            job_status = json_body["status"]
+            if job_status in self.JOB_COMPLETION_STATUSES:
+                return json_body
 
-                await asyncio.sleep(self.refresh_delay)
+            await asyncio.sleep(self.refresh_delay)
 
     async def launch(
         self, name: str, organization: str, job_params: dict
@@ -156,28 +141,14 @@ class JobTemplateRunner:
         jt_id = await self._get_job_template_id(name, organization)
         url = urljoin(self.host, f"{self.JOB_TEMPLATE_SLUG}/{jt_id}/launch/")
 
-        async with aiohttp.ClientSession(
-            headers=self._auth_headers()
-        ) as session:
-            async with session.post(
+        try:
+            async with self._session.post(
                 url, json=job_params, ssl=self._sslcontext
             ) as post_response:
-                response = dict(
-                    status=post_response.status,
-                    body=await post_response.text(),
-                )
-
-                if response["status"] not in self.VALID_POST_CODES:
-                    raise ControllerApiException(
-                        "Failed to post to %s. Status: %s, Body: %s"
-                        % (
-                            url,
-                            response["status"],
-                            response.get("body", "empty"),
-                        )
-                    )
-                json_body = json.loads(response["body"])
-        return json_body
+                return json.loads(await post_response.text())
+        except aiohttp.ClientError as e:
+            logger.error("Error connecting to controller %s", str(e))
+            raise ControllerApiException(str(e))
 
 
 job_template_runner = JobTemplateRunner()


### PR DESCRIPTION
Using aiohttp sessions we can limit the number of concurrent connections to the controller.
The current limit is 30 connections, it can be changed via an env var EDA_CONTROLLER_CONNECTION_LIMIT
When used in conjunction with execution_stratgey: parallel we should be able to create job requests without overloading the controller and getting a 502.

https://issues.redhat.com/browse/AAP-12600