### PR TITLE
test: ensure multiprocess tests don't collision ports

### DIFF
--- a/tests/e2e/test_match_multiple_rules.py
+++ b/tests/e2e/test_match_multiple_rules.py
@@ -1,6 +1,7 @@
 """
 Module with tests for websockets
 """
+
 import asyncio
 import logging
 from functools import partial
@@ -26,7 +27,7 @@ async def test_match_multiple_rules():
     host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
-    port = 31415
+    port = utils.get_safe_port()
     rulebook = utils.BASE_DATA_PATH / "rulebooks/test_match_multiple_rules.yml"
     websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(

--- a/tests/e2e/test_non_alpha_keys.py
+++ b/tests/e2e/test_non_alpha_keys.py
@@ -1,6 +1,7 @@
 """
 Module with tests for websockets
 """
+
 import asyncio
 import logging
 from functools import partial
@@ -27,7 +28,7 @@ async def test_non_alpha_numeric_keys():
     host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
-    port = 31415
+    port = utils.get_safe_port()
     rulebook = utils.EXAMPLES_PATH / "82_non_alpha_keys.yml"
     websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(

--- a/tests/e2e/test_run_module_output.py
+++ b/tests/e2e/test_run_module_output.py
@@ -1,6 +1,7 @@
 """
 Module with tests for websockets
 """
+
 import asyncio
 import logging
 from functools import partial
@@ -26,7 +27,7 @@ async def test_run_module_output():
     host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
-    port = 31416
+    port = utils.get_safe_port()
     rulebook = utils.EXAMPLES_PATH / "29_run_module.yml"
     websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(

--- a/tests/e2e/test_skip_audit_events.py
+++ b/tests/e2e/test_skip_audit_events.py
@@ -1,6 +1,7 @@
 """
 Module with tests for websockets
 """
+
 import asyncio
 import logging
 from functools import partial
@@ -26,7 +27,7 @@ async def test_skip_audit_events():
     host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
-    port = 31417
+    port = utils.get_safe_port()
     rulebook = utils.BASE_DATA_PATH / "rulebooks/test_match_multiple_rules.yml"
     websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(

--- a/tests/e2e/test_websocket.py
+++ b/tests/e2e/test_websocket.py
@@ -29,7 +29,7 @@ async def test_websocket_messages(expect_failure):
     host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
-    port = 31415 if expect_failure else 31414
+    port = utils.get_safe_port()
     rulebook = (
         utils.BASE_DATA_PATH / "rulebooks/websockets/test_websocket_range.yml"
     )
@@ -135,7 +135,7 @@ async def test_worker_startup_output(verbosity):
     host = "127.0.0.1"
     endpoint = "/api/ws2"
     proc_id = "42"
-    port = 31420
+    port = utils.get_safe_port()
     websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
     cmd = utils.Command(
         rulebook=None,

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import random
+import socket
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -167,3 +169,18 @@ async def msg_handler(
             else:
                 await websocket.close()  # should be auto reconnected
         i += 1
+
+
+def get_safe_port() -> int:
+    """
+    Returns a port number that is safe to use for testing
+    """
+    for _ in range(100):
+        port = random.randint(20000, 40000)
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("localhost", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("No available port found")


### PR DESCRIPTION
We can have race conditions in some tests when running pytest with xdist (multiprocesses) with errors because the port is already in use. This ensures the port is different by adding the cpu core of the process. 