### PR TITLE
docs: fix rulebooks documentation for missing gather_facts

### DIFF
--- a/docs/rulebooks.rst
+++ b/docs/rulebooks.rst
@@ -63,6 +63,7 @@ A ruleset has the following properties:
 
     - name: Example
       hosts: all
+      gather_facts: true
       sources:
         - name: range
           range:


### PR DESCRIPTION
gather_facts defaults to false and needs to be set to true in order to interact with facts as this sample does.