### PR TITLE
Update E2E AWX test playbook and guide

### DIFF
--- a/tests/e2e/utils/awx/readme.md
+++ b/tests/e2e/utils/awx/readme.md
@@ -17,6 +17,12 @@ if you are not using the ansible-rulebook dev environment.
 
 # Steps
 
+0. When using Podman
+
+```
+export KIND_EXPERIMENTAL_PROVIDER=podman
+```
+
 1. Create the cluster
 
 ```

--- a/tests/e2e/utils/awx/roles/install-awx/defaults/main.yaml
+++ b/tests/e2e/utils/awx/roles/install-awx/defaults/main.yaml
@@ -3,7 +3,7 @@ awx_name: awx
 awx_image: quay.io/ansible/awx
 awx_image_tag: latest
 awx_operator_image: quay.io/ansible/awx-operator
-awx_operator_image_tag: "1.2.0"
+awx_operator_image_tag: "2.15.0"
 awx_namespace: awx
 awx_hostname: "localhost"
 awx_admin_password: password

--- a/tests/e2e/utils/awx/roles/install-awx/tasks/main.yaml
+++ b/tests/e2e/utils/awx/roles/install-awx/tasks/main.yaml
@@ -43,4 +43,5 @@
     label_selectors:
       - app.kubernetes.io/component=awx
     wait: yes
-    wait_sleep: 3
+    wait_sleep: 10
+    wait_timeout: 300


### PR DESCRIPTION
- increased the version of awx_operator_image_tag to 2.15.0 to fix error with Kustomize
- added a step specific for users of Podman
- increased the timeout for the cluster setup (I saw in testing that the default 120 seconds was not enough for a first install)