### PR TITLE
test: changed examples to use the ansible.eda.generic

### DIFF
--- a/tests/examples/27_var_root.yml
+++ b/tests/examples/27_var_root.yml
@@ -3,7 +3,7 @@
   hosts: all
   sources:
     - name: generic
-      generic:
+      ansible.eda.generic:
         payload:
           - webhook:
               payload:

--- a/tests/examples/36_multiple_rulesets_both_fired.yml
+++ b/tests/examples/36_multiple_rulesets_both_fired.yml
@@ -2,7 +2,7 @@
 - name: 36 multiple rulesets 1
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         loop_count: 5
         startup_delay: 1
         create_index: i
@@ -23,7 +23,7 @@
 - name: 36 multiple rulesets 2
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         loop_count: 5
         shutdown_after: 10
         payload:

--- a/tests/examples/42_contains.yml
+++ b/tests/examples/42_contains.yml
@@ -3,7 +3,7 @@
   hosts: all
   sources:
     - name: generic
-      generic:
+      ansible.eda.generic:
         payload:
           - id_list:
              - 1

--- a/tests/examples/43_not_contains.yml
+++ b/tests/examples/43_not_contains.yml
@@ -3,7 +3,7 @@
   hosts: all
   sources:
     - name: generic
-      generic:
+      ansible.eda.generic:
         payload:
           - id_list:
              - 1

--- a/tests/examples/47_generic_plugin.yml
+++ b/tests/examples/47_generic_plugin.yml
@@ -3,7 +3,7 @@
   hosts: all
   sources:
     - name: generic
-      generic:
+      ansible.eda.generic:
         payload:
            - b: true
            - i: 42

--- a/tests/examples/49_float.yml
+++ b/tests/examples/49_float.yml
@@ -3,7 +3,7 @@
   hosts: all
   sources:
     - name: generic
-      generic:
+      ansible.eda.generic:
         payload:
           - pi: 3.14159
           - mass: 5.97219

--- a/tests/examples/50_negation.yml
+++ b/tests/examples/50_negation.yml
@@ -3,7 +3,7 @@
   hosts: all
   sources:
     - name: generic
-      generic:
+      ansible.eda.generic:
         payload:
            - b: false
            - bt: true

--- a/tests/examples/51_vars_namespace.yml
+++ b/tests/examples/51_vars_namespace.yml
@@ -2,7 +2,7 @@
 - name: 51 vars namespace
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           - name: Fred Flintstone
             address:

--- a/tests/examples/52_once_within.yml
+++ b/tests/examples/52_once_within.yml
@@ -2,7 +2,7 @@
 - name: 52 once within
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         loop_count: 20
         payload:
           - alert:

--- a/tests/examples/53_once_within_multiple_hosts.yml
+++ b/tests/examples/53_once_within_multiple_hosts.yml
@@ -2,7 +2,7 @@
 - name: 53 once within multiple hosts
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         loop_count: 20
         payload:
           - alert:

--- a/tests/examples/54_time_window.yml
+++ b/tests/examples/54_time_window.yml
@@ -2,7 +2,7 @@
 - name: 54 time window
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         create_index: event_index
         shutdown_after: 15
         event_delay: 5

--- a/tests/examples/55_not_all.yml
+++ b/tests/examples/55_not_all.yml
@@ -2,7 +2,7 @@
 - name: 55 not all
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         create_index: event_index
         timestamp: true
         event_delay: 15

--- a/tests/examples/56_once_after.yml
+++ b/tests/examples/56_once_after.yml
@@ -2,7 +2,7 @@
 - name: 56 once after
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         loop_count: 2
         loop_delay: 1
         timestamp: true

--- a/tests/examples/57_once_after_multi.yml
+++ b/tests/examples/57_once_after_multi.yml
@@ -2,7 +2,7 @@
 - name: 57 once after multiple
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         loop_count: 3
         loop_delay: 18
         shutdown_after: 60

--- a/tests/examples/58_string_search.yml
+++ b/tests/examples/58_string_search.yml
@@ -3,7 +3,7 @@
   hosts: all
   sources:
     - name: generic
-      generic:
+      ansible.eda.generic:
         payload:
           - url1: "https://example.com/users/foo/resources/bar"
           - url2: "https://example.com/groups/foo/resources/bar"

