### PR TITLE
chore: add missing dependency: watchdog

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
 	ansible-runner
 	websockets
 	drools_jpy == 0.3.7
+    watchdog
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Add a missing dependency required by https://github.com/ansible/ansible-rulebook/pull/516
Closes: https://github.com/ansible/ansible-rulebook/issues/609