### PR TITLE
fix: pass the controller job id to server via messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 ### Added
 - Support for switching slugs to connect to controller via gateway
+- Support passing in controller job id to server so it can build Job URL
 ### Fixed
 - Fix log level for websocket
 

--- a/ansible_rulebook/action/run_job_template.py
+++ b/ansible_rulebook/action/run_job_template.py
@@ -119,13 +119,14 @@ class RunJobTemplate:
             "run_at": self.controller_job["created"],
             "url": self._controller_job_url(),
             "matching_events": self.helper.get_events(),
+            "controller_job_id": self.controller_job.get("id", ""),
         }
         if "error" in self.controller_job:
             a_log["message"] = self.controller_job["error"]
             a_log["reason"] = {"error": self.controller_job["error"]}
         else:
             logger.info(f"job results url: {a_log['url']}")
-            logger.info(f"job id: {a_log['job_id']}")
+            logger.info(f"controller job id: {a_log['controller_job_id']}")
 
         await self.helper.send_status(a_log)
         set_facts = self.action_args.get("set_facts", False)

--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -125,13 +125,14 @@ class RunWorkflowTemplate:
             "run_at": self.controller_job["created"],
             "url": self._controller_job_url(),
             "matching_events": self.helper.get_events(),
+            "controller_job_id": self.controller_job.get("id", ""),
         }
         if "error" in self.controller_job:
             a_log["message"] = self.controller_job["error"]
             a_log["reason"] = {"error": self.controller_job["error"]}
         else:
             logger.info(f"job results url: {a_log['url']}")
-            logger.info(f"job id: {a_log['job_id']}")
+            logger.info(f"controller job id: {a_log['controller_job_id']}")
 
         await self.helper.send_status(a_log)
         set_facts = self.action_args.get("set_facts", False)

--- a/tests/unit/action/test_run_job_template.py
+++ b/tests/unit/action/test_run_job_template.py
@@ -56,6 +56,7 @@ def _validate(queue, success, reason=None):
         "url",
         "organization",
         "job_id",
+        "controller_job_id",
     }
 
     if not success:

--- a/tests/unit/action/test_run_workflow_template.py
+++ b/tests/unit/action/test_run_workflow_template.py
@@ -56,6 +56,7 @@ def _validate(queue, success, reason=None):
         "url",
         "organization",
         "job_id",
+        "controller_job_id",
     }
 
     if not success:
@@ -233,8 +234,8 @@ async def test_run_workflow_template_retries():
 
 
 URL_PARAMETERS = [
-    (None,),
-    (10,),
+    None,
+    10,
 ]
 
 


### PR DESCRIPTION
The JOB URL is going to be built on the server side since its difficult for the ansible-rulebook to convert an API end point to a URL. If the server has the controller_job_id and and the action type the server can build the URL.


https://issues.redhat.com/browse/AAP-25604