### PR TITLE
fix(backport): enable base_path for controller url (#654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Generic print as well as printing of events use new banner style
 
 ### Fixed
+- Support a base path for the controller url
 
 ## [1.0.4] - 2023-10-30
 

--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -24,6 +24,7 @@ from urllib.parse import urljoin
 import aiohttp
 import dpath
 
+from ansible_rulebook import util
 from ansible_rulebook.exception import (
     ControllerApiException,
     JobTemplateNotFoundException,
@@ -34,8 +35,8 @@ logger = logging.getLogger(__name__)
 
 
 class JobTemplateRunner:
-    UNIFIED_TEMPLATE_SLUG = "/api/v2/unified_job_templates/"
-    CONFIG_SLUG = "/api/v2/config/"
+    UNIFIED_TEMPLATE_SLUG = "api/v2/unified_job_templates/"
+    CONFIG_SLUG = "api/v2/config/"
     JOB_COMPLETION_STATUSES = ["successful", "failed", "error", "canceled"]
 
     def __init__(
@@ -47,6 +48,7 @@ class JobTemplateRunner:
         verify_ssl: str = "yes",
     ):
         self.token = token
+        self._host = ""
         self.host = host
         self.username = username
         self.password = password
@@ -55,6 +57,14 @@ class JobTemplateRunner:
             os.environ.get("EDA_JOB_TEMPLATE_REFRESH_DELAY", 10.0)
         )
         self._session = None
+
+    @property
+    def host(self):
+        return self._host
+
+    @host.setter
+    def host(self, value: str):
+        self._host = util.ensure_trailing_slash(value)
 
     async def close_session(self):
         if self._session and not self._session.closed:

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -273,3 +273,9 @@ def process_controller_host_limit(
             return ",".join(job_args["limit"])
         return str(job_args["limit"])
     return ",".join(parent_hosts)
+
+
+def ensure_trailing_slash(url: str) -> str:
+    if not url.endswith("/"):
+        return url + "/"
+    return url

--- a/tests/data/awx_test_data.py
+++ b/tests/data/awx_test_data.py
@@ -1,8 +1,8 @@
 UNIFIED_JOB_TEMPLATE_COUNT = 2
 ORGANIZATION_NAME = "Default"
 JOB_TEMPLATE_NAME_1 = "JT1"
-JOB_TEMPLATE_1_LAUNCH_SLUG = "/api/v2/job_templates/255/launch/"
-JOB_TEMPLATE_2_LAUNCH_SLUG = "/api/v2/workflow_job_templates/300/launch/"
+JOB_TEMPLATE_1_LAUNCH_SLUG = "api/v2/job_templates/255/launch/"
+JOB_TEMPLATE_2_LAUNCH_SLUG = "api/v2/workflow_job_templates/300/launch/"
 
 JOB_TEMPLATE_1 = dict(
     type="job_template",
@@ -24,10 +24,10 @@ JOB_TEMPLATE_2 = dict(
 )
 
 UNIFIED_JOB_TEMPLATE_PAGE1_SLUG = (
-    f"/api/v2/unified_job_templates/?name={JOB_TEMPLATE_NAME_1}"
+    f"api/v2/unified_job_templates/?name={JOB_TEMPLATE_NAME_1}"
 )
 UNIFIED_JOB_TEMPLATE_PAGE2_SLUG = (
-    f"/api/v2/unified_job_templates/?name={JOB_TEMPLATE_NAME_1}&page=2"
+    f"api/v2/unified_job_templates/?name={JOB_TEMPLATE_NAME_1}&page=2"
 )
 UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE = dict(
     count=UNIFIED_JOB_TEMPLATE_COUNT,
@@ -58,7 +58,7 @@ JOB_ARTIFACTS = {
     "barney": 90,
 }
 JOB_ID_1 = 909
-JOB_1_SLUG = f"/api/v2/jobs/{JOB_ID_1}/"
+JOB_1_SLUG = f"api/v2/jobs/{JOB_ID_1}/"
 JOB_TEMPLATE_POST_RESPONSE = dict(
     job=JOB_ID_1,
     url=JOB_1_SLUG,


### PR DESCRIPTION
A controller url like "https://awx-host/awx" is not supported trying the connection against "https://awx-host/[AWX-SLUG]"

Fixes: https://github.com/ansible/ansible-rulebook/issues/652
Jira: https://issues.redhat.com/browse/AAP-19726

Backport of https://github.com/ansible/ansible-rulebook/pull/654