### PR TITLE
Support ppc64le and s390x for container image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -18,7 +18,14 @@ jobs:
     permissions:
       contents: read
       packages: write
-
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/s390x
+          - linux/ppc64le
+          - linux/arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -46,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - support-extra-archs
     tags:
       - "v*"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ARG DEVEL_COLLECTION_LIBRARY=0
 WORKDIR $HOME
 
 USER 0
-RUN dnf install -y java-17-openjdk-devel
+RUN dnf install -y java-17-openjdk-devel rustc \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 RUN pip install -U pip \
     && pip install ansible \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi9/python-39
 
 ARG USER_ID=${USER_ID:-1001}
 ARG DEVEL_COLLECTION_LIBRARY=0
@@ -6,6 +6,7 @@ WORKDIR $HOME
 
 USER 0
 RUN pip install -U pip
+
 RUN dnf install -y java-17-openjdk-devel rustc cargo \
     && dnf clean all \
     && rm -rf /var/cache/dnf

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG DEVEL_COLLECTION_LIBRARY=0
 WORKDIR $HOME
 
 USER 0
-RUN dnf install -y java-17-openjdk-devel rustc \
+RUN dnf install -y java-17-openjdk-devel rustc cargo \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG DEVEL_COLLECTION_LIBRARY=0
 WORKDIR $HOME
 
 USER 0
+RUN pip install -U pip
 RUN dnf install -y java-17-openjdk-devel rustc cargo \
     && dnf clean all \
     && rm -rf /var/cache/dnf


### PR DESCRIPTION
Includes:
- Support for ppc64le and s390x
- Parallel build
- Install rustc as a requirement for building cryptography with these archs. 
- Improve dnf install step. 
https://issues.redhat.com/browse/AAP-13544