### PR TITLE
feat: reduce image size further

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG USER_ID=${USER_ID:-1001}
 ARG APP_DIR=${APP_DIR:-/app}
 
-FROM quay.io/centos/centos:stream9-development as build
+FROM quay.io/centos/centos:stream9 as build
 
 ARG USER_ID
 ARG APP_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-FROM quay.io/centos/centos:stream9-development
-
 ARG USER_ID=${USER_ID:-1001}
 ARG APP_DIR=${APP_DIR:-/app}
+
+FROM quay.io/centos/centos:stream9-development as build
+
+ARG USER_ID
+ARG APP_DIR
 ARG DEVEL_COLLECTION_LIBRARY=0
 ARG DEVEL_COLLECTION_REPO=git+https://github.com/ansible/event-driven-ansible.git
 
-USER 0
-RUN useradd -u $USER_ID -d $APP_DIR appuser
-WORKDIR $APP_DIR
-COPY . $WORKDIR
-RUN chown -R $USER_ID $APP_DIR
-RUN dnf install -y java-17-openjdk-devel python3-pip
-
-USER $USER_ID
+RUN dnf install -y java-17-openjdk-devel java-17-openjdk-jmods binutils python3-pip
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-ENV PATH="${PATH}:$APP_DIR/.local/bin"
-RUN pip install -U pip \
+
+ENV PATH="$APP_DIR/venv/bin:${PATH}"
+
+RUN python3 -m venv $APP_DIR/venv \
+    && pip install -U pip \
     && pip install ansible-core \
     ansible-runner \
     jmespath \
@@ -29,6 +28,41 @@ RUN pip install -U pip \
 RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \
     ansible-galaxy collection install ${DEVEL_COLLECTION_REPO} --force; fi"
 
+WORKDIR $APP_DIR
+COPY . $WORKDIR
+
 RUN pip install .
 
-RUN chmod -R 0775 $APP_DIR
+RUN $JAVA_HOME/bin/jdeps \
+    --ignore-missing-deps \
+    --print-module-deps \
+    --multi-release 17 \
+    --recursive \
+    $(find $APP_DIR -path '*/drools/jars/*' -name 'drools*.jar') > $APP_DIR/drools_jar_modules \
+    && $JAVA_HOME/bin/jlink \
+    --add-modules $(cat $APP_DIR/drools_jar_modules) \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output $APP_DIR/custom_jre
+
+FROM quay.io/centos/centos:stream9-minimal as dist
+
+ARG USER_ID
+ARG APP_DIR
+
+ENV PATH="$APP_DIR/venv/bin:${PATH}"
+ENV JAVA_HOME=/jre
+
+COPY --from=build $APP_DIR/custom_jre $JAVA_HOME
+COPY --from=build $APP_DIR/venv $APP_DIR/venv
+
+RUN microdnf install -y shadow-utils \
+    && useradd -u $USER_ID -d $APP_DIR appuser \
+    && chown -R $USER_ID $APP_DIR \
+    && chmod -R 0775 $APP_DIR \
+    && microdnf clean all
+
+WORKDIR $APP_DIR
+USER $USER_ID


### PR DESCRIPTION
Reduces the size of the resulting image to around 400 MB. 
- Uses multi-stage build process. 
- Python dependencies are packaged into one venv. 
- Java JRE is created custom, only keeping the modules Drools needs. 
- Both the venv and the JRE are copied to the second stage of the build based on stream9-minimal image to reduce the size even further.

Comparison with the original image:
```
$  buildah build --no-cache --tag localhost/ansible-rulebook:slim -f Dockerfile

$  podman images --format "table {{.Repository}}:{{.Tag}} {{.Size}}" | rg ansible-rulebook
31128877f949  localhost/ansible-rulebook:slim                  323 MB
5cbebc6a4a9b  localhost/ansible-rulebook:latest                702 MB
```

_Note: When built with podman, the image size will be ~100 MB larger for some reason (despite buildah being used internally in podman-build), even with compression forced on._