### PR TITLE
refactor: the controller tests were failing intermittently

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -64,15 +64,15 @@ def mocked_job_template_runner():
 
 
 @pytest.mark.asyncio
-async def test_job_template_get_config(mocked_job_template_runner):
+async def test_job_template_get_config(new_job_template_runner):
     text = json.dumps(dict(version="4.4.1"))
     with aioresponses() as mocked:
         mocked.get(
-            f"{mocked_job_template_runner.host}{CONFIG_SLUG}",
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
             status=200,
             body=text,
         )
-        data = await mocked_job_template_runner.get_config()
+        data = await new_job_template_runner.get_config()
         assert data["version"] == "4.4.1"
 
 
@@ -98,37 +98,36 @@ async def test_job_template_get_config_auth_error(mocked_job_template_runner):
 
 
 @pytest.mark.asyncio
-async def test_run_job_template(mocked_job_template_runner):
+async def test_run_job_template(new_job_template_runner):
     with aioresponses() as mocked:
         mocked.get(
-            f"{mocked_job_template_runner.host}"
+            f"{new_job_template_runner.host}"
             f"{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
             status=200,
             body=json.dumps(UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE),
         )
         mocked.get(
-            f"{mocked_job_template_runner.host}"
+            f"{new_job_template_runner.host}"
             f"{UNIFIED_JOB_TEMPLATE_PAGE2_SLUG}",
             status=200,
             body=json.dumps(UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE),
         )
         mocked.post(
-            f"{mocked_job_template_runner.host}"
-            f"{JOB_TEMPLATE_1_LAUNCH_SLUG}",
+            f"{new_job_template_runner.host}" f"{JOB_TEMPLATE_1_LAUNCH_SLUG}",
             status=200,
             body=json.dumps(JOB_TEMPLATE_POST_RESPONSE),
         )
         mocked.get(
-            f"{mocked_job_template_runner.host}{JOB_1_SLUG}",
+            f"{new_job_template_runner.host}{JOB_1_SLUG}",
             status=200,
             body=json.dumps(JOB_1_RUNNING),
         )
         mocked.get(
-            f"{mocked_job_template_runner.host}{JOB_1_SLUG}",
+            f"{new_job_template_runner.host}{JOB_1_SLUG}",
             status=200,
             body=json.dumps(JOB_1_SUCCESSFUL),
         )
-        data = await mocked_job_template_runner.run_job_template(
+        data = await new_job_template_runner.run_job_template(
             JOB_TEMPLATE_NAME_1, ORGANIZATION_NAME, {"a": 1}
         )
         assert data["status"] == "successful"
@@ -136,38 +135,37 @@ async def test_run_job_template(mocked_job_template_runner):
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_template(mocked_job_template_runner):
+async def test_run_workflow_template(new_job_template_runner):
     with aioresponses() as mocked:
         mocked.get(
-            f"{mocked_job_template_runner.host}"
+            f"{new_job_template_runner.host}"
             f"{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
             status=200,
             body=json.dumps(UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE),
         )
         mocked.get(
-            f"{mocked_job_template_runner.host}"
+            f"{new_job_template_runner.host}"
             f"{UNIFIED_JOB_TEMPLATE_PAGE2_SLUG}",
             status=200,
             body=json.dumps(UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE),
         )
         mocked.post(
-            f"{mocked_job_template_runner.host}"
-            f"{JOB_TEMPLATE_2_LAUNCH_SLUG}",
+            f"{new_job_template_runner.host}" f"{JOB_TEMPLATE_2_LAUNCH_SLUG}",
             status=200,
             body=json.dumps(JOB_TEMPLATE_POST_RESPONSE),
         )
         mocked.get(
-            f"{mocked_job_template_runner.host}{JOB_1_SLUG}",
+            f"{new_job_template_runner.host}{JOB_1_SLUG}",
             status=200,
             body=json.dumps(JOB_1_RUNNING),
         )
         mocked.get(
-            f"{mocked_job_template_runner.host}{JOB_1_SLUG}",
+            f"{new_job_template_runner.host}{JOB_1_SLUG}",
             status=200,
             body=json.dumps(JOB_1_SUCCESSFUL),
         )
 
-        data = await mocked_job_template_runner.run_workflow_job_template(
+        data = await new_job_template_runner.run_workflow_job_template(
             JOB_TEMPLATE_NAME_1, ORGANIZATION_NAME, {"a": 1, "limit": "all"}
         )
         assert data["status"] == "successful"
@@ -175,31 +173,31 @@ async def test_run_workflow_template(mocked_job_template_runner):
 
 
 @pytest.mark.asyncio
-async def test_missing_job_template(mocked_job_template_runner):
+async def test_missing_job_template(new_job_template_runner):
     with aioresponses() as mocked:
         mocked.get(
-            f"{mocked_job_template_runner.host}"
+            f"{new_job_template_runner.host}"
             f"{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
             status=200,
             body=json.dumps(NO_JOB_TEMPLATE_PAGE1_RESPONSE),
         )
         with pytest.raises(JobTemplateNotFoundException):
-            await mocked_job_template_runner.run_job_template(
+            await new_job_template_runner.run_job_template(
                 JOB_TEMPLATE_NAME_1, ORGANIZATION_NAME, {"a": 1}
             )
 
 
 @pytest.mark.asyncio
-async def test_missing_workflow_template(mocked_job_template_runner):
+async def test_missing_workflow_template(new_job_template_runner):
     with aioresponses() as mocked:
         mocked.get(
-            f"{mocked_job_template_runner.host}"
+            f"{new_job_template_runner.host}"
             f"{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
             status=200,
             body=json.dumps(NO_JOB_TEMPLATE_PAGE1_RESPONSE),
         )
         with pytest.raises(WorkflowJobTemplateNotFoundException):
-            await mocked_job_template_runner.run_workflow_job_template(
+            await new_job_template_runner.run_workflow_job_template(
                 JOB_TEMPLATE_NAME_1, ORGANIZATION_NAME, {"a": 1}
             )
 


### PR DESCRIPTION
We have a global variable for job_template_runner which causes tests to fail intermittently. I have fixed only the ones that were broken on Mac.