### PR TITLE
chore: add missing pyyaml dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
 	drools_jpy == 0.3.9
 	watchdog
 	xxhash
+    pyyaml
 
 [options.packages.find]
 include =


### PR DESCRIPTION
pyyaml is a dependency from https://github.com/ansible/ansible-rulebook/pull/651/files#diff-1a9e40c0d3dc7e78f05263ea69bfd8e3ea9b2e3cdb0309da0c3f8a902adb4ff6R17