### PR TITLE
chore: move constants to conf

### DIFF
--- a/ansible_rulebook/collection.py
+++ b/ansible_rulebook/collection.py
@@ -14,34 +14,22 @@
 
 import logging
 import os
-import shutil
 import subprocess
 from functools import lru_cache
 
 import yaml
 
 from ansible_rulebook import terminal
+from ansible_rulebook.constants import (
+    ANSIBLE_GALAXY,
+    EDA_FILTER_PATHS,
+    EDA_PATH_PREFIX,
+    EDA_PLAYBOOKS_PATHS,
+    EDA_SOURCE_PATHS,
+    EDA_YAML_EXTENSIONS,
+)
 from ansible_rulebook.exception import RulebookNotFoundException
 from ansible_rulebook.vault import has_vaulted_str
-
-ANSIBLE_GALAXY = shutil.which("ansible-galaxy")
-EDA_PATH_PREFIX = "extensions/eda"
-
-EDA_FILTER_PATHS = [
-    f"{EDA_PATH_PREFIX}/plugins/event_filter",
-    f"{EDA_PATH_PREFIX}/plugins/event_filters",
-    "plugins/event_filter",
-]
-
-EDA_SOURCE_PATHS = [
-    f"{EDA_PATH_PREFIX}/plugins/event_source",
-    f"{EDA_PATH_PREFIX}/plugins/event_sources",
-    "plugins/event_source",
-]
-
-EDA_PLAYBOOKS_PATHS = [".", "playbooks"]
-
-EDA_YAML_EXTENSIONS = [".yml", ".yaml"]
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_rulebook/condition_parser.py
+++ b/ansible_rulebook/condition_parser.py
@@ -57,35 +57,11 @@ from ansible_rulebook.condition_types import (  # noqa: E402
     String,
     to_condition_type,
 )
