### PR TITLE
fix: failing e2e tests in CI due to ipv6 binding

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -31,6 +31,7 @@ jobs:
         pytest -m "e2e" -n auto'
 
   build-and-push-image:
+    needs: build-and-test-image
     if: github.repository == 'ansible/ansible-rulebook'
     runs-on: ubuntu-latest
     permissions:

--- a/tests/e2e/test_match_multiple_rules.py
+++ b/tests/e2e/test_match_multiple_rules.py
@@ -28,7 +28,7 @@ async def test_match_multiple_rules():
     proc_id = "42"
     port = 31415
     rulebook = utils.BASE_DATA_PATH / "rulebooks/test_match_multiple_rules.yml"
-    websocket_address = f"ws://localhost:{port}{endpoint}"
+    websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(
         rulebook=rulebook,
         websocket=websocket_address,

--- a/tests/e2e/test_non_alpha_keys.py
+++ b/tests/e2e/test_non_alpha_keys.py
@@ -28,7 +28,7 @@ async def test_non_alpha_numeric_keys():
     proc_id = "42"
     port = 31415
     rulebook = utils.EXAMPLES_PATH / "82_non_alpha_keys.yml"
-    websocket_address = f"ws://localhost:{port}{endpoint}"
+    websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(
         rulebook=rulebook,
         websocket=websocket_address,

--- a/tests/e2e/test_run_module_output.py
+++ b/tests/e2e/test_run_module_output.py
@@ -28,7 +28,7 @@ async def test_run_module_output():
     proc_id = "42"
     port = 31415
     rulebook = utils.EXAMPLES_PATH / "29_run_module.yml"
-    websocket_address = f"ws://localhost:{port}{endpoint}"
+    websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(
         rulebook=rulebook,
         websocket=websocket_address,

--- a/tests/e2e/test_websocket.py
+++ b/tests/e2e/test_websocket.py
@@ -29,7 +29,7 @@ async def test_websocket_messages():
     rulebook = (
         utils.BASE_DATA_PATH / "rulebooks/websockets/test_websocket_range.yml"
     )
-    websocket_address = f"ws://localhost:{port}{endpoint}"
+    websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(
         rulebook=rulebook,
         websocket=websocket_address,


### PR DESCRIPTION
Some tests in the e2e suite are attempting to bind to ipv6 in the CI pipeline. Switching 'localhost' for '127.0.0.1' to prevent these failures.

Also updating the build-and-push-image CI job to run only if the e2e tests pass.