### PR TITLE
feat: added action kafka_notify

### DIFF
--- a/ansible_rulebook/action/kafka_notify.py
+++ b/ansible_rulebook/action/kafka_notify.py
@@ -1,0 +1,62 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+import logging
+
+from aiokafka import AIOKafkaProducer
+from aiokafka.errors import KafkaError
+
+from .control import Control
+from .helper import Helper
+from .metadata import Metadata
+
+logger = logging.getLogger(__name__)
+# TODO: Use FAILED_STATUS and FAILED_STATUS from helper
+SUCCESSFUL_STATUS = "successful"
+FAILED_STATUS = "failed"
+
+
+class KafkaNotify:
+    """The Kafka notify action used to send messages to a Kafka topic
+    The required arguments are:
+    connection: The connection object with the Kafka properties
+    topic: The name of the topic
+    event: The matching event
+
+    At the end we send back the action status
+    """
+
+    def __init__(self, metadata: Metadata, control: Control, **action_args):
+        self.helper = Helper(metadata, control, "kafka_notify")
+        self.action_args = action_args
+
+    async def __call__(self):
+        producer = None
+        try:
+            producer = AIOKafkaProducer(**self.action_args["connection"])
+            await producer.start()
+            await producer.send_and_wait(
+                self.action_args["topic"],
+                json.dumps(self.action_args["event"]).encode("utf-8"),
+            )
+            await self.helper.send_default_status()
+        except (ValueError, KafkaError) as e:
+            logger.error("Kafka Producer error %s", str(e))
+            data = {"status": FAILED_STATUS, "message": str(e)}
+            await self.helper.send_status(data)
+            raise e
+        finally:
+            if producer:
+                await producer.stop()

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -30,6 +30,7 @@ from drools.ruleset import session_stats
 
 from ansible_rulebook.action.control import Control
 from ansible_rulebook.action.debug import Debug
+from ansible_rulebook.action.kafka_notify import KafkaNotify
 from ansible_rulebook.action.metadata import Metadata
 from ansible_rulebook.action.noop import Noop
 from ansible_rulebook.action.post_event import PostEvent
@@ -74,6 +75,7 @@ ACTION_CLASSES = {
     "run_module": RunModule,
     "run_job_template": RunJobTemplate,
     "run_workflow_template": RunWorkflowTemplate,
+    "kafka_notify": KafkaNotify,
 }
 
 

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -206,6 +206,9 @@
                             },
                             {
                                 "$ref": "#/$defs/shutdown-action"
+                            },
+                            {
+                                "$ref": "#/$defs/kafka-notify-action"
                             }
                         ]
                     }
@@ -244,6 +247,9 @@
                         },
                         {
                             "$ref": "#/$defs/shutdown-action"
+                        },
+                        {
+                            "$ref": "#/$defs/kafka-notify-action"
                         }
                     ]
                 }
@@ -708,6 +714,38 @@
                 "shutdown"
             ],
             "additionalProperties": false
