### PR TITLE
feat: print relevant versions at worker startup AAP-40781

### DIFF
--- a/.github/actions/common-tests/action.yml
+++ b/.github/actions/common-tests/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Run common tests
       shell: bash
-      run: pytest -m "not e2e and not long_run" -vv -n auto --cov=./ --cov-report=xml --junit-xml=common-test-results.xml
+      run: pytest -vv -s -m "not e2e and not long_run" -vv -n auto --cov=./ --cov-report=xml --junit-xml=common-test-results.xml
 
     - name: Upload jUnit test results (APDE CI)
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 ### Added
 - Log stacktrace with source filename, function and line number
+- Log relevant version information at startup of worker
 ### Fixed
 
 

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -37,6 +37,7 @@ from ansible_rulebook.rule_types import RuleSet, RuleSetQueue
 from ansible_rulebook.util import (
     decryptable,
     decrypted_context,
+    startup_logging,
     substitute_variables,
     validate_url,
 )
@@ -87,6 +88,7 @@ async def run(parsed_args: argparse.Namespace) -> None:
     file_monitor = None
 
     if parsed_args.worker and parsed_args.websocket_url and parsed_args.id:
+        startup_logging(logger)
         logger.info("Starting worker mode")
         startup_args = await request_workload(parsed_args.id)
         if not startup_args:

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -15,11 +15,9 @@
 
 import argparse
 import asyncio
-import importlib.metadata
 import logging
 import os
 import sys
-from importlib.metadata import version as pkg_version
 from typing import List
 
 import ansible_rulebook.util as util
@@ -82,7 +80,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--version",
         action="version",
         help="Show the version and exit",
-        version=get_version(),
+        version=util.get_version(),
     )
     parser.add_argument(
         "-S",
@@ -247,20 +245,6 @@ def get_parser() -> argparse.ArgumentParser:
         default=False,
     )
     return parser
-
-
-def get_version() -> str:
-    java_home = util.get_java_home()
-    java_version = util.get_java_version()
-    result = [
-        f"ansible-rulebook [{pkg_version('ansible-rulebook')}]",
-        f"  Executable location = {sys.argv[0]}",
-        f"  Drools_jpy version = {importlib.metadata.version('drools_jpy')}",
-        f"  Java home = {java_home}",
-        f"  Java version = {java_version}",
-        f"  Python version = {''.join(sys.version.splitlines())}",
-    ]
-    return "\n".join(result)
 
 
 def validate_args(args: argparse.Namespace) -> None:

--- a/ansible_rulebook/collection.py
+++ b/ansible_rulebook/collection.py
@@ -14,17 +14,16 @@
 
 import logging
 import os
-import shutil
 import subprocess
 from functools import lru_cache
 
 import yaml
 
 from ansible_rulebook import terminal
+from ansible_rulebook.conf import settings
 from ansible_rulebook.exception import RulebookNotFoundException
 from ansible_rulebook.vault import has_vaulted_str
 
