### PR TITLE
chore: optionally allow to use a separate collection repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM registry.access.redhat.com/ubi8/python-39
 
 ARG USER_ID=${USER_ID:-1001}
 ARG DEVEL_COLLECTION_LIBRARY=0
+ARG DEVEL_COLLECTION_REPO=git+https://github.com/ansible/event-driven-ansible.git
 WORKDIR $HOME
 
 USER 0
@@ -19,7 +20,7 @@ RUN pip install -U pip \
     && ansible-galaxy collection install ansible.eda
 
 RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \
-    ansible-galaxy collection install git+https://github.com/ansible/event-driven-ansible.git --force; fi"
+    ansible-galaxy collection install ${DEVEL_COLLECTION_REPO} --force; fi"
 
 COPY . $WORKDIR
 RUN chown -R $USER_ID ./


### PR DESCRIPTION
When developing new features which involves using newer collection we need access to the collection in the image. When doing a developer build of an image provide a build arg for the name of repo

e.g.
```
podman build --build-arg DEVEL_COLLECTION_LIBRARY=1 --build-arg DEVEL_COLLECTION_REPO=git+https://github.com/mkanoor/event-driven-ansible.git,pg_listener -t localhost/ansible-rulebook:latest .
```