### PR TITLE
fix: e2e test ws binding to ipv6

### DIFF
--- a/tests/e2e/test_match_multiple_rules.py
+++ b/tests/e2e/test_match_multiple_rules.py
@@ -23,7 +23,7 @@ async def test_match_multiple_rules():
     and send the event messages to a websocket server
     """
     # variables
-    host = "localhost"
+    host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
     port = 31415

--- a/tests/e2e/test_non_alpha_keys.py
+++ b/tests/e2e/test_non_alpha_keys.py
@@ -23,7 +23,7 @@ async def test_non_alpha_numeric_keys():
     and send the event messages to a websocket server
     """
     # variables
-    host = "localhost"
+    host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
     port = 31415

--- a/tests/e2e/test_run_module_output.py
+++ b/tests/e2e/test_run_module_output.py
@@ -23,7 +23,7 @@ async def test_run_module_output():
     run_module and then used in a condition
     """
     # variables
-    host = "localhost"
+    host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
     port = 31415

--- a/tests/e2e/test_websocket.py
+++ b/tests/e2e/test_websocket.py
@@ -22,7 +22,7 @@ async def test_websocket_messages():
     send event messages to a websocket server
     """
     # variables
-    host = "localhost"
+    host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
     port = 31415


### PR DESCRIPTION
Missed to update the 'host' variable, which is used for instantiating the websocket server.