### PR TITLE
chore: subprocess.signal.SIGINT missing in 3.12.9

### DIFF
--- a/tests/e2e/test_runtime.py
+++ b/tests/e2e/test_runtime.py
@@ -2,6 +2,7 @@
 Module with tests for general CLI runtime
 """
 import logging
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -216,7 +217,7 @@ def test_terminate_process_sigint():
     start = time.time()
     while line := process.stdout.readline():
         if "'action': 'long_loop'" in line:
-            process.send_signal(subprocess.signal.SIGINT)
+            process.send_signal(signal.SIGINT)
             process.wait()
             break
         time.sleep(0.1)


### PR DESCRIPTION
Fixed a broken test
https://github.com/ansible/ansible-rulebook/actions/runs/13295697912/job/37127030121