### PR TITLE
chore: pin minor version of aiohttp

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.9
 install_requires =
-	aiohttp >=3,<4
+	aiohttp >=3,<3.11
 	pyparsing >= 3.0,<4
 	jsonschema >=4,<5
 	jinja2 >=3,<4


### PR DESCRIPTION
Yesterday, 3.11 version of `aiohttp` was released with [breaking changes ](https://github.com/aio-libs/aiohttp/releases/tag/v3.11.0 ) which breaks `aioresponses` library used for our mocks and as consequence some of our tests are failing. 
Ref: https://github.com/pnuckowski/aioresponses/pull/262

Regardless of whether this is fixed in aioresponses, aiohttp can introduce breaking changes in minor versions, so I pin it to the latest tested version as this library is critical for the stability in some of our features. 