### PR TITLE
fix: add activation_instance_id alone with activation_id

### DIFF
--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -494,6 +494,7 @@ class RuleSetRunner:
                     action=action,
                     action_uuid=str(uuid.uuid4()),
                     activation_id=settings.identifier,
+                    activation_instance_id=settings.identifier,
                     playbook_name=action_args.get("name"),
                     status="failed",
                     run_at=run_at(),

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -229,6 +229,7 @@ async def send_session_stats(event_log: asyncio.Queue, stats: Dict):
         dict(
             type="SessionStats",
             activation_id=settings.identifier,
+            activation_instance_id=settings.identifier,
             stats=stats,
             reported_at=run_at(),
         )

--- a/ansible_rulebook/websocket.py
+++ b/ansible_rulebook/websocket.py
@@ -124,21 +124,27 @@ async def _connect_websocket(
     return result
 
 
-async def request_workload(activation_id: str) -> StartupArgs:
+async def request_workload(activation_instance_id: str) -> StartupArgs:
     return await _connect_websocket(
         handler=_handle_request_workload,
         retry=False,
-        activation_id=activation_id,
+        activation_instance_id=activation_instance_id,
     )
 
 
 async def _handle_request_workload(
     websocket: WebSocketClientProtocol,
-    activation_id: str,
+    activation_instance_id: str,
 ) -> StartupArgs:
     logger.info("workload websocket connected")
     await websocket.send(
-        json.dumps(dict(type="Worker", activation_id=activation_id))
+        json.dumps(
+            dict(
+                type="Worker",
+                activation_id=activation_instance_id,
+                activation_instance_id=activation_instance_id,
+            )
+        )
     )
 
     project_data_fh = None

--- a/tests/e2e/test_match_multiple_rules.py
+++ b/tests/e2e/test_match_multiple_rules.py
@@ -79,7 +79,7 @@ async def test_match_multiple_rules():
             assert stats["ruleSetName"] == "Test match multiple rules"
             assert stats["numberOfRules"] == 2
             assert stats["numberOfDisabledRules"] == 0
-            assert data["activation_id"] == proc_id
+            assert data["activation_instance_id"] == proc_id
 
     assert stats["rulesTriggered"] == 2
     assert stats["eventsProcessed"] == 5

--- a/tests/e2e/test_run_module_output.py
+++ b/tests/e2e/test_run_module_output.py
@@ -98,7 +98,7 @@ async def test_run_module_output():
             assert stats["ruleSetName"] == "29 run module"
             assert stats["numberOfRules"] == 2
             assert stats["numberOfDisabledRules"] == 0
-            assert data["activation_id"] == proc_id
+            assert data["activation_instance_id"] == proc_id
 
     assert stats["rulesTriggered"] == 2
     assert stats["eventsProcessed"] == 6

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2160,7 +2160,7 @@ async def test_46_job_template_exception(err_msg, err):
             required_keys = {
                 "action",
                 "action_uuid",
-                "activation_id",
+                "activation_instance_id",
                 "message",
                 "rule_run_at",
                 "run_at",

--- a/tests/unit/action/test_debug.py
+++ b/tests/unit/action/test_debug.py
@@ -54,7 +54,7 @@ def _validate(queue, metadata):
 
     assert action["action"] == "debug"
     assert action["action_uuid"] == DUMMY_UUID
-    assert action["activation_id"] == settings.identifier
+    assert action["activation_instance_id"] == settings.identifier
     assert action["run_at"] == ACTION_RUN_AT
     assert action["rule_run_at"] == metadata.rule_run_at
     assert action["rule"] == metadata.rule

--- a/tests/unit/action/test_run_playbook.py
+++ b/tests/unit/action/test_run_playbook.py
@@ -62,7 +62,7 @@ def _validate(queue, metadata, status, rc):
     }
     assert action["action"] == "run_playbook"
     assert action["action_uuid"] == DUMMY_UUID
-    assert action["activation_id"] == settings.identifier
+    assert action["activation_instance_id"] == settings.identifier
     assert action["run_at"] == ACTION_RUN_AT
     assert action["rule_run_at"] == metadata.rule_run_at
     assert action["rule"] == metadata.rule

--- a/tests/unit/action/test_set_fact.py
+++ b/tests/unit/action/test_set_fact.py
@@ -82,7 +82,7 @@ async def test_noop():
     }
     assert action["action"] == "set_fact"
     assert action["action_uuid"] == DUMMY_UUID
-    assert action["activation_id"] == settings.identifier
+    assert action["activation_instance_id"] == settings.identifier
     assert action["run_at"] == ACTION_RUN_AT
     assert action["rule_run_at"] == metadata.rule_run_at
     assert action["rule"] == metadata.rule

--- a/tests/unit/action/test_shutdown.py
+++ b/tests/unit/action/test_shutdown.py
@@ -81,7 +81,7 @@ async def test_shutdown():
     }
     assert action["action"] == "shutdown"
     assert action["action_uuid"] == DUMMY_UUID
-    assert action["activation_id"] == settings.identifier
+    assert action["activation_instance_id"] == settings.identifier
     assert action["run_at"] == ACTION_RUN_AT
     assert action["rule_run_at"] == metadata.rule_run_at
     assert action["rule"] == metadata.rule


### PR DESCRIPTION
Both keys will co-exist in the message body sent to eda-server for backward compatibility reason. activation_id will be removed in the future.

Fixes AAP-18855: ansible-rulebook reports activation instance ID as activation ID