### PR TITLE
chore: update changelog for 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 ## [Unreleased]
 ### Changed
 ### Added
+### Fixed
+
+## [1.1.0] - 2024-05-15
+### Added
 - Support for vaulted variables
 - Support for string interpolation from encrypted variables
 - Added aiobotocore package needed for our SQS plugin
-
-### Fixed
-
 
 ## [1.0.5] - 2024-02-07
 


### PR DESCRIPTION
The version is already bump so we only need to update the changelog prior to tag and build the release. 