### PR TITLE
chore: fix the pre-commit to fix json files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
     hooks:
       - id: pretty-format-json
         language_version: python3
+        args: [--autofix]


### PR DESCRIPTION
Our ruleset schema doesn't get autofixed when we make changes to it. This way in the first pass it will complain and fix it and we can git add it after the pre-commit runs