### PR TITLE
Update community comms info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,15 +67,16 @@ Documentation
 ===============
 Please refer to the `Getting Started guide <https://ansible-rulebook.readthedocs.io/en/stable/getting_started.html>`_ to get started with ``ansible-rulebook``.
 
-
 ===============
 Contributing
 ===============
 We ask all of our community members and contributors to adhere to the `Ansible code of conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_.
 If you have questions or need assistance, please reach out to our community team at codeofconduct@ansible.com
 
-Refer to the Contributing guide to get started developing, reporting bugs or providing feedback.
+Refer to the `Contributing guide <https://ansible.readthedocs.io/projects/rulebook/en/stable/contributing.html>`_ to get started developing, reporting bugs or providing feedback.
 
+To find out how to join the community and get in touch, see the `Community <https://ansible.readthedocs.io/projects/rulebook/en/stable/contributing.html#community>`_ section of our docs.
+You can also find more information in the `Ansible communication guide <https://docs.ansible.com/ansible/devel/community/communication.html>`_.
 
 Credits
 -------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -20,9 +20,6 @@ Search by categories and tags to find interesting topics or start a new one; sub
 
 See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.
 
-You can also check the `Matrix chat <https://matrix.to/#/#eda:ansible.com>`__, or via the
-event-driven-automation@redhat.com email.
-
 Types of Contributions
 ----------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,10 +5,28 @@ Contributing
 Contributions are welcome, and they are greatly appreciated! Every little bit
 helps, and credit will always be given.
 
-You can contribute in many ways:
+Getting in touch
+----------------
+
+Join the `Ansible Forum <https://forum.ansible.com>`_, the default communication platform for questions and help, development discussions, events, and much more.
+`Register <https://forum.ansible.com/signup?>`_ to join the community.
+Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+
+* `Get Help <https://forum.ansible.com/c/help/6>`_: get help or help others. Please add appropriate tags if you start new discussions, for example `ansible-rulebook`.
+* `Posts tagged with 'ansible-rulebook' <https://forum.ansible.com/tag/ansible-rulebook>`_: subscribe to participate in project-related conversations.
+* `Bullhorn newsletter <https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
+* `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.
+* `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
+
+See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.
+
+You can also check the `Matrix chat <https://matrix.to/#/#eda:ansible.com>`__, or via the
+event-driven-automation@redhat.com email.
 
 Types of Contributions
 ----------------------
+
+You can contribute in many ways:
 
 Report Bugs
 ~~~~~~~~~~~
@@ -26,8 +44,6 @@ Fix Bugs
 
 Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
 wanted" is open to whoever wants to implement it.
-
-
 
 Implement Features
 ~~~~~~~~~~~~~~~~~~
@@ -67,7 +83,3 @@ If you are proposing a feature:
 * Keep the scope as narrow as possible, to make it easier to implement.
 * Remember that this is a volunteer-driven project, and that contributions
   are welcome :)
-
-
-Also you can check the `Matrix chat <https://matrix.to/#/#eda:ansible.com>`__, or via the
-event-driven-automation@redhat.com email.


### PR DESCRIPTION
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!