### PR TITLE
feat: bundle kerberos libraries for GSSAPI support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN for dir in \
     do mkdir -p $dir ; chown -R "${USER_ID}:0" $dir ; chmod 0775 $dir ; done \
     && useradd --uid "$USER_ID" --gid 0 --home-dir "$APP_DIR" appuser
 
-RUN dnf install -y java-17-openjdk-devel python3-pip postgresql-devel gcc python3-devel git
+RUN dnf install -y java-17-openjdk-devel python3-pip postgresql-devel gcc python3-devel git krb5-libs krb5-devel
 
 USER $USER_ID
 WORKDIR $APP_DIR
@@ -34,7 +34,7 @@ RUN pip install -U pip \
     ansible-runner \
     jmespath \
     aiohttp \
-    aiokafka \
+    aiokafka[gssapi] \
     watchdog \
     azure-servicebus \
     aiobotocore \


### PR DESCRIPTION
For kafka-gssapi we need some Kerberos libraries to be installed alongside the python gssapi package.

https://issues.redhat.com/browse/AAPRFE-1662