### PR TITLE
feat: log stacktrace with just file, function name and line number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [1.1.4 - Unreleased]
 ### Changed
 ### Added
+- Log stacktrace with source filename, function and line number
 ### Fixed
 
 

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -16,6 +16,8 @@ import argparse
 import asyncio
 import logging
 import os
+import sys
+import traceback
 from asyncio.exceptions import CancelledError
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -66,6 +68,18 @@ class NullQueue:
 logger = logging.getLogger(__name__)
 INVENTORY_ACTIONS = ("run_playbook", "run_module")
 CONTROLLER_ACTIONS = ("run_job_template", "run_workflow_template")
+
+
+def log_exception_without_data(exc_type, exc_value, exc_traceback):
+    logger.error(exc_type.__name__ + ": " + str(exc_value))
+    if exc_traceback is not None:
+        for frame in traceback.extract_tb(exc_traceback)[::-1]:
+            logger.error(
+                frame.filename + ":" + str(frame.lineno) + " " + frame.name
+            )
+
+
+sys.excepthook = log_exception_without_data
 
 
 # FIXME(cutwater): Replace parsed_args with clear interface
@@ -161,7 +175,9 @@ async def run(parsed_args: argparse.Namespace) -> None:
         if isinstance(result, Exception) and not isinstance(
             result, CancelledError
         ):
-            logger.error(result)
+            log_exception_without_data(
+                type(result), result, result.__traceback__
+            )
             error_found = True
 
     logger.info("Main complete")

--- a/tests/e2e/files/rulebooks/test_source_stacktrace.yml
+++ b/tests/e2e/files/rulebooks/test_source_stacktrace.yml
@@ -1,0 +1,13 @@
+---
+- name: Raise exception midst processing
+  hosts: localhost
+  sources:
+    - name: Raise Exception
+      fail_after:
+        limit: "{{ LIMIT | default(10) }}"
+        after: "{{ FAIL_AFTER | default(4) }}"
+  rules:
+    - name: Simple Rule
+      condition: true
+      action:
+        debug:

--- a/tests/e2e/test_source_stacktrace.py
+++ b/tests/e2e/test_source_stacktrace.py
@@ -1,0 +1,54 @@
+"""
+Module with tests for source failures
+"""
+import logging
+import subprocess
+
+import pytest
+
+from . import utils
+from .settings import SETTINGS
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_CMD_TIMEOUT = SETTINGS["cmd_timeout"]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "limit, trace_present",
+    [
+        pytest.param("2", False),
+        pytest.param("10", True),
+    ],
+)
+def test_source_stacktrace(update_environment, limit, trace_present):
+    """
+    Execute a rulebook that has source that fails with
+    exception in certain conditions, we should see the
+    stack trace with the file and line number in specific cases
+    """
+
+    env = update_environment({"LIMIT": limit})
+    rulebook = utils.BASE_DATA_PATH / "rulebooks/test_source_stacktrace.yml"
+    vars_file = (
+        utils.BASE_DATA_PATH / "extra_vars/test_variables_extra_vars.yml"
+    )
+
+    cmd = utils.Command(
+        rulebook=rulebook,
+        envvars="LIMIT",
+        vars_file=vars_file,
+    )
+
+    LOGGER.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd,
+        timeout=DEFAULT_CMD_TIMEOUT,
+        env=env,
+        capture_output=True,
+        cwd=utils.BASE_DATA_PATH,
+        text=True,
+    )
+
+    found = "sources/fail_after.py:36" in result.stderr
+    assert found == trace_present

--- a/tests/sources/fail_after.py
+++ b/tests/sources/fail_after.py
@@ -1,0 +1,50 @@
+"""fail_after.py.
+
+An ansible-rulebook event source plugin for generating events with an
+increasing index i. It raises an exception when it reaches the value
+of fail_after (4 by default) and sleeps every delay (0 by default)
+
+Arguments:
+---------
+    limit: The upper limit of the range of the index.
+    delay: The number of seconds to sleep between events
+    after: Fail after we have reached the prescribed amount
+
+Example:
+-------
+    - fail_after:
+        limit: 5
+        delay: 0
+        after: 4
+
+"""
+
+import asyncio
+import secrets
+from typing import Any
+
+
+async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:
+    """Generate events with an increasing index i with a limit."""
+    password = secrets.token_hex()
+    after = int(args.get("after", "4"))
+    delay = int(args.get("delay", "0"))
+
+    for i in range(int(args["limit"])):
+        await queue.put({"i": i})
+        if i == after:
+            i.something_that_does_not_exist(password)
+        await asyncio.sleep(delay)
+
+
+if __name__ == "__main__":
+    # MockQueue if running directly
+
+    class MockQueue(asyncio.Queue[Any]):
+        """A fake queue."""
+
+        async def put(self: "MockQueue", event: dict[str, Any]) -> None:
+            """Print the event."""
+            print(event)  # noqa: T201
+
+    asyncio.run(main(MockQueue(), {"limit": 5}))


### PR DESCRIPTION
A regular stack trace will print out args, data which can lead to security leak. So we want to limit the stack trace to just
* source file name
* function name
* line number

This will help users debug their source plugins etc, otherwise it would be very challenging where the code has issues

https://issues.redhat.com/browse/AAP-41261
<img width="1217" alt="stacktrace" src="https://github.com/user-attachments/assets/f09a0816-0c85-4763-afb7-b469958f0055" />


