### PR TITLE
fix: container image permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,5 @@ RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \
     ansible-galaxy collection install ${DEVEL_COLLECTION_REPO} --force; fi"
 
 RUN pip install .
+
+RUN chmod -R 0775 $APP_DIR


### PR DESCRIPTION
Resolves [ AAP-19015](https://issues.redhat.com/browse/AAP-19015). Fixes the image to set 0775 permissions on the /app directory.