-
-VALID_SELECT_ATTR_OPERATORS = [
-    "==",
-    "!=",
-    ">",
-    ">=",
-    "<",
-    "<=",
-    "regex",
-    "search",
-    "match",
-    "in",
-    "not in",
-    "contains",
-    "not contains",
-]
-
-VALID_SELECT_OPERATORS = [
-    "==",
-    "!=",
-    ">",
-    ">=",
-    "<",
-    "<=",
-    "regex",
-    "search",
-    "match",
-]
-SUPPORTED_SEARCH_KINDS = ("match", "regex", "search")
+from ansible_rulebook.constants import (  # noqa: E402
+    SUPPORTED_SEARCH_KINDS,
+    VALID_SELECT_ATTR_OPERATORS,
+    VALID_SELECT_OPERATORS,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_rulebook/constants.py
+++ b/ansible_rulebook/constants.py
@@ -1,0 +1,103 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import shutil
+
+# Constants for collection
+ANSIBLE_GALAXY = shutil.which("ansible-galaxy")
+EDA_PATH_PREFIX = "extensions/eda"
+
+EDA_FILTER_PATHS = [
+    f"{EDA_PATH_PREFIX}/plugins/event_filter",
+    f"{EDA_PATH_PREFIX}/plugins/event_filters",
+    "plugins/event_filter",
+]
+
+EDA_SOURCE_PATHS = [
+    f"{EDA_PATH_PREFIX}/plugins/event_source",
+    f"{EDA_PATH_PREFIX}/plugins/event_sources",
+    "plugins/event_source",
+]
+
+EDA_PLAYBOOKS_PATHS = [".", "playbooks"]
+
+EDA_YAML_EXTENSIONS = [".yml", ".yaml"]
+
+# Constants for condition parser
+VALID_SELECT_ATTR_OPERATORS = [
+    "==",
+    "!=",
+    ">",
+    ">=",
+    "<",
+    "<=",
+    "regex",
+    "search",
+    "match",
+    "in",
+    "not in",
+    "contains",
+    "not contains",
+]
+
+VALID_SELECT_OPERATORS = [
+    "==",
+    "!=",
+    ">",
+    ">=",
+    "<",
+    "<=",
+    "regex",
+    "search",
+    "match",
+]
+SUPPORTED_SEARCH_KINDS = ("match", "regex", "search")
+
+# Constants for json generator
+OPERATOR_MNEMONIC = {
+    "!=": "NotEqualsExpression",
+    "==": "EqualsExpression",
+    "and": "AndExpression",
+    "or": "OrExpression",
+    ">": "GreaterThanExpression",
+    "<": "LessThanExpression",
+    ">=": "GreaterThanOrEqualToExpression",
+    "<=": "LessThanOrEqualToExpression",
+    "+": "AdditionExpression",
+    "-": "SubtractionExpression",
+    "<<": "AssignmentExpression",
+    "in": "ItemInListExpression",
+    "not in": "ItemNotInListExpression",
+    "contains": "ListContainsItemExpression",
+    "not contains": "ListNotContainsItemExpression",
+}
+
+# Constant for messages
+DEFAULT_SHUTDOWN_DELAY = 60.0
+
+# Constant for util
+EDA_BUILTIN_FILTER_PREFIX = "eda.builtin."
+
+# Constant for validators
+DEFAULT_RULEBOOK_SCHEMA = "ruleset_schema"
+
+# Constant for vault
+VAULT_HEADER = "$ANSIBLE_VAULT"
+b_VAULT_HEADER = b"$ANSIBLE_VAULT"
+
+# Constant for websocket
+BACKOFF_MIN = 1.92
+BACKOFF_MAX = 60.0
+BACKOFF_FACTOR = 1.618
+BACKOFF_INITIAL = 5

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -34,6 +34,7 @@ from ansible_rulebook.condition_types import (
     String,
     to_condition_type,
 )
+from ansible_rulebook.constants import OPERATOR_MNEMONIC
 from ansible_rulebook.exception import (
     InvalidAssignmentException,
     InvalidIdentifierException,
@@ -49,24 +50,6 @@ from ansible_rulebook.rule_types import (
     Throttle,
 )
 from ansible_rulebook.util import substitute_variables
-
-OPERATOR_MNEMONIC = {
-    "!=": "NotEqualsExpression",
-    "==": "EqualsExpression",
-    "and": "AndExpression",
-    "or": "OrExpression",
-    ">": "GreaterThanExpression",
-    "<": "LessThanExpression",
-    ">=": "GreaterThanOrEqualToExpression",
-    "<=": "LessThanOrEqualToExpression",
-    "+": "AdditionExpression",
-    "-": "SubtractionExpression",
-    "<<": "AssignmentExpression",
-    "in": "ItemInListExpression",
-    "not in": "ItemNotInListExpression",
-    "contains": "ListContainsItemExpression",
-    "not contains": "ListNotContainsItemExpression",
-}
 
 
 def visit_condition(parsed_condition: ConditionTypes, variables: Dict):

--- a/ansible_rulebook/messages.py
+++ b/ansible_rulebook/messages.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass
 
-DEFAULT_SHUTDOWN_DELAY = 60.0
+from ansible_rulebook.constants import DEFAULT_SHUTDOWN_DELAY
 
 
 @dataclass(frozen=True)

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -35,6 +35,7 @@ from packaging.version import InvalidVersion
 
 from ansible_rulebook import terminal
 from ansible_rulebook.conf import settings
+from ansible_rulebook.constants import EDA_BUILTIN_FILTER_PREFIX
 from ansible_rulebook.exception import (
     InvalidFilterNameException,
     InventoryNotFound,
@@ -42,9 +43,6 @@ from ansible_rulebook.exception import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-EDA_BUILTIN_FILTER_PREFIX = "eda.builtin."
 
 
 def decrypted_context(

--- a/ansible_rulebook/validators.py
+++ b/ansible_rulebook/validators.py
@@ -11,7 +11,8 @@ else:
 import jsonschema
 from jsonschema.exceptions import SchemaError, ValidationError
 
-DEFAULT_RULEBOOK_SCHEMA = "ruleset_schema"
+from ansible_rulebook.constants import DEFAULT_RULEBOOK_SCHEMA
+
 logger = logging.getLogger(__name__)
 
 

--- a/ansible_rulebook/vault.py
+++ b/ansible_rulebook/vault.py
@@ -18,13 +18,14 @@ import tempfile
 
 import pexpect
 
+from ansible_rulebook.constants import (
+    VAULT_HEADER,
+    b_VAULT_HEADER,
+)
 from ansible_rulebook.exception import (
     AnsibleVaultNotFound,
     VaultDecryptException,
 )
-
-VAULT_HEADER = "$ANSIBLE_VAULT"
-b_VAULT_HEADER = b"$ANSIBLE_VAULT"
 
 
 class Vault:

--- a/ansible_rulebook/websocket.py
+++ b/ansible_rulebook/websocket.py
@@ -30,6 +30,12 @@ from websockets.client import WebSocketClientProtocol
 from ansible_rulebook import rules_parser as rules_parser
 from ansible_rulebook.common import StartupArgs
 from ansible_rulebook.conf import settings
+from ansible_rulebook.constants import (
+    BACKOFF_FACTOR,
+    BACKOFF_INITIAL,
+    BACKOFF_MAX,
+    BACKOFF_MIN,
+)
 from ansible_rulebook.token import renew_token
 from ansible_rulebook.util import validate_url
 from ansible_rulebook.vault import Vault, has_vaulted_str
@@ -38,12 +44,6 @@ from .exception import InvalidUrlException
 
 logger = logging.getLogger(__name__)
 logging.getLogger("websockets").setLevel(logging.ERROR)
-
-
-BACKOFF_MIN = 1.92
-BACKOFF_MAX = 60.0
-BACKOFF_FACTOR = 1.618
-BACKOFF_INITIAL = 5
 
 
 async def _wait_before_retry(backoff_delay: float) -> float:


### PR DESCRIPTION
Move the `constants` to `constants.py` for centralized management, and  improve the maintainability, keep the main code cleaner.