### PR TITLE
chore: improve error msg for jinja undefined action args

### DIFF
--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -21,6 +21,7 @@ from types import MappingProxyType
 from typing import Dict, List, Optional, Union, cast
 
 import dpath
+import jinja2.exceptions as jinja2_exceptions
 from drools import ruleset as lang
 from drools.exceptions import (
     MessageNotHandledException,
@@ -485,6 +486,17 @@ class RuleSetRunner:
             except asyncio.CancelledError:
                 logger.debug("Action task caught Cancelled error")
                 raise
+            except jinja2_exceptions.UndefinedError as e:
+                error = e
+                undefined_variable = str(e).split("has no attribute")
+                if len(undefined_variable) > 1:
+                    logger.error(
+                        "Undefined jinja variable %s in action %s",
+                        undefined_variable[-1],
+                        action,
+                    )
+                else:
+                    raise
             except Exception as e:
                 logger.error("Error calling action %s, err %s", action, str(e))
                 error = e


### PR DESCRIPTION
If the action args contains an undefined variable we print the generic error returned by jinja:
`ansible_rulebook.rule_set_runner - ERROR - Error calling action debug, err 'dict object' has no attribute 'unexistent'`

Catch the exception to provide a little more descriptive of the issue:
`ansible_rulebook.rule_set_runner - ERROR - Undefined jinja variable  'unexistent' in action debug`

How to test:
```
- name: Ruleset 1
  hosts: all
  sources:
    - ansible.eda.generic:
        shutdown_after: 1
        payload:
            name: "Wilma"
  rules:
    - name: Run debug
      condition: event.name == "Wilma"
      actions:
        - debug:
            msg: "Event received, accesing unexistent key {{ event.unexistent }}"
```
