### PR TITLE
feat: add terse but informative task cancellation message

### DIFF
--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -156,9 +156,15 @@ class RuleSetRunner:
                 timeout=self.shutdown.delay,
             )
 
-        for task in self.active_actions:
-            logger.debug("Cancelling active task %s", task.get_name())
-            task.cancel()
+        if self.active_actions:
+            logger.info(
+                "Cancelling %d active tasks, ruleset %s cleanup",
+                len(self.active_actions),
+                self.name,
+            )
+            for task in self.active_actions:
+                logger.debug("Cancelling active task %s", task.get_name())
+                task.cancel()
         if self.shutdown:
             await self.event_log.put(
                 dict(


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/AAP-22056

Make it obvious that tasks are being cancelled when a source plugin shuts down (cleanup) or an error occurs while running the ruleset.