### PR TITLE
fix: only upload on main branch

### DIFF
--- a/.github/actions/all-tests/action.yml
+++ b/.github/actions/all-tests/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Upload jUnit test results (APDE CI)
       shell: bash
-      if: ${{ env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL != '' }}
+      if: env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL != '' && github.ref == 'refs/heads/main'
       run: >-
         http --check-status --ignore-stdin
         --auth "${{ env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ env.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"

--- a/.github/actions/common-tests/action.yml
+++ b/.github/actions/common-tests/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Upload jUnit test results (APDE CI)
       shell: bash
-      if: ${{ env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL != '' }}
+      if: env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL != '' && github.ref == 'refs/heads/main'
       run: >-
         http --check-status --ignore-stdin
         --auth "${{ env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ env.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Upload jUnit test results (APDE CI)
       shell: bash
-      if: ${{ env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL != '' }}
+      if: env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL != '' && github.ref == 'refs/heads/main'
       run: >-
         http --check-status --ignore-stdin
         --auth "${{ env.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ env.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"


### PR DESCRIPTION
After further validation, we only need to be uploading test results from the main branch.