### PR TITLE
fix: [AAP-14735] process output from a module

### DIFF
--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -156,3 +156,8 @@ class UnsupportedActionException(Exception):
 class InventoryNotFound(Exception):
 
     pass
+
+
+class MissingArtifactKeyException(Exception):
+
+    pass

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -351,9 +351,6 @@
                 "run_module": {
                     "type": "object",
                     "properties": {
-                        "copy_files": {
-                            "type": "boolean"
-                        },
                         "name": {
                             "type": "string"
                         },
@@ -385,7 +382,10 @@
                             "type": "number"
                         },
                         "module_args": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "extra_vars": {
                             "type": "object"

--- a/tests/e2e/test_actions.py
+++ b/tests/e2e/test_actions.py
@@ -173,7 +173,7 @@ def test_actions_sanity(update_environment):
         ), "multiple_action action failed"
 
     assert (
-        len(result.stdout.splitlines()) == 56
+        len(result.stdout.splitlines()) == 106
     ), "unexpected output from the rulebook"
 
 

--- a/tests/examples/29_run_module.yml
+++ b/tests/examples/29_run_module.yml
@@ -9,14 +9,11 @@
       condition: event.i == 1
       action:
         run_module:
+          post_events: True
           name: ansible.eda.upcase
           module_args:
               name: Fred Flintstone
-
-
-
-
-
-
-
-
+    - name: r2
+      condition: event.message == "FRED FLINTSTONE"
+      action:
+        print_event:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -843,7 +843,7 @@ async def test_29_run_module():
 
     event = event_log.get_nowait()
     assert event["type"] == "Job", "0"
-    for i in range(4):
+    for i in range(9):
         assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
 
     event = event_log.get_nowait()
@@ -857,6 +857,9 @@ async def test_29_run_module():
     }
     assert event["rc"] == 0, "2.1"
     assert event["status"] == "successful", "2.2"
+    event = event_log.get_nowait()
+    assert event["type"] == "Action"
+    assert event["action"] == "print_event"
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "8"
     assert event_log.empty()
@@ -881,14 +884,14 @@ async def test_30_run_module_missing():
 
     event = event_log.get_nowait()
     assert event["type"] == "Job", "0"
-    for i in range(4):
+    for i in range(10):
         assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
 
     event = event_log.get_nowait()
     assert event["type"] == "Action", "1"
     assert event["action"] == "run_module", "2"
 
-    assert event["rc"] == 2, "2.1"
+    assert event["rc"] == 4, "2.1"
     assert event["status"] == "failed", "2.2"
     event = event_log.get_nowait()
     assert event["type"] == "Shutdown", "8"
@@ -914,7 +917,7 @@ async def test_31_run_module_missing_args():
 
     event = event_log.get_nowait()
     assert event["type"] == "Job", "0"
-    for i in range(4):
+    for i in range(6):
         assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
 
     event = event_log.get_nowait()
@@ -947,7 +950,7 @@ async def test_32_run_module_fail():
 
     event = event_log.get_nowait()
     assert event["type"] == "Job", "0"
-    for i in range(8):
+    for i in range(12):
         assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
 
     event = event_log.get_nowait()


### PR DESCRIPTION
Wraps the module into a playbook and runs the playbook via ansible runner. This gives us the ability to get the module output.

https://issues.redhat.com/browse/AAP-14735

The following is a sample wrapper for a module, the module_args can be a string or it can be a dictionary.

```yaml
- gather_facts: false
  hosts: all
  name: wrapper
  tasks:
  - ansible.eda.upcase:
      name: Fred Flintstone
    name: Module wrapper
    register: module_result
  - ansible.builtin.set_fact:
      cacheable: true
      module_result: '{{ module_result }}'
    name: save result
```