### PR TITLE
chore: update dockerfile, support for openshift

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@ venv
 .tox
 .vscode/
 .idea/
+.ansible/
+*.egg-info/
+.pytest_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,38 @@
-FROM quay.io/centos/centos:stream9-development
+FROM quay.io/centos/centos:stream9
 
 ARG USER_ID=${USER_ID:-1001}
 ARG APP_DIR=${APP_DIR:-/app}
 ARG DEVEL_COLLECTION_LIBRARY=0
 ARG DEVEL_COLLECTION_REPO=git+https://github.com/ansible/event-driven-ansible.git
 
-USER 0
-RUN useradd -u $USER_ID -d $APP_DIR appuser
-WORKDIR $APP_DIR
-COPY . $WORKDIR
-RUN chown -R $USER_ID $APP_DIR
-RUN dnf install -y java-17-openjdk-devel python3-pip postgresql-devel gcc python3-devel
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV PATH="$APP_DIR/.local/bin:$PATH"
+ENV PYTHONPATH="$APP_DIR/.local/lib/python3.9/site-packages:$PYTHONPATH"
+ENV HOME=$APP_DIR
 
-RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \
-    dnf install -y git; fi"
+USER 0
+
+# support random uid number and gid 0 for openshift
+RUN for dir in \
+    $APP_DIR \
+    $APP_DIR/.local \
+    $APP_DIR/.local/bin \
+    $APP_DIR/.local/lib \
+    $APP_DIR/.local/lib/python3.9/site-packages \
+    $APP_DIR/.ansible; \
+    do mkdir -p $dir ; chown -R "${USER_ID}:0" $dir ; chmod 0775 $dir ; done \
+    && useradd --uid "$USER_ID" --gid 0 --home-dir "$APP_DIR" appuser
+
+RUN dnf install -y java-17-openjdk-devel python3-pip postgresql-devel gcc python3-devel git
 
 USER $USER_ID
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-ENV PATH="${PATH}:$APP_DIR/.local/bin"
+WORKDIR $APP_DIR
+COPY --chown=${USER_ID}:0 . $WORKDIR
+
 RUN pip install -U pip \
     && pip install ansible-core \
     ansible-runner \
     jmespath \
-    asyncio \
     aiohttp \
     aiokafka \
     watchdog \
@@ -34,6 +44,3 @@ RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \
     ansible-galaxy collection install ${DEVEL_COLLECTION_REPO} --force; fi"
 
 RUN pip install .[production]
-
-RUN chmod -R 0775 $APP_DIR
-RUN chmod -x $APP_DIR/tests/e2e/files/passwords/*.*


### PR DESCRIPTION
Update dockerfile to support openshift plus several minor improvements. 
- move from centos:stream9-development to centos:stream9 since the development image doesn't have up to date packages
- extend dockerignore
- remove unneeded asyncio package
- revisit and improve file permissions. 

Jira: https://issues.redhat.com/browse/AAP-24526