### PR TITLE
test: fix port conflicts in websocket tests

### DIFF
--- a/tests/e2e/test_run_module_output.py
+++ b/tests/e2e/test_run_module_output.py
@@ -26,7 +26,7 @@ async def test_run_module_output():
     host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
-    port = 31415
+    port = 31416
     rulebook = utils.EXAMPLES_PATH / "29_run_module.yml"
     websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(

--- a/tests/e2e/test_skip_audit_events.py
+++ b/tests/e2e/test_skip_audit_events.py
@@ -26,7 +26,7 @@ async def test_skip_audit_events():
     host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
-    port = 31415
+    port = 31417
     rulebook = utils.BASE_DATA_PATH / "rulebooks/test_match_multiple_rules.yml"
     websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(


### PR DESCRIPTION
When tests are run in parallel we were getting port conflicts. Since the 2 tests were copied from the websocket tests they used the same port numbers.
We don't see these errors when tests are run serially

E OSError: [Errno 48] error while attempting to bind on address ('127.0.0.1', 31415): address already in use