### PR TITLE
[AAP-13209] Skip connecting to controller if no run_job_template action

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -87,7 +87,9 @@ async def run(parsed_args: argparse.ArgumentParser) -> None:
         startup_args.controller_ssl_verify = parsed_args.controller_ssl_verify
 
     validate_actions(startup_args)
-    await validate_controller_params(startup_args)
+
+    if startup_args.check_controller_connection:
+        await validate_controller_params(startup_args)
 
     if parsed_args.websocket_address:
         event_log = asyncio.Queue()
@@ -225,6 +227,8 @@ def validate_actions(startup_args: StartupArgs) -> None:
     for ruleset in startup_args.rulesets:
         for rule in ruleset.rules:
             for action in rule.actions:
+                if action.action == "run_job_template":
+                    startup_args.check_controller_connection = True
                 if (
                     action.action in INVENTORY_ACTIONS
                     and not startup_args.inventory

--- a/ansible_rulebook/common.py
+++ b/ansible_rulebook/common.py
@@ -27,3 +27,4 @@ class StartupArgs:
     controller_ssl_verify: str = field(default="")
     project_data_file: str = field(default="")
     inventory: str = field(default="")
+    check_controller_connection: bool = field(default=False)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -157,6 +157,7 @@ async def test_run_with_websocket(create_ruleset):
                     controller_url="abc",
                     controller_token="token",
                     controller_ssl_verify="no",
+                    check_controller_connection=True,
                 )
                 with patch(
                     "ansible_rulebook.app.job_template_runner.get_config",


### PR DESCRIPTION
At startup once we validate the rulebook for actions if there is an action called run_job_template, we will validate the connection to the controller.

https://issues.redhat.com/browse/AAP-13209