### PR TITLE
fix: check if variables are decryptable outside of substitution

### DIFF
--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -32,7 +32,7 @@ from ansible_rulebook.conf import settings
 from ansible_rulebook.engine import run_rulesets, start_source
 from ansible_rulebook.job_template_runner import job_template_runner
 from ansible_rulebook.rule_types import RuleSet, RuleSetQueue
-from ansible_rulebook.util import substitute_variables
+from ansible_rulebook.util import decryptable
 from ansible_rulebook.validators import Validate
 from ansible_rulebook.vault import has_vaulted_str
 from ansible_rulebook.websocket import (
@@ -244,9 +244,7 @@ def spawn_sources(
 
 
 def validate_variables(startup_args: StartupArgs) -> None:
-    for _key, value in startup_args.variables.items():
-        # attempt to substitute, raise an error on failure
-        substitute_variables(value, {})
+    decryptable(startup_args.variables)
 
 
 def validate_actions(startup_args: StartupArgs) -> None:
@@ -280,9 +278,7 @@ def validate_actions(startup_args: StartupArgs) -> None:
                         "which needs controller url and token to be defined"
                     )
                 if startup_args.check_vault:
-                    for _key, value in action.action_args.items():
-                        # attempt to substitute, raise an error on failure
-                        substitute_variables(value, {})
+                    decryptable(action.action_args)
 
 
 async def validate_controller_params(startup_args: StartupArgs) -> None:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -13,8 +13,41 @@
 #  limitations under the License.
 import pytest
 
-from ansible_rulebook.exception import InvalidFilterNameException
-from ansible_rulebook.util import has_builtin_filter
+from ansible_rulebook.conf import settings
+from ansible_rulebook.exception import (
+    InvalidFilterNameException,
+    VaultDecryptException,
+)
+from ansible_rulebook.util import decryptable, has_builtin_filter
+from ansible_rulebook.vault import Vault
+
+TEST_PASSWORD = "secret"
+
+FRED = (
+    "$ANSIBLE_VAULT;1.1;AES256\n"
+    "316365636638653961346230633664336265643233"
+    "66653065393430383361373438623331363836\n"
+    "653336326262313433373035646335626264633631"
+    "6433620a313464386630326163353031313563\n"
+    "386332303732313831623030326539333135363437"
+    "66336132303539373836343137613761663834\n"
+    "6134393138383234360a3064393136313030663732"
+    "39313031303836653566323930643462623961\n"
+    "3866"
+)
+
+BARNEY = (
+    "$ANSIBLE_VAULT;1.1;AES256\n"
+    "616361626134646337386632323933643534663033"
+    "35313336633835303230616231663133613061\n"
+    "376438356666346164396630613437653466323133"
+    "3832630a643138396136623536383532656130\n"
+    "343230373864306434383532646435396239396563"
+    "33656334323262353436316562643466383564\n"
+    "3466376465323866380a3261653138613934646436"
+    "64393838336130323537333566386339323733\n"
+    "6138"
+)
 
 
 def test_bad_builtin_filter():
@@ -32,3 +65,55 @@ def test_has_builtin_filter_missing():
 
 def test_builtin_filter_bad_prefix():
     assert not has_builtin_filter("eda.gobbledygook.")
+
+
+test_data = [
+    {
+        "A": FRED,
+        "NESTED": {"B": BARNEY, "flag": True, "x": [FRED, BARNEY]},
+    },
+    FRED,
+    True,
+    12,
+    [FRED, BARNEY],
+    "Hello World",
+    "This is event data {{ event.i }}",
+]
+
+
+@pytest.mark.parametrize("obj", test_data)
+def test_decryptable(obj):
+    vault_info = {
+        "type": "VaultPassword",
+        "label": "test",
+        "password": TEST_PASSWORD,
+    }
+    settings.vault = Vault(passwords=[vault_info])
+
+    try:
+        decryptable(obj)
+    except Exception as exc:
+        raise AssertionError(f"test raised an exception {exc}")
+
+
+bad_test_data = [
+    {
+        "A": FRED,
+        "NESTED": {"B": BARNEY, "flag": True, "x": [FRED, BARNEY]},
+    },
+    FRED,
+    [FRED, BARNEY],
+]
+
+
+@pytest.mark.parametrize("obj", bad_test_data)
+def test_decryptable_with_errors(obj):
+    vault_info = {
+        "type": "VaultPassword",
+        "label": "test",
+        "password": "bogus",
+    }
+    settings.vault = Vault(passwords=[vault_info])
+
+    with pytest.raises(VaultDecryptException):
+        decryptable(obj)


### PR DESCRIPTION
We were relying on checking if a string is decryptable by using substitution which causes issues when the data can contain data that will only be available when events are processed

Added a separate function called decryptable that can be called to check if the passed in 

* strings in extra vars if vaulted can be decrypted
* strings in action args if vaulted can be decrypted

source args are used at startup so that failure is seen right away

https://issues.redhat.com/browse/AAP-22487

This is part of the story where we want to catch decryption errors at startup so we don't have to wait for the rulebook to start executing and report decryption errors when running actions. https://issues.redhat.com/browse/AAP-19611