### PR TITLE
test: fix failed tests using ansible.builtin.debug module

### DIFF
--- a/tests/e2e/test_run_module_output.py
+++ b/tests/e2e/test_run_module_output.py
@@ -65,8 +65,8 @@ async def test_run_module_output():
         },
         "r2": {
             "action": "print_event",
-            "event_key": "m/message",
-            "event_value": "FRED FLINTSTONE",
+            "event_key": "m/msg",
+            "event_value": "I am Malenia, blade of Miquella",
         },
     }
     while not queue.empty():
@@ -101,7 +101,7 @@ async def test_run_module_output():
             assert data["activation_instance_id"] == proc_id
 
     assert stats["rulesTriggered"] == 2
-    assert stats["eventsProcessed"] == 6
+    assert stats["eventsProcessed"] == 4
     assert stats["eventsMatched"] == 2
 
     assert session_stats_counter >= 2

--- a/tests/examples/29_run_module.yml
+++ b/tests/examples/29_run_module.yml
@@ -2,18 +2,21 @@
 - name: 29 run module
   hosts: all
   sources:
-    - range:
-        limit: 5
+    - ansible.eda.generic:
+        payload:
+          - i: 1
+          - i: 2
+          - i: 3
   rules:
     - name: r1
       condition: event.i == 1
       action:
         run_module:
           post_events: True
-          name: ansible.eda.upcase
+          name: ansible.builtin.debug
           module_args:
-              name: Fred Flintstone
+              msg: "I am Malenia, blade of Miquella"
     - name: r2
-      condition: event.message == "FRED FLINTSTONE"
+      condition: event.msg == "I am Malenia, blade of Miquella"
       action:
         print_event:

--- a/tests/examples/31_run_module_missing_args.yml
+++ b/tests/examples/31_run_module_missing_args.yml
@@ -2,16 +2,20 @@
 - name: 31 run module missing args
   hosts: all
   sources:
-    - range:
-        limit: 5
+    - ansible.eda.generic:
+        payload:
+          - name: fred
+            i: 1
+          - name: fred
+            i: 2
   rules:
     - name: r1
       condition: event.i == 1
       action:
         run_module:
-          name: ansible.eda.upcase
+          name: ansible.builtin.debug
           module_args:
-              un_name: fred
+              idonotexist: fred
 
 
 

--- a/tests/examples/32_run_module_fail.yml
+++ b/tests/examples/32_run_module_fail.yml
@@ -9,7 +9,7 @@
       condition: event.i == 1
       action:
         run_module:
-          name: ansible.eda.upcase
+          name: ansible.builtin.fail
           module_args:
-              name: fail
+            msg: expected failure
           retry: True

--- a/tests/unit/action/test_run_module.py
+++ b/tests/unit/action/test_run_module.py
@@ -93,8 +93,8 @@ async def test_run_module():
         project_data_file="",
     )
     action_args = {
-        "module_args": {"name": "Fred Flintstone"},
-        "name": "ansible.eda.upcase",
+        "module_args": {"msg": "I am Malenia"},
+        "name": "ansible.builtin.debug",
     }
 
     with patch("uuid.uuid4", return_value=DUMMY_UUID):


### PR DESCRIPTION
ansible.eda.upcase has been removed from the collection. Fix failed tests like [this one](https://github.com/ansible/ansible-rulebook/actions/runs/10451252336/job/28937289092) by using a standard ansible.builting.debug module. 
