### PR TITLE
feat: allow for explicit boolean in condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Added
+- Support for standalone boolean in conditions
 
 ### Fixed
 

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -189,6 +189,8 @@ def parse_action(action: Dict) -> rt.Action:
 def parse_condition(condition: Any) -> rt.Condition:
     if isinstance(condition, str):
         return rt.Condition("all", [parse_condition_value(condition)])
+    elif isinstance(condition, bool):
+        return rt.Condition("all", [parse_condition_value(str(condition))])
     elif isinstance(condition, dict):
         timeout = condition.pop("timeout", None)
         keys = list(condition.keys())
@@ -196,7 +198,7 @@ def parse_condition(condition: Any) -> rt.Condition:
             when = keys[0]
             return rt.Condition(
                 when,
-                [parse_condition_value(c) for c in condition[when]],
+                [parse_condition_value(str(c)) for c in condition[when]],
                 timeout,
             )
         else:

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -157,6 +157,9 @@
                             "type": "string"
                         },
                         {
+                            "type": "boolean"
+                        },
+                        {
                             "$ref": "#/$defs/all-condition"
                         },
                         {

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -185,6 +185,22 @@ Single condition
 
 When an event comes with ``outage`` attribute as true, the specified playbook is executed.
 
+Single boolean
+--------------
+
+    .. code-block:: yaml
+
+        name: An automatic remediation rule
+        condition: event.outage
+        action:
+          run_playbook:
+            name: remediate_outage.yml
+
+If the ``outage`` attribute is a boolean, you can use it
+by itself in the condition. This is a shorter version of
+the previous example. If the value is true the condition
+passes and the action is triggered.
+
 Multiple conditions where **all** of them have to match
 -------------------------------------------------------
 

--- a/tests/examples/83_boolean_true.yml
+++ b/tests/examples/83_boolean_true.yml
@@ -1,0 +1,12 @@
+---
+- name: "83 boolean true"
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 3
+  rules:
+    - name: r1
+      condition: true
+      action:
+        print_event:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2408,3 +2408,29 @@ async def test_82_non_alpha_keys():
             ],
         }
         await validate_events(event_log, **checks)
+
+
+@pytest.mark.asyncio
+async def test_83_boolean_true():
+    ruleset_queues, event_log = load_rulebook("examples/83_boolean_true.yml")
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    with SourceTask(rs.sources[0], "sources", {}, queue):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            dict(),
+            dict(),
+        )
+
+        checks = {
+            "max_events": 4,
+            "shutdown_events": 1,
+            "actions": [
+                "83 boolean true::r1::print_event",
+                "83 boolean true::r1::print_event",
+                "83 boolean true::r1::print_event",
+            ],
+        }
+        await validate_events(event_log, **checks)


### PR DESCRIPTION
Since rules have a condition if we need the condition to fire everytime for some usecases (like repeater) you can set the condition to true

e.g.
```
  rules:
    - name: r1
      condition: true
      action:
        print_event:
```

Currently we support this
```
   - name: r1
      condition: "true == true"
      action:
        print_event:
```