### PR TITLE
Connecting to controller if run_workflow_template too

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -57,6 +57,7 @@ class NullQueue:
 
 logger = logging.getLogger(__name__)
 INVENTORY_ACTIONS = ("run_playbook", "run_module")
+CONTROLLER_ACTIONS = ("run_job_template", "run_workflow_template")
 
 
 # FIXME(cutwater): Replace parsed_args with clear interface
@@ -234,10 +235,7 @@ def validate_actions(startup_args: StartupArgs) -> None:
     for ruleset in startup_args.rulesets:
         for rule in ruleset.rules:
             for action in rule.actions:
-                if action.action in [
-                    "run_job_template",
-                    "run_workflow_template",
-                ]:
+                if action.action in CONTROLLER_ACTIONS:
                     startup_args.check_controller_connection = True
                 if (
                     action.action in INVENTORY_ACTIONS
@@ -249,8 +247,7 @@ def validate_actions(startup_args: StartupArgs) -> None:
                     )
 
                 if (
-                    action.action
-                    in ["run_job_template", "run_workflow_template"]
+                    action.action in CONTROLLER_ACTIONS
                     and not startup_args.controller_url
                     and not startup_args.controller_token
                 ):

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -249,7 +249,6 @@ def validate_actions(startup_args: StartupArgs) -> None:
                     )
 
                 if (
-                    # action.action == "run_job_template"
                     action.action
                     in ["run_job_template", "run_workflow_template"]
                     and not startup_args.controller_url

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -234,8 +234,10 @@ def validate_actions(startup_args: StartupArgs) -> None:
     for ruleset in startup_args.rulesets:
         for rule in ruleset.rules:
             for action in rule.actions:
-                if action.action in ["run_job_template",
-                                     "run_workflow_template"]:
+                if action.action in [
+                    "run_job_template",
+                    "run_workflow_template",
+                ]:
                     startup_args.check_controller_connection = True
                 if (
                     action.action in INVENTORY_ACTIONS
@@ -248,8 +250,8 @@ def validate_actions(startup_args: StartupArgs) -> None:
 
                 if (
                     # action.action == "run_job_template"
-                    action.action in ["run_job_template",
-                                      "run_workflow_template"]
+                    action.action
+                    in ["run_job_template", "run_workflow_template"]
                     and not startup_args.controller_url
                     and not startup_args.controller_token
                 ):

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -234,7 +234,8 @@ def validate_actions(startup_args: StartupArgs) -> None:
     for ruleset in startup_args.rulesets:
         for rule in ruleset.rules:
             for action in rule.actions:
-                if action.action == "run_job_template":
+                if action.action in ["run_job_template",
+                                     "run_workflow_template"]:
                     startup_args.check_controller_connection = True
                 if (
                     action.action in INVENTORY_ACTIONS
@@ -246,7 +247,9 @@ def validate_actions(startup_args: StartupArgs) -> None:
                     )
 
                 if (
-                    action.action == "run_job_template"
+                    # action.action == "run_job_template"
+                    action.action in ["run_job_template",
+                                      "run_workflow_template"]
                     and not startup_args.controller_url
                     and not startup_args.controller_token
                 ):


### PR DESCRIPTION
In ansible-rulebook 1.0.1 (#538), the connection to the controller was checked only when using the `run_job_template` action.

In ansible-rulebook 1.0.2 (#543), `run_workflow_template` action was added.

This PR allows checking the connection to the controller even when using the `run_workflow_template` action.