### PR TITLE
feat: support controller username and password

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -92,6 +92,8 @@ async def run(parsed_args: argparse.Namespace) -> None:
         startup_args.controller_url = parsed_args.controller_url
         startup_args.controller_token = parsed_args.controller_token
         startup_args.controller_ssl_verify = parsed_args.controller_ssl_verify
+        startup_args.controller_username = parsed_args.controller_username
+        startup_args.controller_password = parsed_args.controller_password
 
     validate_actions(startup_args)
     validate_variables(startup_args)
@@ -289,6 +291,13 @@ async def validate_controller_params(startup_args: StartupArgs) -> None:
         job_template_runner.token = startup_args.controller_token
         if startup_args.controller_ssl_verify:
             job_template_runner.verify_ssl = startup_args.controller_ssl_verify
+
+        if (
+            startup_args.controller_username
+            and startup_args.controller_password
+        ):
+            job_template_runner.username = startup_args.controller_username
+            job_template_runner.password = startup_args.controller_password
 
         data = await job_template_runner.get_config()
         logger.info("AAP Version %s", data["version"])

--- a/ansible_rulebook/common.py
+++ b/ansible_rulebook/common.py
@@ -25,6 +25,8 @@ class StartupArgs:
     controller_url: str = field(default="")
     controller_token: str = field(default="")
     controller_ssl_verify: str = field(default="")
+    controller_username: str = field(default="")
+    controller_password: str = field(default="")
     project_data_file: str = field(default="")
     inventory: str = field(default="")
     check_controller_connection: bool = field(default=False)

--- a/ansible_rulebook/websocket.py
+++ b/ansible_rulebook/websocket.py
@@ -192,6 +192,8 @@ async def _handle_request_workload(
             response.controller_url = data.get("url")
             response.controller_token = data.get("token")
             response.controller_ssl_verify = data.get("ssl_verify")
+            response.controller_username = data.get("username", "")
+            response.controller_password = data.get("password", "")
     return response
 
 


### PR DESCRIPTION
On the websocket channel previously we only supported sending tokens with this PR we can send a username and password from the eda-server. The username and password can be created in the RH AAP Credential Type.

https://issues.redhat.com/browse/AAP-22060