--- a/tests/examples/60_json_filter.yml
+++ b/tests/examples/60_json_filter.yml
@@ -2,7 +2,7 @@
 - name: 60 json filter
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           key1:
             key2:

--- a/tests/examples/61_select_1.yml
+++ b/tests/examples/61_select_1.yml
@@ -2,7 +2,7 @@
 - name: 61 select 1
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           - name: Fred
             age: 54

--- a/tests/examples/62_select_2.yml
+++ b/tests/examples/62_select_2.yml
@@ -2,7 +2,7 @@
 - name: 62 select 2
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           - name: Fred
             age: 54

--- a/tests/examples/63_selectattr_1.yml
+++ b/tests/examples/63_selectattr_1.yml
@@ -2,7 +2,7 @@
 - name: 63 selectattr 1
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           - people:
              - person:

--- a/tests/examples/64_selectattr_2.yml
+++ b/tests/examples/64_selectattr_2.yml
@@ -2,7 +2,7 @@
 - name: 64 selectattr 2
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           - people:
              - person:

--- a/tests/examples/65_selectattr_3.yml
+++ b/tests/examples/65_selectattr_3.yml
@@ -2,7 +2,7 @@
 - name: 65 selectattr 3
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
              - person:
                  name: Fred

--- a/tests/examples/66_sleepy_playbook.yml
+++ b/tests/examples/66_sleepy_playbook.yml
@@ -2,7 +2,7 @@
 - name: 66 sleepy playbook
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         create_index: i
         loop_count: 5
         shutdown_after: 45
@@ -21,7 +21,7 @@
 - name: terminate gracefully
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         create_index: j
         loop_count: 5
         shutdown_after: 45

--- a/tests/examples/67_shutdown_now.yml
+++ b/tests/examples/67_shutdown_now.yml
@@ -2,7 +2,7 @@
 - name: 67 shutdown now
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         create_index: i
         loop_count: 5
         shutdown_after: 45
@@ -21,7 +21,7 @@
 - name: terminate now
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         create_index: j
         loop_count: 5
         shutdown_after: 45

--- a/tests/examples/70_null.yml
+++ b/tests/examples/70_null.yml
@@ -2,7 +2,7 @@
 - name: 70 null
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           - x: 1
             y: null

--- a/tests/examples/72_set_fact_with_type.yml
+++ b/tests/examples/72_set_fact_with_type.yml
@@ -2,7 +2,7 @@
 - name: 72 set fact with type
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         shutdown_after: 1
         payload:
           - action: "go"

--- a/tests/examples/73_mix_and_match_list.yml
+++ b/tests/examples/73_mix_and_match_list.yml
@@ -2,7 +2,7 @@
 - name: 73 mix and match list 
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           - my_bool: false
           - my_str: fred

--- a/tests/examples/74_self_referential.yml
+++ b/tests/examples/74_self_referential.yml
@@ -2,7 +2,7 @@
 - name: 74 Self referential
   hosts: all
   sources:
-    - generic:
+    - ansible.eda.generic:
         payload:
           - x: Fred
             y: Fred

--- a/tests/examples/75_all_conditions.yml
+++ b/tests/examples/75_all_conditions.yml
@@ -2,7 +2,7 @@
 - name: 75 all conditions
   hosts: all
   sources:
-     - generic:
+     - ansible.eda.generic:
           payload:
              - friend_list:
                  names:

--- a/tests/examples/76_all_conditions.yml
+++ b/tests/examples/76_all_conditions.yml
@@ -2,7 +2,7 @@
 - name: 76 all conditions
   hosts: all
   sources:
-     - generic:
+     - ansible.eda.generic:
           payload:
              - request:
                  type: Delete

--- a/tests/examples/77_default_events_ttl.yml
+++ b/tests/examples/77_default_events_ttl.yml
@@ -3,7 +3,7 @@
   hosts: all
   default_events_ttl: 2 seconds
   sources:
-     - generic:
+     - ansible.eda.generic:
           event_delay: 4
           payload:
             - i: 1


### PR DESCRIPTION
Since we have the generic source plugin in the eda collection we can switch the source to use the one from collection