### PR TITLE
Add trailing slash to config slug in awx client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix an issue where rule_run_at field is not send to the websocket
 - Don't try to connect with AWX when no run_job_template action is used
 - Limits the number of simultaneously open connections to controller to 30
+- Fixes a wrong 401 response from AWX when 443 port is present in CONTROLLER_URL (<https://github.com/ansible/ansible-rulebook/issues/554>)
 
 
 ### Removed

--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 class JobTemplateRunner:
     UNIFIED_TEMPLATE_SLUG = "/api/v2/unified_job_templates/"
-    CONFIG_SLUG = "/api/v2/config"
+    CONFIG_SLUG = "/api/v2/config/"
     JOB_COMPLETION_STATUSES = ["successful", "failed", "error", "canceled"]
 
     def __init__(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -39,7 +39,7 @@ from .data.awx_test_data import (
     UNIFIED_JOB_TEMPLATE_PAGE2_SLUG,
 )
 
-CONFIG_SLUG = "/api/v2/config"
+CONFIG_SLUG = "/api/v2/config/"
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes: https://github.com/ansible/ansible-rulebook/issues/554
Jira: https://issues.redhat.com/browse/AAP-14215