### PR TITLE
fix: workflow_template job url was incorrect

### DIFF
--- a/ansible_rulebook/builtin.py
+++ b/ansible_rulebook/builtin.py
@@ -26,6 +26,7 @@ from asyncio.exceptions import CancelledError
 from functools import partial
 from pprint import pprint
 from typing import Callable, Dict, List, Optional, Union
+from urllib.parse import urljoin
 
 import ansible_runner
 import dpath
@@ -835,7 +836,7 @@ async def run_job_template(
         rule_uuid=source_rule_uuid,
         status=controller_job["status"],
         run_at=controller_job["created"],
-        url=_controller_job_url(controller_job),
+        url=_controller_job_url(controller_job, "jobs"),
         matching_events=_get_events(variables),
         rule_run_at=rule_run_at,
     )
@@ -954,7 +955,7 @@ async def run_workflow_template(
         rule_uuid=source_rule_uuid,
         status=controller_job["status"],
         run_at=controller_job["created"],
-        url=_controller_job_url(controller_job),
+        url=_controller_job_url(controller_job, "jobs/workflow"),
         matching_events=_get_events(variables),
         rule_run_at=rule_run_at,
     )
@@ -1084,9 +1085,10 @@ def _embellish_internal_event(event: Dict, method_name: str) -> Dict:
     )
 
 
-def _controller_job_url(data: dict) -> str:
+def _controller_job_url(data: dict, prefix: str) -> str:
     if "id" in data:
-        return f"{job_template_runner.host}/#/jobs/{data['id']}/details"
+        href_slug = f"/#/{prefix}/{data['id']}/details"
+        return urljoin(job_template_runner.host, href_slug)
     return ""
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2303,7 +2303,7 @@ async def test_79_workflow_job_template():
         status="successful", id=945, created="dummy", artifacts=dict(a=1)
     )
     job_template_runner.host = "https://examples.com"
-    job_url = "https://examples.com/#/jobs/945/details"
+    job_url = "https://examples.com/#/jobs/workflow/945/details"
     with SourceTask(rs.sources[0], "sources", {}, queue):
         with patch(
             "ansible_rulebook.builtin.job_template_runner."


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-15939
The job ui url for workflow template was incorrect it was missing workflow in the path.

e.g. https://<controller_ip>/#/jobs/workflow/3822/details