### PR TITLE
ci: rollback exclude files for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
   pull_request:
     branches:
       - "main"
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
exclude paths is incompatible with required checks. 
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks