### PR TITLE
AAP-10738 DROOLS-7475 Proposed feature for ['key'] accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Added
+- rulebook and Drools squared accessor syntax (AAP-10738, DROOLS-7475)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [Unreleased]
 
 ### Added
-- rulebook and Drools squared accessor syntax (AAP-10738, DROOLS-7475)
+- rulebook and Drools bracket notation syntax
 
 ### Fixed
 

--- a/ansible_rulebook/condition_parser.py
+++ b/ansible_rulebook/condition_parser.py
@@ -32,6 +32,7 @@ from pyparsing import (
     infix_notation,
     one_of,
     pyparsing_common,
+    originalTextFor,
 )
 
 from ansible_rulebook.exception import (
@@ -101,7 +102,18 @@ valid_prefix = (
     | Keyword("fact")
 )
 varname = (
-    Combine(valid_prefix + ZeroOrMore("." + ident))
+    Combine(valid_prefix + ZeroOrMore(
+        ("." + ident)
+        |
+        (
+            ("[")
+            + (
+                originalTextFor(QuotedString('"'))
+                | originalTextFor(QuotedString("'"))
+            )
+            + ("]")
+        )
+    ))
     .copy()
     .add_parse_action(lambda toks: Identifier(toks[0]))
 )

--- a/ansible_rulebook/condition_parser.py
+++ b/ansible_rulebook/condition_parser.py
@@ -31,8 +31,8 @@ from pyparsing import (
     delimitedList,
     infix_notation,
     one_of,
-    pyparsing_common,
     originalTextFor,
+    pyparsing_common,
 )
 
 from ansible_rulebook.exception import (

--- a/ansible_rulebook/condition_parser.py
+++ b/ansible_rulebook/condition_parser.py
@@ -111,6 +111,7 @@ varname = (
                 + (
                     originalTextFor(QuotedString('"'))
                     | originalTextFor(QuotedString("'"))
+                    | pyparsing_common.signed_integer
                 )
                 + ("]")
             )

--- a/ansible_rulebook/condition_parser.py
+++ b/ansible_rulebook/condition_parser.py
@@ -102,18 +102,20 @@ valid_prefix = (
     | Keyword("fact")
 )
 varname = (
-    Combine(valid_prefix + ZeroOrMore(
-        ("." + ident)
-        |
-        (
-            ("[")
-            + (
-                originalTextFor(QuotedString('"'))
-                | originalTextFor(QuotedString("'"))
+    Combine(
+        valid_prefix
+        + ZeroOrMore(
+            ("." + ident)
+            | (
+                ("[")
+                + (
+                    originalTextFor(QuotedString('"'))
+                    | originalTextFor(QuotedString("'"))
+                )
+                + ("]")
             )
-            + ("]")
         )
-    ))
+    )
     .copy()
     .add_parse_action(lambda toks: Identifier(toks[0]))
 )

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -48,6 +48,56 @@ The data type is of great importance for the rules engine. The following types a
 * floats (dot notation and scientific notation)
 * null
 
+Navigate structured data
+************************
+
+You can navigate strutured event, fact, var data objects using either dot notation or bracket notation:
+
+    .. code-block:: yaml
+
+      rules:
+        - name: Using dot notation
+          condition: event.something.nested == true
+          action:
+            debug:
+        - name: Analogous, but using bracket notation
+          condition: event.something["nested"] == true
+          action:
+            debug:
+
+Both of the above examples checks for the same value (attribute "nested" inside of "something") to be equal to `true`.
+
+Bracket notation might be preferable to dot notation when the structured data contains a key using symbols
+or other special characters:
+
+    .. code-block:: yaml
+
+      name: Looking for specific metadata
+      condition: event.resource.metadata.labels["app.kubernetes.io/name"] == "hello-pvdf"
+      action:
+        debug:
+
+You can find more information about dot notation and bracket notation also in the Ansible playbook `manual <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#referencing-key-value-dictionary-variables>`_.
+
+You can access list in strutured event, fact, var data objects using bracket notation too.
+The first item in a list is item 0, the second item is item 1.
+Like Python, you can access the `n`-to-last item in the list by supplying a negative index.
+For example:
+
+    .. code-block:: yaml
+
+      rules:
+        - name: Looking for the first item in the list
+          condition: event.letters[0] == "a"
+          action:
+            debug:
+        - name: Looking for the last item in the list
+          condition: event.letters[-1] == "z"
+          action:
+            debug:
+
+You can find more information the bracket notation for list also in the Ansible playbook `manual <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#referencing-list-variables>`_.
+
 Supported Operators
 *******************
 
@@ -796,6 +846,8 @@ Check if an item does not exist in a list based on a test
 | The value is based on the operator used, if the operator is regex then the value is a pattern.
 | If the operator is one of >,>=,<,<= then the value is either an integer or a float
 
+You can find more information for the *select* condition also in the Ansible playbook `manual <https://docs.ansible.com/ansible/latest/playbook_guide/complex_data_manipulation.html#loops-and-list-comprehensions>`_.
+
 Checking if an object exists in a list based on a test
 ------------------------------------------------------
 
@@ -833,6 +885,8 @@ Checking if an object does not exist in a list based on a test
 | The value is based on the operator used, if the operator is regex then the value is a pattern.
 | If the operator is one of >, >=, <, <= then the value is either an integer or a float.
 | If the operator is in or not in then the value is list of integer, float or string.
+
+You can find more information for the *selectattr* condition also in the Ansible playbook `manual <https://docs.ansible.com/ansible/latest/playbook_guide/complex_data_manipulation.html#loops-and-list-comprehensions>`_.
 
 
 FAQ

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.3.5
+	drools_jpy == 0.3.6
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.3.4
+	drools_jpy == 0.3.5
 
 [options.packages.find]
 include = 

--- a/tests/e2e/files/rulebooks/operators/test_logical_operators.yml
+++ b/tests/e2e/files/rulebooks/operators/test_logical_operators.yml
@@ -136,6 +136,15 @@
           - id: "Testcase #11"
             left_hand: 5
             right_hand: 5
+          - id: "Testcase #12"
+            asd:
+              x:
+              - 0
+              -
+                - 0
+                - 0
+                - a:
+                    b: 3.1415
 
 
 
@@ -222,4 +231,10 @@
       action:
         debug:
           msg: "Testcase #11 passes"
+
+    - name: "Testcase #12"
+      condition: event.asd["x"][1][2].a["b"] == 3.1415
+      action:
+        debug:
+          msg: "Testcase #12 passes"
 

--- a/tests/e2e/files/rulebooks/operators/test_selectattr_operator.yml
+++ b/tests/e2e/files/rulebooks/operators/test_selectattr_operator.yml
@@ -112,6 +112,15 @@
                     - 15
                     - 8121.99
                     - 1111
+          - id: "Testcase #12"
+            asd:
+              x:
+              - 0
+              -
+                - 0
+                - 0
+                - a:
+                    b: 3.1415
 
 
   rules:
@@ -213,3 +222,9 @@
       action:
         debug:
           msg: "Output for testcase #11"
+
+    - name: selectattr and squared accessor interaction
+      condition: event.asd["x"][1][2] is selectattr("a.b", "==", 3.1415)
+      action:
+        debug:
+          msg: "Output for testcase #12"

--- a/tests/e2e/test_operators.py
+++ b/tests/e2e/test_operators.py
@@ -494,6 +494,9 @@ def test_logical_operators(update_environment):
     with check:
         assert "Testcase #11 passes" in result.stdout, "Testcase #11 failed"
 
+    with check:
+        assert "Testcase #12 passes" in result.stdout, "Testcase #12 failed"
+
 
 @pytest.mark.e2e
 def test_string_match():
@@ -785,3 +788,15 @@ def test_selectattr_operator():
             )
             == 1
         ), "testcase #11 failed"
+
+    with check:
+        assert (
+            len(
+                [
+                    line
+                    for line in result.stdout.splitlines()
+                    if "Output for testcase #12" in line
+                ]
+            )
+            == 1
+        ), "testcase #12 failed"

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -85,8 +85,7 @@ def test_parse_condition():
             "rhs": {"Float": 3.1415},
         }
     } == visit_condition(
-        parse_condition('fact.range["pi"].value == 3.1415'),
-        {}
+        parse_condition('fact.range["pi"].value == 3.1415'), {}
     )
 
     assert {

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -62,6 +62,34 @@ def test_parse_condition():
     } == visit_condition(parse_condition("fact.range.i > 1"), {})
 
     assert {
+        "EqualsExpression": {
+            "lhs": {"Fact": "range['pi']"},
+            "rhs": {"Float": 3.1415},
+        }
+    } == visit_condition(parse_condition("fact.range['pi'] == 3.1415"), {})
+    assert {
+        "EqualsExpression": {
+            "lhs": {"Fact": 'range["pi"]'},
+            "rhs": {"Float": 3.1415},
+        }
+    } == visit_condition(parse_condition('fact.range["pi"] == 3.1415'), {})
+    # `Should start with event., events.,fact., facts. or vars.` semantic check
+    with pytest.raises(InvalidIdentifierException):
+        visit_condition(
+            parse_condition('fact["range"].pi == 3.1415'),
+            {},
+        )
+    assert {
+        "EqualsExpression": {
+            "lhs": {"Fact": 'range["pi"].value'},
+            "rhs": {"Float": 3.1415},
+        }
+    } == visit_condition(
+        parse_condition('fact.range["pi"].value == 3.1415'),
+        {}
+    )
+
+    assert {
         "NegateExpression": {
             "Event": "enabled",
         }

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -89,24 +89,20 @@ def test_parse_condition():
     )
     assert {
         "EqualsExpression": {
-            "lhs": {"Fact": 'range[0]'},
+            "lhs": {"Fact": "range[0]"},
             "rhs": {"Float": 3.1415},
         }
-    } == visit_condition(
-        parse_condition('fact.range[0] == 3.1415'), {}
-    )
+    } == visit_condition(parse_condition("fact.range[0] == 3.1415"), {})
     assert {
         "EqualsExpression": {
-            "lhs": {"Fact": 'range[-1]'},
+            "lhs": {"Fact": "range[-1]"},
             "rhs": {"Float": 3.1415},
         }
-    } == visit_condition(
-        parse_condition('fact.range[-1] == 3.1415'), {}
-    )
+    } == visit_condition(parse_condition("fact.range[-1] == 3.1415"), {})
     # invalid index must be signed int, not a floating point
     with pytest.raises(ConditionParsingException):
         visit_condition(
-            parse_condition('fact.range[-1.23] == 3.1415'),
+            parse_condition("fact.range[-1.23] == 3.1415"),
             {},
         )
     assert {

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -87,6 +87,36 @@ def test_parse_condition():
     } == visit_condition(
         parse_condition('fact.range["pi"].value == 3.1415'), {}
     )
