### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,7 @@ ENV/
 
 # awx provision
 tests/e2e/utils/awx/artifacts
+
+# Mac
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
On Mac we were not ignoring the .DS_Store