### PR TITLE
chore: bump 1.1.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.2
 commit = False
 tag = False
 search = {current_version}

--- a/ansible_rulebook/__init__.py
+++ b/ansible_rulebook/__init__.py
@@ -16,7 +16,7 @@
 
 import yaml
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 
 def construct_vault_encrypted_unicode(loader, node):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ansible_rulebook
-version = 1.1.1
+version = 1.1.2
 description = Event driven automation for Ansible
 url = https://github.com/ansible/ansible-rulebook
 license = Apache-2.0


### PR DESCRIPTION
Prepare new 1.1.2 version in order to be sync main with stable branch later. 