### PR TITLE
Include gcc package in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN useradd -u $USER_ID -d $APP_DIR appuser
 WORKDIR $APP_DIR
 COPY . $WORKDIR
 RUN chown -R $USER_ID $APP_DIR
-RUN dnf install -y java-17-openjdk-devel python3-pip
+RUN dnf install -y java-17-openjdk-devel python3-pip gcc
 
 USER $USER_ID
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN useradd -u $USER_ID -d $APP_DIR appuser
 WORKDIR $APP_DIR
 COPY . $WORKDIR
 RUN chown -R $USER_ID $APP_DIR
-RUN dnf install -y java-17-openjdk-devel python3-pip gcc
+RUN dnf install -y java-17-openjdk-devel python3-pip gcc python-devel
 
 USER $USER_ID
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk


### PR DESCRIPTION
Many python packages will compile native extensions and require GCC