### PR TITLE
chore(backport): set python3.11 as the minimal supported version (#649)

### DIFF
--- a/.github/actions/run-flake/action.yml
+++ b/.github/actions/run-flake/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/run-isort/action.yml
+++ b/.github/actions/run-isort/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
-          - "3.10"
           - "3.11"
 
     steps:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -42,8 +42,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
-          - "3.10"
           - "3.11"
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9-development
+FROM quay.io/centos/centos:stream9
 
 ARG USER_ID=${USER_ID:-1001}
 ARG APP_DIR=${APP_DIR:-/app}
@@ -10,7 +10,13 @@ RUN useradd -u $USER_ID -d $APP_DIR appuser
 WORKDIR $APP_DIR
 COPY . $WORKDIR
 RUN chown -R $USER_ID $APP_DIR
-RUN dnf install -y java-17-openjdk-devel python3-pip postgresql-devel gcc python3-devel
+RUN dnf install -y \
+    java-17-openjdk-devel \
+    python3.11 \
+    python3.11-pip \
+    postgresql-devel \
+    gcc \
+    python3.11-devel
 
 RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \
     dnf install -y git; fi"
@@ -18,7 +24,7 @@ RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \
 USER $USER_ID
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH="${PATH}:$APP_DIR/.local/bin"
-RUN pip install -U pip \
+RUN pip3.11 install -U pip \
     && pip install ansible-core \
     ansible-runner \
     jmespath \

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -52,7 +52,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.9
+3. The pull request should work for Python 3.11
 4. Commit messages must conform to `conventional commit <https://www.conventionalcommits.org/en/v1.0.0/>`__
 
 

--- a/docs/development_environment.rst
+++ b/docs/development_environment.rst
@@ -24,7 +24,7 @@ Ready to contribute? Here's how to set up `ansible_rulebook` for local developme
 .. code-block:: console
 
     cd ansible_rulebook/
-    python3.9 -m venv venv
+    python3.11 -m venv venv
     source venv/bin/activate
     pip install -e .[development]
     pip install -r requirements_dev.txt

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Please ensure you have installed all components listed in the **Requirements** s
 Requirements
 ------------
 
-* Python >= 3.9
+* Python >= 3.11
 * Python 3 pip
 
 * Java development kit >= 17

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,15 +13,13 @@ classifiers =
 	License :: OSI Approved :: Apache Software License
 	Natural Language :: English
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.9
-	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.11
 install_requires =
 	aiohttp
 	pyparsing >= 3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = flake8,py39,py310,py311
+envlist = flake8,py311
 isolated_build = True
 
 [travis]
 python =
-    3.9: py39
-    3.10: py310
     3.11: py311
 
 [testenv:flake8]


### PR DESCRIPTION
Make python3.11 the minimal supported version of python, required for incoming features and dependencies.
Jira: https://issues.redhat.com/browse/AAP-19622

backport of https://github.com/ansible/ansible-rulebook/pull/649