### PR TITLE
AAP-15000: Changes to container image to reduce overall size

### DIFF
--- a/.github/actions/image-test/action.yml
+++ b/.github/actions/image-test/action.yml
@@ -18,6 +18,6 @@ runs:
     - name: Run tests
       shell: bash
       run: >
-        docker run --rm -u 0 localhost/ansible-rulebook:test bash -c '
+        docker run --rm localhost/ansible-rulebook:test bash -c '
         pip install -r requirements_test.txt &&
         pytest -m "e2e" -n auto'


### PR DESCRIPTION
Closes [AAP-15000](https://issues.redhat.com/browse/AAP-15000).

The main changes are switching to Centos stream image and installing ansible-core instead of the full ansible package.
Image size is reduced from ~2gb to ~500mb.
Tests in the eda-qa test suite are passing with this image.