+        },
+        "kafka-notify-action": {
+            "type": "object",
+            "properties": {
+                "kafka_notify": {
+                    "type": "object",
+                    "properties": {
+                        "connection": {
+                            "type": "object"
+                        },
+                        "topic": {
+                            "type": "string"
+                        },
+                        "event": {
+                            "type": [
+                                "string",
+                                "object"
+                            ]
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "connection",
+                        "topic",
+                        "event"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "kafka_notify"
+            ]
         }
     }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,8 @@ install_requires =
 	ansible-runner
 	websockets
 	drools_jpy == 0.3.8
-    watchdog
+        watchdog
+        aiokafka
 
 [options.packages.find]
 include =

--- a/tests/unit/action/test_kafka_notify.py
+++ b/tests/unit/action/test_kafka_notify.py
@@ -1,0 +1,170 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiokafka.errors import KafkaError
+from freezegun import freeze_time
+
+from ansible_rulebook.action.control import Control
+from ansible_rulebook.action.kafka_notify import KafkaNotify
+from ansible_rulebook.action.metadata import Metadata
+from ansible_rulebook.conf import settings
+
+SUCCESSFUL_STATUS = "successful"
+FAILED_STATUS = "failed"
+
+DUMMY_UUID = "eb7de03f-6f8f-4943-b69e-3c90db346edf"
+RULE_UUID = "abcdef3f-6f8f-4943-b69e-3c90db346edf"
+RULE_SET_UUID = "00aabbcc-1111-2222-b69e-3c90db346edf"
+RULE_RUN_AT = "2023-06-11T12:13:10Z"
+ACTION_RUN_AT = "2023-06-11T12:13:14Z"
+REQUIRED_KEYS = {
+    "action",
+    "action_uuid",
+    "activation_id",
+    "activation_instance_id",
+    "message",
+    "rule_run_at",
+    "run_at",
+    "rule",
+    "ruleset",
+    "rule_uuid",
+    "ruleset_uuid",
+    "status",
+    "type",
+    "matching_events",
+}
+
+
+def _validate(queue, metadata, status, event, message=None):
+    while not queue.empty():
+        data = queue.get_nowait()
+        if data["type"] == "Action":
+            action = data
+
+    assert action["action"] == "kafka_notify"
+    assert action["action_uuid"] == DUMMY_UUID
+    assert action["activation_id"] == settings.identifier
+    assert action["rule_run_at"] == metadata.rule_run_at
+    assert action["rule"] == metadata.rule
+    assert action["ruleset"] == metadata.rule_set
+    assert action["rule_uuid"] == metadata.rule_uuid
+    assert action["ruleset_uuid"] == metadata.rule_set_uuid
+    assert action["status"] == status
+    assert action["type"] == "Action"
+    if action["status"] == SUCCESSFUL_STATUS:
+        assert action["run_at"] == ACTION_RUN_AT
+        assert action["matching_events"] == event
+    assert action.get("message", None) == message
+    assert len(set(action.keys()).difference(REQUIRED_KEYS)) == 0
+
+
+TEST_PAYLOADS = [
+    ({"abc": "def", "simple": True, "pi": 3.14259}),
+    ({"abc": "def", "simple": True, "pi": 3.14259, "meta": {"uuid": 1}},),
+    ({"a": 1, "blob": "x" * 9000, "y": 365, "phased": True},),
+]
+
+
+@freeze_time("2023-06-11 12:13:14")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event", TEST_PAYLOADS)
+async def test_kafka_notify(event):
+    queue = asyncio.Queue()
+    metadata = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+    )
+    topic = "my_chanel"
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"event": event},
+        project_data_file="",
+    )
+
+    connection = {"bootstrap_servers": "localhost:9002"}
+    action_args = {
+        "connection": connection,
+        "event": event,
+        "topic": topic,
+    }
+    if "meta" in event:
+        action_args["remove_meta"] = True
+        compared_event = event.copy()
+        compared_event.pop("meta")
+    else:
+        compared_event = event
+
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        with patch(
+            "ansible_rulebook.action.kafka_notify.AIOKafkaProducer",
+            return_value=AsyncMock(),
+        ):
+            await KafkaNotify(metadata, control, **action_args)()
+            _validate(queue, metadata, "successful", {"m": event})
+
+
+EXCEPTIONAL_PAYLOADS = [
+    (
+        {"abc": "will fail"},
+        {"message": "KafkaError: Kaboom", "exception": KafkaError("Kaboom")},
+    ),
+]
+
+
+@freeze_time("2023-06-11 12:13:14")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event,result", EXCEPTIONAL_PAYLOADS)
+async def test_kafka_notify_with_exception(event, result):
+    queue = asyncio.Queue()
+    metadata = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+    )
+    topic = "my_chanel"
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"event": event},
+        project_data_file="",
+    )
+
+    connection = {"bootstrap_servers": "localhost:9002"}
+    action_args = {
+        "connection": connection,
+        "event": event,
+        "topic": topic,
+    }
+
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        with pytest.raises(KafkaError):
+            with patch(
+                "ansible_rulebook.action.kafka_notify.AIOKafkaProducer",
+                return_value=AsyncMock(),
+            ) as producer:
+                producer.side_effect = result["exception"]
+                await KafkaNotify(metadata, control, **action_args)()
+
+    _validate(queue, metadata, "failed", {"m": event}, result["message"])


### PR DESCRIPTION
Added a new action called kafka_notify to contrast with pg_notify This action would allow an event to be posted to a Kafka topic for other consumers.

To generate arbitrary sized blobs we have enhanced our generic source plugin to use the new collection you would have to build an image with those changes

* podman login quay.io
* podman build --no-cache --build-arg DEVEL_COLLECTION_LIBRARY=1 --build-arg DEVEL_COLLECTION_REPO=git+https://github.com/mkanoor/event-driven-ansible.git,pg_listener -t quay.io/<your_userid>/ansible-rulebook:latest .
* podman push quay.io/<your_user_id>/ansible-rulebook:latest

Then you can use the updated collection in these 2 rule books

* [Kafka Generator](https://github.com/mkanoor/eda-project/blob/main/rulebooks/kafka_generator.yml)
* [Kafka Listener](https://github.com/mkanoor/eda-project/blob/main/rulebooks/kafka_listener.yml)


To test the Activations first create the Listener Activation and then the Generator Activation

