### PR TITLE
fix: decryption before every substitution disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Allow user to optionally include matching events
 - Allow for fetching env and file contents from EDA server
+- Overhead of running decryption before every usage
 
 
 ## [1.1.1] - 2024-09-19

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -78,12 +78,6 @@ async def run(parsed_args: argparse.Namespace) -> None:
             raise WebSocketExchangeException(
                 "Error communicating with web socket server"
             )
-        context = decrypted_context(startup_args.variables)
-        startup_args.env_vars = substitute_variables(
-            startup_args.env_vars, context
-        )
-        for k, v in startup_args.env_vars.items():
-            os.environ[k] = str(v)
     else:
         startup_args = StartupArgs()
         startup_args.variables = load_vars(parsed_args)
@@ -107,6 +101,12 @@ async def run(parsed_args: argparse.Namespace) -> None:
 
     validate_actions(startup_args)
     validate_variables(startup_args)
+    startup_args.variables = decrypted_context(startup_args.variables)
+    startup_args.env_vars = substitute_variables(
+        startup_args.env_vars, startup_args.variables
+    )
+    for k, v in startup_args.env_vars.items():
+        os.environ[k] = str(v)
 
     if startup_args.check_controller_connection:
         await validate_controller_params(startup_args)

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -42,7 +42,6 @@ from ansible_rulebook.rule_types import (
 )
 from ansible_rulebook.util import (
     collect_ansible_facts,
-    decrypted_context,
     find_builtin_filter,
     has_builtin_filter,
     send_session_stats,
@@ -161,9 +160,8 @@ async def start_source(
                 (source_filter_module["main"], source_filter.filter_args)
             )
 
-        context = decrypted_context(variables)
         args = {
-            k: substitute_variables(v, context)
+            k: substitute_variables(v, variables)
             for k, v in source.source_args.items()
         }
         fqueue = FilteredQueue(source_filters, queue)

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -48,7 +48,7 @@ from ansible_rulebook.rule_types import (
     RuleSet,
     Throttle,
 )
-from ansible_rulebook.util import decrypted_context, substitute_variables
+from ansible_rulebook.util import substitute_variables
 
 OPERATOR_MNEMONIC = {
     "!=": "NotEqualsExpression",
@@ -273,8 +273,7 @@ def visit_source_filter(parsed_source: EventSourceFilter, variables: Dict):
 
 def generate_condition(ansible_condition: RuleCondition, variables: Dict):
     """Generate the condition AST."""
-    context = decrypted_context(variables)
-    condition = visit_condition(ansible_condition.value, context)
+    condition = visit_condition(ansible_condition.value, variables)
     if ansible_condition.when == "any":
         data = {"AnyCondition": condition}
     elif ansible_condition.when == "all":

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -58,7 +58,6 @@ from ansible_rulebook.rule_types import (
 )
 from ansible_rulebook.rules_parser import parse_hosts
 from ansible_rulebook.util import (
-    decrypted_context,
     run_at,
     send_session_stats,
     substitute_variables,
@@ -429,24 +428,12 @@ class RuleSetRunner:
 
                 if "var_root" in action_args:
                     var_root = action_args.pop("var_root")
-                    logger.debug(
-                        "Update variables [%s] with new root [%s]",
-                        variables_copy,
-                        var_root,
-                    )
                     _update_variables(variables_copy, var_root)
 
-                logger.debug(
-                    "substitute_variables [%s] [%s]",
-                    action_args,
-                    variables_copy,
-                )
-                context = decrypted_context(variables_copy)
                 action_args = {
-                    k: substitute_variables(v, context)
+                    k: substitute_variables(v, variables_copy)
                     for k, v in action_args.items()
                 }
-                logger.debug("action args: %s", action_args)
 
                 if "ruleset" not in action_args:
                     action_args["ruleset"] = metadata.rule_set

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -20,7 +20,7 @@ from ansible_rulebook.condition_parser import (
     parse_condition as parse_condition_value,
 )
 from ansible_rulebook.conf import settings
-from ansible_rulebook.util import decrypted_context, substitute_variables
+from ansible_rulebook.util import substitute_variables
 
 from .exception import (
     RulenameDuplicateException,
@@ -133,8 +133,7 @@ def parse_rules(rules: Dict, variables: Dict) -> List[rt.Rule]:
         if name is None:
             raise RulenameEmptyException("Rule name not provided")
 
-        context = decrypted_context(variables)
-        name = substitute_variables(name, context)
+        name = substitute_variables(name, variables)
         if name == "":
             raise RulenameEmptyException("Rule name cannot be an empty string")
 


### PR DESCRIPTION
Calling ansible-vault as a separate process is a huge overhead and takes upto 2 seconds per variable. Doing this over and over before every substitution slows doen the entire processing. Now we decrypt once at startup and keep the decrypted values in memory and reuse them during substitution.

https://issues.redhat.com/browse/AAP-40490