### PR TITLE
chore: pin to websockets 10.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
 	dpath >= 2.1.4
 	janus
 	ansible-runner
-	websockets == 13.1
+	websockets == 10.4
 	drools_jpy == 0.3.9
 	watchdog
 


### PR DESCRIPTION
Pin to version 10.4 to better align with downstream builds