### PR TITLE
chore: ruleset.name is required parameter

### DIFF
--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -56,6 +56,7 @@
                 }
             },
             "required": [
+                "name",
                 "hosts",
                 "sources",
                 "rules"


### PR DESCRIPTION
Every ruleset should have a name so we can post events/facts between them.