### PR TITLE
refactor: changed some info to debug

### DIFF
--- a/ansible_rulebook/action/run_job_template.py
+++ b/ansible_rulebook/action/run_job_template.py
@@ -58,7 +58,7 @@ class RunJobTemplate:
             self.name,
             self.organization,
         )
-        logger.info(
+        logger.debug(
             "ruleset: %s, rule %s",
             self.helper.metadata.rule_set,
             self.helper.metadata.rule,

--- a/ansible_rulebook/action/run_playbook.py
+++ b/ansible_rulebook/action/run_playbook.py
@@ -68,14 +68,14 @@ class RunPlaybook:
 
     async def __call__(self):
         try:
-            logger.info(
+            logger.debug(
                 f"ruleset: {self.helper.metadata.rule_set}, "
                 f"rule: {self.helper.metadata.rule}"
             )
             logger.debug("private data dir %s", self.private_data_dir)
             await self._pre_process()
             await self._job_start_event()
-            logger.info("Calling Ansible runner")
+            logger.debug("Calling Ansible runner")
             await self._run()
         finally:
             if os.path.exists(self.private_data_dir):

--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -58,7 +58,7 @@ class RunWorkflowTemplate:
             self.name,
             self.organization,
         )
-        logger.info(
+        logger.debug(
             "ruleset: %s, rule %s",
             self.helper.metadata.rule_set,
             self.helper.metadata.rule,

--- a/ansible_rulebook/rule_generator.py
+++ b/ansible_rulebook/rule_generator.py
@@ -69,7 +69,7 @@ def make_fn(
     plan: Plan,
 ) -> Callable:
     def fn(rule_engine_results):
-        logger.info("calling %s", ansible_rule.name)
+        logger.debug("callback calling %s", ansible_rule.name)
         add_to_plan(
             ruleset,
             ruleset_uuid,


### PR DESCRIPTION
We had some messages which were more appropriate as debug rather than info. This reduces some of the noise that gets generated when run with -v option and we have lots of events