### PR TITLE
[AAP-12522] Resend the last event when the websocket connection is reconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Checking of controller url and token at startup
 - rule_uuid and ruleset_uuid provided even when an action fails
 - Drools intermittently misses firing of rules
+- Resend events lost during websocket disconnect
 
 ### Removed
 


### PR DESCRIPTION
The websocket connection at times will get disconnected from the server side, when this disconnect happens we miss posting the event. The connection is re-established but the event that was being sent during the disconnect is not resent. This PR addresses this issue.

The logs looks like following:

```
2023-06-07 14:39:19,150 - ansible_rulebook.websocket - WARNING - websocket ws://host.containers.internal:8000/api/eda/ws/ansible-rulebook connection closed
2023-06-07 14:39:19,151 - ansible_rulebook.rule_set_runner - INFO - Task action::run_job_template::Launch storm of JT's with a single action::Run job template - storm mode - single action finished, active actions 0
2023-06-07 14:39:19 151 [main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.RegisterOnlyAgendaFilter - Activation of effective rule "Run job template - storm mode - single action" with facts: {m={meta={received_at=2023-06-07T14:38:57.012756Z, source={name=ansible.eda.generic, type=ansible.eda.generic}, uuid=5f0ff2fd-d47a-4115-9f69-884bc2f8f64b}, index=88, state=down}}
2023-06-07 14:39:19,151 - ansible_rulebook.rule_generator - INFO - calling Run job template - storm mode - single action                                                                                            
2023-06-07 14:39:19,152 - ansible_rulebook.rule_set_runner - INFO - call_action run_job_template
2023-06-07 14:39:19,152 - ansible_rulebook.rule_set_runner - INFO - substitute_variables [{'name': 'run_basic', 'organization': 'Default', 'job_args': {'extra_vars': {'fake_execution_time': '10'}}}] [{'event': {'meta': {'received_at': '2023-06-07T14:36:45.487084Z', 'source': {'name': 'ansible.eda.generic', 'type': 'ansible.eda.generic'}, 'uuid': 'bf912dea-5859-484e-9f01-fe4befd80255'}, 'index': 77, 'state': 'down'}}]
2023-06-07 14:39:19,152 - ansible_rulebook.rule_set_runner - INFO - action args: {'name': 'run_basic', 'organization': 'Default', 'job_args': {'extra_vars': {'fake_execution_time': '10'}}}                        
2023-06-07 14:39:19,152 - ansible_rulebook.builtin - INFO - running job template: run_basic, organization: Default                                                                                                  
2023-06-07 14:39:19,152 - ansible_rulebook.builtin - INFO - ruleset: Launch storm of JT's with a single action, rule Run job template - storm mode - single action
2023-06-07 14:39:19,157 - ansible_rulebook.websocket - INFO - websocket ws://host.containers.internal:8000/api/eda/ws/ansible-rulebook connected
```
The event between websockets closed and opened is missing in the EDA server side.

Resolves: [AAP-12522](https://issues.redhat.com/browse/AAP-12522)