### PR TITLE
Point to correct stream9 image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9-development
+FROM quay.io/centos/centos:stream9
 
 ARG USER_ID=${USER_ID:-1001}
 ARG APP_DIR=${APP_DIR:-/app}


### PR DESCRIPTION
`stream9-development` was last updated Oct 9 2022, while the`stream9` tag is being actively updated 

https://quay.io/repository/centos/centos?tab=tags