### PR TITLE
chore: for pretty_json indent should be 4 and dont sort keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
     hooks:
       - id: pretty-format-json
         language_version: python3
-        args: [--autofix]
+        args: ['--autofix', '--no-sort-keys', '--indent', '4']

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -30,7 +30,10 @@
                 },
                 "execution_strategy": {
                     "type": "string",
-                    "enum": ["sequential", "parallel"],
+                    "enum": [
+                        "parallel",
+                        "sequential"
+                    ],
                     "default": "sequential"
                 },
                 "sources": {


### PR DESCRIPTION
The pretty-format-json has a default indent of 2 spaces which causes our json file to change completely, set indent to be 4