### PR TITLE
[DO-NOT-MERGE] [AAP-13172] Ansible-rulebook modify schema to support delay_warning_t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Sending heartbeat to the server with the session stats
 - Added command line option --execution-strategy
 - Rulesets in rulebook can have execution_strategy attribute
+- Support for delay_warning_threshold at ruleset level
 
 ### Fixed
 - In a collection look for playbook in playbooks directory
@@ -74,7 +75,7 @@
 
 ### Removed
 
-- Redis and durability 
+- Redis and durability
 - envvar for rules_engine
 
 
@@ -84,12 +85,12 @@
 
 - Support for vars namespace
 - Support for negation
-- Support for Floats 
-- Log format and set the log stream for debug/verbose 
-- A builtin action : echo 
-- Cmdline option --print_events 
-- New action: run_job_template 
-- Support for in and contains in condition 
+- Support for Floats
+- Log format and set the log stream for debug/verbose
+- A builtin action : echo
+- Cmdline option --print_events
+- New action: run_job_template
+- Support for in and contains in condition
 - Add more info to --version flag
 - Add EDA prefix to environment variables
 - Enable drools for python 3.11
@@ -104,9 +105,9 @@
 
 ### Changed
 
-- Configure controller API access 
-- Switch the default rules engine back to drools 
-- Print help if run without arguments 
+- Configure controller API access
+- Switch the default rules engine back to drools
+- Print help if run without arguments
 
 ### Removed
 
@@ -120,7 +121,7 @@
 
 ### Changed
 
-Update minimal python version 
+Update minimal python version
 Improves error messages for unhandled events
 
 ### Removed
@@ -133,7 +134,7 @@ Improves error messages for unhandled events
 
 ### Added
 
-- Job details for eda-server usage 
+- Job details for eda-server usage
 - add arg to install devel collection
 
 ### Fixed
@@ -193,7 +194,7 @@ Improves error messages for unhandled events
 
 ### Fixed
 
-- An error msg 
+- An error msg
 
 ## [0.6.0] - 2022-08-24
 

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -309,6 +309,9 @@ def visit_ruleset(ruleset: RuleSet, variables: Dict):
     if ruleset.default_events_ttl:
         data["default_events_ttl"] = ruleset.default_events_ttl
 
+    if ruleset.delay_warning_threshold:
+        data["delay_warning_threshold"] = ruleset.delay_warning_threshold
+
     return {"RuleSet": data}
 
 

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -78,6 +78,7 @@ class RuleSet(NamedTuple):
     gather_facts: bool
     uuid: Optional[str] = None
     default_events_ttl: Optional[str] = None
+    delay_warning_threshold: Optional[str] = None
 
 
 class ActionContext(NamedTuple):

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -83,6 +83,7 @@ def parse_rule_sets(
                 gather_facts=rule_set.get("gather_facts", False),
                 uuid=str(uuid.uuid4()),
                 default_events_ttl=rule_set.get("default_events_ttl", None),
+                delay_warning_threshold=rule_set.get("delay_warning_threshold", None),
             )
         )
     return rule_set_list

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -18,6 +18,10 @@
                     "type": "string",
                     "pattern": "^\\d+\\s(seconds?|minutes?|hours?|days?)$"
                 },
+                "delay_warning_threshold": {
+                    "type": "string",
+                    "pattern": "^\\d+\\s(milliseconds?|seconds?|minutes?|hours?|days?)$"
+                },
                 "hosts": {
                     "type": "string"
                 },

--- a/docs/rulebooks.rst
+++ b/docs/rulebooks.rst
@@ -16,6 +16,7 @@ A ruleset has the following properties:
 * hosts similar to Ansible playbook
 * gather_facts: boolean
 * default_events_ttl: time to keep the partially matched events around (default is 2 hours)
+* delay_warning_threshold: Threshold to log a warn message when a rule is matched and the pseudo clock is how much diverged from the real clock (default is 5 seconds)
 * execution_strategy: How actions should be executed, sequential|parallel (default: sequential). For sequential strategy we wait for each action to finish before we kick off the next action.
 * sources: A list of sources
 * rules: a list of rules
@@ -28,8 +29,14 @@ A ruleset has the following properties:
 | The default_events_ttl takes time in the following format
 | default_events_ttl : nnn seconds|minutes|hours|days
 | e.g. default_events_ttl : 3 hours
-| If the rule set doesn't define this attribute the default events ttl that is 
+| If the rule set doesn't define this attribute the default events ttl that is
 | enforced by the rule engine is 2 hours
+
+| The delay_warning_threshold takes time in the following format
+| delay_warning_threshold : nnn milliseconds|seconds|minutes|hours|days
+| e.g. delay_warning_threshold : 2 seconds
+| If the rule set doesn't define this attribute the delay warning threshold that is
+| enforced by the rule engine is 5 seconds
 
 | When we start a rulebook we can optionally collect artifacts from the different hosts
 | if **gather_facts** is set to **true**. This host data is then uploaded to the Rules

--- a/tests/examples/79_delay_warning_threshold.yml
+++ b/tests/examples/79_delay_warning_threshold.yml
@@ -1,0 +1,22 @@
+---
+- name: 79 delay warning threshold
+  hosts: all
+  delay_warning_threshold: 1 milliseconds
+  sources:
+     - generic:
+          event_delay: 1
+          payload:
+            - i: 1
+            - j: 2
+            - k: 3
+  rules:
+     - name: r1
+       condition:
+         any:
+           - event.i == 1
+           - event.j == 2
+           - event.k == 3
+       action:
+         print_event:
+           pretty: true
+

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2224,3 +2224,31 @@ async def test_78_complete_retract_fact():
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "7"
     assert event_log.empty()
+
+
+@pytest.mark.asyncio
+async def test_79_delay_warning_threshold():
+    ruleset_queues, event_log = load_rulebook(
+        "examples/79_delay_warning_threshold.yml"
+    )
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    with SourceTask(rs.sources[0], "sources", {}, queue):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            dict(),
+            load_inventory("playbooks/inventory.yml"),
+        )
+
+        checks = {
+            "max_events": 4,
+            "shutdown_events": 1,
+            "actions": [
+                "79 delay warning threshold::r1::print_event",
+                "79 delay warning threshold::r1::print_event",
+                "79 delay warning threshold::r1::print_event",
+            ],
+        }
+        await validate_events(event_log, **checks)


### PR DESCRIPTION
…hreshold

https://issues.redhat.com/browse/AAP-13172

This draft PR is to support delay_warning_threshold, which will be available in drools_jpy 0.3.5, so this is not yet ready to merge. This will likely be rebased and ready for review after AAP-13075. At the moment, this is just a draft PR.