### PR TITLE
feat(backport): upgrade to drools 1.0.6 (#646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 - Support for standalone boolean in conditions
 - Add basic auth to controller
 - Use token for websocket authentication
-- skip-audit-events to disable sending audit events to server 
+- skip-audit-events to disable sending audit events to server
+- restrict drools async connection to localhost
+
 
 ### Changed
 - Generic print as well as printing of events use new banner style

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ install_requires =
 	janus
 	ansible-runner
 	websockets
-	drools_jpy == 0.3.8
-    watchdog
+	drools_jpy == 0.3.9
+	watchdog
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Several fixes from drools ansible integration
https://issues.redhat.com/browse/AAP-19291

Backport from https://github.com/ansible/ansible-rulebook/pull/646