### PR TITLE
chore: include 3.12 as supported python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - ssl_verify option now also supports "true" or "false" values
 - Support for standalone boolean in conditions
 - Add basic auth to controller
+- Support for python 3.12
 
 ### Fixed
 
@@ -130,7 +131,7 @@
 
 ### Removed
 
-- Redis and durability 
+- Redis and durability
 - envvar for rules_engine
 
 
@@ -140,12 +141,12 @@
 
 - Support for vars namespace
 - Support for negation
-- Support for Floats 
-- Log format and set the log stream for debug/verbose 
-- A builtin action : echo 
-- Cmdline option --print_events 
-- New action: run_job_template 
-- Support for in and contains in condition 
+- Support for Floats
+- Log format and set the log stream for debug/verbose
+- A builtin action : echo
+- Cmdline option --print_events
+- New action: run_job_template
+- Support for in and contains in condition
 - Add more info to --version flag
 - Add EDA prefix to environment variables
 - Enable drools for python 3.11
@@ -160,9 +161,9 @@
 
 ### Changed
 
-- Configure controller API access 
-- Switch the default rules engine back to drools 
-- Print help if run without arguments 
+- Configure controller API access
+- Switch the default rules engine back to drools
+- Print help if run without arguments
 
 ### Removed
 
@@ -176,7 +177,7 @@
 
 ### Changed
 
-Update minimal python version 
+Update minimal python version
 Improves error messages for unhandled events
 
 ### Removed
@@ -189,7 +190,7 @@ Improves error messages for unhandled events
 
 ### Added
 
-- Job details for eda-server usage 
+- Job details for eda-server usage
 - add arg to install devel collection
 
 ### Fixed
@@ -249,7 +250,7 @@ Improves error messages for unhandled events
 
 ### Fixed
 
-- An error msg 
+- An error msg
 
 ## [0.6.0] - 2022-08-24
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 zip_safe = False


### PR DESCRIPTION
Add python 3.12 as supported version. 
jira: https://issues.redhat.com/browse/AAP-13387