### PR TITLE
chore: remove setting level of drools. logger

### DIFF
--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -240,7 +240,6 @@ def setup_logging(args: argparse.Namespace) -> None:
         display.level = level
 
     logging.basicConfig(stream=stream, level=level, format=LOG_FORMAT)
-    logging.getLogger("drools.").setLevel(level)
 
 
 def main(args: List[str] = None) -> int:


### PR DESCRIPTION
Investigation demonstrates it has no impact on what is logged.