### PR TITLE
chore: fix bump2version config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 1.0.2
-commit = True
-tag = True
+commit = False
+tag = False
 search = {current_version}
 
 [bumpversion:file:setup.cfg]


### PR DESCRIPTION
- the bump2version commit doesn't conform to commitlint hence disabling it
- the tag creation has also been disabled since the tag is created before the PR is merged.

This was discovered when trying to create a 1.0.3 release of the product