+    assert {
+        "EqualsExpression": {
+            "lhs": {"Fact": 'range[0]'},
+            "rhs": {"Float": 3.1415},
+        }
+    } == visit_condition(
+        parse_condition('fact.range[0] == 3.1415'), {}
+    )
+    assert {
+        "EqualsExpression": {
+            "lhs": {"Fact": 'range[-1]'},
+            "rhs": {"Float": 3.1415},
+        }
+    } == visit_condition(
+        parse_condition('fact.range[-1] == 3.1415'), {}
+    )
+    # invalid index must be signed int, not a floating point
+    with pytest.raises(ConditionParsingException):
+        visit_condition(
+            parse_condition('fact.range[-1.23] == 3.1415'),
+            {},
+        )
+    assert {
+        "EqualsExpression": {
+            "lhs": {"Fact": 'range["x"][1][2].a["b"]'},
+            "rhs": {"Float": 3.1415},
+        }
+    } == visit_condition(
+        parse_condition('fact.range["x"][1][2].a["b"] == 3.1415'), {}
+    )
 
     assert {
         "NegateExpression": {


### PR DESCRIPTION
work-in-progress as i'm volunteering to work on this e2e, so this is a quite-complete draft for the ansible-rulebook side; i'll keep posted as i will progress on drools-ansible-rulebook-integration side.

EDIT: demonstrate working locally and added e2e test as requested

**JIRA**: https://issues.redhat.com/browse/DROOLS-7475

**referenced Pull Requests**: 

* https://github.com/ansible/ansible-rulebook/pull/539
* https://github.com/ansible/drools_jpy/pull/50
* https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/56
* https://github.com/kiegroup/drools/pull/5333
* https://issues.redhat.com/browse/AAP-10738
* https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/65
* https://github.com/ansible/drools_jpy/pull/51