### PR TITLE
docs: update the rulebook name

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -87,7 +87,7 @@ remediate the issue.
 Let's build an example rulebook that will trigger an action from a
 webhook. We will be looking for a specific payload from the webhook, and
 if that condition is met from the webhook event, then ``ansible-rulebook``
-will trigger the desired action. Below is our example rulebook:
+will trigger the desired action. Below is our example rulebook ``webhook-example.yml``:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The below command is use the rulebook name, it should be better to mention:
```
root@ansible-rulebook:/root# ansible-rulebook --rulebook webhook-example.yml  << -i inventory.yml --verbose
```