### PR TITLE
chore: update get version output

### DIFF
--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -246,7 +246,7 @@ def get_version() -> str:
     java_home = util.get_java_home()
     java_version = util.get_java_version()
     result = [
-        f"{ansible_rulebook.__version__}",
+        f"ansible-rulebook [{ansible_rulebook.__version__}]",
         f"  Executable location = {sys.argv[0]}",
         f"  Drools_jpy version = {importlib.metadata.version('drools_jpy')}",
         f"  Java home = {java_home}",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,7 +11,7 @@ from ansible_rulebook.util import check_jvm
 def test_get_version():
     output = get_version()
     pattern = re.compile(
-        r"""\d+\.\d+\.\d+
+        r"""ansible-rulebook \[\d+\.\d+\.\d+\]
   Executable location = (.+)
   Drools_jpy version = \d+\.\d+\.\d+
   Java home = (.+)


### PR DESCRIPTION
Keep similar with ansible/ansible-playbook's version output:
```
before:
$ ansible-rulebook --version
1.1.3

after:
$ ansible-rulebook --version
ansible-rulebook [1.1.3]
```