### PR TITLE
ci: add more configuration for commitlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,5 @@ repos:
     rev: v9.5.0
     hooks:
       - id: commitlint
+        additional_dependencies: ['@commitlint/config-conventional']
         stages: [commit-msg]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,7 +4,6 @@ module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
         'body-max-line-length': [2, 'always', Infinity],
-        'subject-case': [0, 'always', 'lower-case'],
         'body-case': [0, 'always', 'lower-case'],
     },
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,6 +4,5 @@ module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
         'body-max-line-length': [2, 'always', Infinity],
-        'body-case': [0, 'always', 'lower-case'],
     },
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,6 +3,8 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
-        'body-max-line-length': [2, 'always', '*'],
+        'body-max-line-length': [2, 'always', Infinity],
+        'subject-case': [0, 'always', 'lower-case'],
+        'body-case': [0, 'always', 'lower-case'],
     },
 };

--- a/docs/development_environment.rst
+++ b/docs/development_environment.rst
@@ -53,8 +53,13 @@ To get flake8 and tox, just pip install them into your virtualenv.
 7. Commit your changes and push your branch to GitHub:
    We follow the conventionalcommit_ standards for commit message
    During the pre-commit phase we will validate the commit message
+   You have to install the hook with the following command:
 
-.. _conventionalcommit : https://www.conventionalcommits.org/en/v1.0.0/  
+.. code-block:: console
+
+    pre-commit install --hook-type commit-msg
+
+.. _conventionalcommit : https://www.conventionalcommits.org/en/v1.0.0/
 
 .. code-block:: console
 


### PR DESCRIPTION
- Disable subject-case: we might use acronyms or jira tickets that will contain uppercase letters. 
- Fix wrong configuration for body length
- Add a dependency to pre-commit
- Extends docs for commitlint with pre-commit