### PR TITLE
docs: add warning about webhook host usage in podman

### DIFF
--- a/docs/sources.rst
+++ b/docs/sources.rst
@@ -83,6 +83,11 @@ There are 3 basic patterns that you'll be developing against when considering a 
     These can also require other ingress policies and firewall rules to be available and configured properly
     to operate.
 
+    .. warning::
+        When running within a Podman container, be aware that by default (with rootlesskit) Podman networking 
+        changes the source IP of all requests to usually 10.0.2.100. Adjust the value of ``host:`` accordingly.
+        By default the ``webhook`` plugin listens to all interfaces.
+
 It's strongly recommended to adopt one of the first two patterns and only consider callback plugins in the absence
 of any other solution.
 


### PR DESCRIPTION
- added a small warning section to Callback plugins about when running ansible-rulebook in Podman
  - Ref: https://issues.redhat.com/browse/AAP-18943

Discussed this with the Ansible docks team (Jameira) , downstream we have no good place to put this. This was the only place we could think of.