### PR TITLE
fix: missing aiobotocore needed for SQS source plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Support for vaulted variables
 - Support for string interpolation from encrypted variables
+- Added aiobotocore package needed for our SQS plugin
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN pip install -U pip \
     aiokafka \
     watchdog \
     azure-servicebus \
+    aiobotocore \
     && ansible-galaxy collection install ansible.eda
 
 RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \


### PR DESCRIPTION
Our [SQS Source plugin](https://github.com/ansible/event-driven-ansible/blob/7d84d9cca37428f6817da2bbc60c73d21672acbb/extensions/eda/plugins/event_source/aws_sqs_queue.py#L30) needs aiobotocore

https://issues.redhat.com/browse/AAP-23381

Fixed the Dockerfile to include the aiobotocore package