### PR TITLE
fix: switch slugs based on presence of path in controller url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 ### Changed
 ### Added
+- Support for switching slugs to connect to controller via gateway
 ### Fixed
 - Fix log level for websocket
 

--- a/ansible_rulebook/action/run_job_template.py
+++ b/ansible_rulebook/action/run_job_template.py
@@ -125,6 +125,7 @@ class RunJobTemplate:
             a_log["reason"] = {"error": self.controller_job["error"]}
         else:
             logger.info(f"job results url: {a_log['url']}")
+            logger.info(f"job id: {a_log['job_id']}")
 
         await self.helper.send_status(a_log)
         set_facts = self.action_args.get("set_facts", False)

--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -131,6 +131,7 @@ class RunWorkflowTemplate:
             a_log["reason"] = {"error": self.controller_job["error"]}
         else:
             logger.info(f"job results url: {a_log['url']}")
+            logger.info(f"job id: {a_log['job_id']}")
 
         await self.helper.send_status(a_log)
         set_facts = self.action_args.get("set_facts", False)

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -141,7 +141,9 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--controller-url",
         help="Controller API base url, e.g. https://host1:8080 can also be "
-        "passed via the env var EDA_CONTROLLER_URL",
+        "passed via the env var EDA_CONTROLLER_URL, if your URL has a path "
+        "it should include api in it. api would only be appended if the URL "
+        "only contains host, port.",
         default=os.environ.get("EDA_CONTROLLER_URL", ""),
     )
     parser.add_argument(

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -128,6 +128,11 @@ Run a job template.
 .. note::
     You can define the environment variable ``EDA_CONTROLLER_CONNECTION_LIMIT`` to limit the number of concurrent connections to the controller. The default is 30.
 
+.. note::
+    The controller URL is the API end point, that ansible-rulebook will try to reach.
+    If you have a path specified in your URL it should have the api embedded in it.
+    If you have just provided a host and port but no path we will append api to the URL$
+    for backward compatibility.
 
 .. list-table::
    :widths: 25 150 10
@@ -178,6 +183,12 @@ Run a workflow template.
 .. note::
     You can define the environment variable ``EDA_CONTROLLER_CONNECTION_LIMIT`` to limit the number of concurrent connections to the controller. The default is 30.
 
+
+.. note::
+    The controller URL is the api end point, that ansible-rulebook will try to reach.
+    If you have a path specified in your URL it should have the api embedded in it.
+    If you have just provided a host and port but no path we will append api to the URL$
+    for backward compatibility.
 
 .. list-table::
    :widths: 25 150 10

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -241,15 +241,15 @@ async def test_run_workflow_template_fail(mocked_job_template_runner):
         ("https://example.com/", "https://example.com/api/v2/config/"),
         (
             "https://example.com/custom/awx",
-            "https://example.com/custom/awx/api/v2/config/",
+            "https://example.com/custom/awx/v2/config/",
         ),
         (
-            "https://example.com/awx/",
+            "https://example.com/awx/api",
             "https://example.com/awx/api/v2/config/",
         ),
         (
             "https://example.com/custom/awx/",
-            "https://example.com/custom/awx/api/v2/config/",
+            "https://example.com/custom/awx/v2/config/",
         ),
     ],
 )


### PR DESCRIPTION
ansible-rulebook needs to be able to connect to 2.4 controller as well as the contoller in version 2.5 via the gateway

This is accomplished by the paths in the URL
If we need to talk to the 2.4 controller the URL is
* https://my_old_controller/
 If we need to talk to the 2.5 contoller via Gateway the URL
* https://my_gateway/api/controller/

We append the slugs based on the presence of path

If the path is missing we append
  * /api/v2/config
  * /api/v2/unified_job_templates/

If the path is defined in the URL we append the following slug
  * /v2/config
  * /v2/unified_job_templates/

https://issues.redhat.com/browse/AAP-25509