-ANSIBLE_GALAXY = shutil.which("ansible-galaxy")
 EDA_PATH_PREFIX = "extensions/eda"
 
 EDA_FILTER_PATHS = [
@@ -53,13 +52,13 @@ def split_collection_name(collection_resource):
 
 @lru_cache
 def find_collection(name):
-    if ANSIBLE_GALAXY is None:
+    if settings.ansible_galaxy_path is None:
         raise Exception("ansible-galaxy is not installed")
     try:
         env = os.environ.copy()
         env["ANSIBLE_LOCAL_TEMP"] = "/tmp"
         output = subprocess.check_output(
-            [ANSIBLE_GALAXY, "collection", "list", name],
+            [settings.ansible_galaxy_path, "collection", "list", name],
             stderr=subprocess.STDOUT,
             env=env,
         )

--- a/ansible_rulebook/conf.py
+++ b/ansible_rulebook/conf.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import shutil
 import uuid
 
 from ansible_rulebook.vault import Vault
@@ -31,6 +32,7 @@ class _Settings:
         self.websocket_refresh_token = None
         self.skip_audit_events = False
         self.vault = Vault()
+        self.ansible_galaxy_path = shutil.which("ansible-galaxy")
 
 
 settings = _Settings()

--- a/tests/e2e/test_operators.py
+++ b/tests/e2e/test_operators.py
@@ -1,6 +1,7 @@
 """
 Module with tests for operators
 """
+
 import logging
 import subprocess
 

--- a/tests/e2e/test_runtime.py
+++ b/tests/e2e/test_runtime.py
@@ -1,6 +1,7 @@
 """
 Module with tests for general CLI runtime
 """
+
 import logging
 import signal
 import subprocess

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -22,10 +22,10 @@ class Command:
     provides methods to render it for cmd runners
     """
 
-    rulebook: Path
+    rulebook: Optional[Path]
     program_name: str = "ansible-rulebook"
     cwd: Path = BASE_DATA_PATH
-    inventory: Path = DEFAULT_INVENTORY
+    inventory: Optional[Path] = DEFAULT_INVENTORY
     sources: Optional[Path] = DEFAULT_SOURCES
     vars_file: Optional[Path] = None
     envvars: Optional[str] = None
@@ -61,7 +61,8 @@ class Command:
     def to_list(self) -> List:
         result = [self.program_name]
 
-        result.extend(["-i", str(self.inventory.absolute())])
+        if self.inventory:
+            result.extend(["-i", str(self.inventory.absolute())])
 
         if self.sources:
             result.extend(["-S", str(self.sources.absolute())])

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
-from ansible_rulebook.cli import get_version, main
-from ansible_rulebook.util import check_jvm, validate_url
+from ansible_rulebook.cli import main
+from ansible_rulebook.util import check_jvm, get_version, validate_url
 
 
 def test_get_version():
@@ -16,7 +16,10 @@ def test_get_version():
   Drools_jpy version = \d+\.\d+\.\d+
   Java home = (.+)
   Java version = \d+(\.\d+)?(\.\d+)?(\.\d+)?
-  Python version = \d+\.\d+\.\d+ (.+)$"""
+  Ansible core version = \d+\.\d+\.\d+([a-zA-Z0-9\+\-\.]*)?
+  Python version = \d+\.\d+\.\d+([a-zA-Z0-9\+\-\.]*)?
+  Python executable = (\S+)
+  Platform = (.+)$"""
     )
     assert pattern.match(output)
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -11,6 +11,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import importlib.metadata
+import logging
+import subprocess
+from unittest.mock import patch
+
 import pytest
 
 from ansible_rulebook.conf import settings
@@ -18,7 +23,14 @@ from ansible_rulebook.exception import (
     InvalidFilterNameException,
     VaultDecryptException,
 )
-from ansible_rulebook.util import decryptable, has_builtin_filter
+from ansible_rulebook.util import (
+    decryptable,
+    get_installed_collections,
+    get_package_version,
+    get_version,
+    has_builtin_filter,
+    startup_logging,
+)
 from ansible_rulebook.vault import Vault
 
 TEST_PASSWORD = "secret"
@@ -117,3 +129,105 @@ def test_decryptable_with_errors(obj):
 
     with pytest.raises(VaultDecryptException):
         decryptable(obj)
+
+
+def test_get_package_version(caplog):
+    assert get_package_version("aiohttp") == importlib.metadata.version(
+        "aiohttp"
+    )
+
+    # assert outcome when package is not found
+    with patch(
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError,
+    ):
+        assert get_package_version("idonotexist") == "unknown"
+        assert "Cannot read version" in caplog.text
+
+
+@patch("ansible_rulebook.conf.settings.ansible_galaxy_path", None)
+def test_get_installed_collections_no_ansible_galaxy_path():
+    assert get_installed_collections() is None
+
+
+@patch(
+    "ansible_rulebook.conf.settings.ansible_galaxy_path",
+    "/path/to/ansible-galaxy",
+)
+def test_get_installed_collections_success():
+    subprocess_output = "collection1\ncollection2\n"
+    subprocess_mock = subprocess.CompletedProcess(
+        args=["/path/to/ansible-galaxy", "collection", "list"],
+        returncode=0,
+        stdout=subprocess_output,
+        stderr="",
+    )
+    subprocess_run_mock = subprocess_mock
+    subprocess_run_mock.stdout = subprocess_output
+    subprocess_run_mock.stderr = ""
+    subprocess_run_mock.check_returncode = lambda: None
+
+    with patch("subprocess.run", return_value=subprocess_run_mock) as run_mock:
+        assert get_installed_collections() == subprocess_output
+
+    run_mock.assert_called_once_with(
+        ["/path/to/ansible-galaxy", "collection", "list"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+@patch(
+    "ansible_rulebook.conf.settings.ansible_galaxy_path",
+    "/path/to/ansible-galaxy",
+)
+def test_get_installed_collections_error():
+    subprocess_error = subprocess.CalledProcessError(
+        returncode=1, cmd=["ansible-galaxy"]
+    )
+    subprocess_run_mock = subprocess_error
+    subprocess_run_mock.check_returncode = lambda: None
+
+    with patch("subprocess.run", side_effect=subprocess_run_mock) as run_mock:
+        assert get_installed_collections() is None
+
+    run_mock.assert_called_once_with(
+        [settings.ansible_galaxy_path, "collection", "list"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_startup_logging(caplog):
+    logger = logging.getLogger("test_logger")
+    version_output = get_version()
+
+    with patch(
+        "ansible_rulebook.util.get_installed_collections",
+        return_value="collection1\ncollection2\n",
+    ):
+        startup_logging(logger)
+    assert version_output in caplog.text
+    assert "collection1\ncollection2" not in caplog.text
+    logger.setLevel(logging.DEBUG)
+    with patch(
+        "ansible_rulebook.util.get_installed_collections",
+        return_value="collection1\ncollection2\n",
+    ):
+        startup_logging(logger)
+    assert "collection1\ncollection2" in caplog.text
+
+
+def test_startup_logging_no_collections(caplog):
+    logger = logging.getLogger("test_logger")
+    logger.setLevel(logging.DEBUG)
+    version_output = get_version()
+    with patch(
+        "ansible_rulebook.util.get_installed_collections",
+        return_value=None,
+    ):
+        startup_logging(logger)
+    assert version_output in caplog.text
+    assert "No collections found" in caplog.text


### PR DESCRIPTION
Print relevant versions in logs when ansible-rulebook starts in worker mode. 
- Refactor some helpers and ansible-galaxy path setting for reusability. 
- Enhance get_version function. 
- Collections are printed when debug enabled, regular versions only in info level. 
- e2e and unit tests. 
Jira: [AAP-40781](https://issues.redhat.com/browse/AAP-40781)