### PR TITLE
feat: support receiving file contents and env vars from EDA Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 ### Fixed
 - Allow user to optionally include matching events
+- Allow for fetching env and file contents from EDA server
 
 
 ## [1.1.1] - 2024-09-19

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -32,7 +32,11 @@ from ansible_rulebook.conf import settings
 from ansible_rulebook.engine import run_rulesets, start_source
 from ansible_rulebook.job_template_runner import job_template_runner
 from ansible_rulebook.rule_types import RuleSet, RuleSetQueue
-from ansible_rulebook.util import decryptable
+from ansible_rulebook.util import (
+    decryptable,
+    decrypted_context,
+    substitute_variables,
+)
 from ansible_rulebook.validators import Validate
 from ansible_rulebook.vault import has_vaulted_str
 from ansible_rulebook.websocket import (
@@ -74,6 +78,12 @@ async def run(parsed_args: argparse.Namespace) -> None:
             raise WebSocketExchangeException(
                 "Error communicating with web socket server"
             )
+        context = decrypted_context(startup_args.variables)
+        startup_args.env_vars = substitute_variables(
+            startup_args.env_vars, context
+        )
+        for k, v in startup_args.env_vars.items():
+            os.environ[k] = str(v)
     else:
         startup_args = StartupArgs()
         startup_args.variables = load_vars(parsed_args)

--- a/ansible_rulebook/common.py
+++ b/ansible_rulebook/common.py
@@ -31,3 +31,4 @@ class StartupArgs:
     inventory: str = field(default="")
     check_controller_connection: bool = field(default=False)
     check_vault: bool = field(default=True)
+    env_vars: Dict = field(default_factory=dict)

--- a/tests/data/test_cert.pem
+++ b/tests/data/test_cert.pem
@@ -1,0 +1,1 @@
+This is a bogus certfile

--- a/tests/data/test_env.yml
+++ b/tests/data/test_env.yml
@@ -1,0 +1,3 @@
+---
+  ENV1: abc
+  ENV2: xyz

--- a/tests/data/test_key.pem
+++ b/tests/data/test_key.pem
@@ -1,0 +1,1 @@
+This is a bogus keyfile


### PR DESCRIPTION
AAP Credential Types support File contents via file injectors.
https://docs.ansible.com/automation-controller/latest/html/userguide/credential_types.html

We create temporary files with the data sent from Server The source plugin can access the temporary file names to access the data.

Supports single file as well as multiple files.

To access the filenames in the source rulebook you can use the following extra vars

- eda.filename or
- eda.filename.<<key_name1>>
- eda.filename.<<key_name2>>

e.g.
```
- name: Use payload file to check events
  hosts: all
  sources:
    - ansible.eda.generic:
        payload_file: "{{ eda.filename.test_payload_file }}"
```

The env variables are treated like extra_vars and added to the current processes environment

https://issues.redhat.com/browse/AAP-25519
