### PR TITLE
fix: websocket logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 ### Added
 ### Fixed
+- Fix log level for websocket
 
 ## [1.1.0] - 2024-05-15
 ### Added

--- a/ansible_rulebook/websocket.py
+++ b/ansible_rulebook/websocket.py
@@ -34,6 +34,7 @@ from ansible_rulebook.token import renew_token
 from ansible_rulebook.vault import Vault, has_vaulted_str
 
 logger = logging.getLogger(__name__)
+logging.getLogger("websockets").setLevel(logging.ERROR)
 
 
 BACKOFF_MIN = 1.92


### PR DESCRIPTION
Set the log level of websocket library to be ERROR since at DEBUG level it logs Authorization Headers leaking tokens