### PR TITLE
fix: wrong 401 from AWX with 443 port - issue #554 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Fixed
+- Fixes a wrong 401 response from AWX when 443 is present in an https CONTROLLER_URL (<https://github.com/ansible/ansible-rulebook/issues/554>)
 
 ### Removed
 - Remove official support for Python 3.8

--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -33,8 +33,8 @@ logger = logging.getLogger(__name__)
 
 
 class JobTemplateRunner:
-    JOB_TEMPLATE_SLUG = "/api/v2/job_templates"
-    CONFIG_SLUG = "/api/v2/config"
+    JOB_TEMPLATE_SLUG = "/api/v2/job_templates/"
+    CONFIG_SLUG = "/api/v2/config/"
     JOB_COMPLETION_STATUSES = ["successful", "failed", "error", "canceled"]
 
     def __init__(


### PR DESCRIPTION
Avoid unnecessary redirects from AWX. 
Fixes https://github.com/ansible/ansible-rulebook/issues/554

