### PR TITLE
docs: fixed rulebooks documentation for missing gather_facts and FQCN for range source

### DIFF
--- a/docs/rulebooks.rst
+++ b/docs/rulebooks.rst
@@ -63,6 +63,7 @@ A ruleset has the following properties:
 
     - name: Example
       hosts: all
+      gather_facts: true
       sources:
         - name: range
           range:

--- a/docs/rulebooks.rst
+++ b/docs/rulebooks.rst
@@ -65,7 +65,7 @@ A ruleset has the following properties:
       hosts: all
       gather_facts: true
       sources:
-        - name: range
+        - name: ansible.eda.range
           range:
             limit: 5
       rules:


### PR DESCRIPTION
Call range using FQCN.
gather_facts defaults to false and is necessary to use facts in the conditionals.