### PR TITLE
chore: pin ansible-core to 2.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,14 @@ ARG APP_DIR=${APP_DIR:-/app}
 ARG SETUPTOOLS_SCM_PRETEND_VERSION
 ARG DEVEL_COLLECTION_LIBRARY=0
 ARG DEVEL_COLLECTION_REPO=git+https://github.com/ansible/event-driven-ansible.git
+ARG ANSIBLE_CORE_VER=${ANSIBLE_CORE_VER:-2.16}
+ARG PYTHON_VER="3.11"
+ARG PYTHON_BIN="python${PYTHON_VER}"
+ARG PIP_BIN="pip${PYTHON_VER}"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH="$APP_DIR/.local/bin:$PATH"
-ENV PYTHONPATH="$APP_DIR/.local/lib/python3.9/site-packages:$PYTHONPATH"
+ENV PYTHONPATH="$APP_DIR/.local/lib/${PYTHON_BIN}/site-packages:$PYTHONPATH"
 ENV HOME=$APP_DIR
 
 USER 0
@@ -24,14 +28,23 @@ RUN for dir in \
     do mkdir -p $dir ; chown -R "${USER_ID}:0" $dir ; chmod 0775 $dir ; done \
     && useradd --uid "$USER_ID" --gid 0 --home-dir "$APP_DIR" appuser
 
-RUN dnf install -y java-17-openjdk-devel python3-pip postgresql-devel gcc python3-devel git krb5-libs krb5-devel
+RUN dnf install -y \
+    ${PYTHON_BIN} \
+    ${PYTHON_BIN}-devel \
+    ${PYTHON_BIN}-pip \
+    java-17-openjdk-devel \
+    postgresql-devel \
+    gcc \
+    git \
+    krb5-libs \
+    krb5-devel
 
 USER $USER_ID
 WORKDIR $APP_DIR
 COPY --chown=${USER_ID}:0 . $WORKDIR
 
-RUN pip install -U pip \
-    && pip install ansible-core \
+RUN ${PIP_BIN} install -U pip \
+    && pip install ansible-core==${ANSIBLE_CORE_VER} \
     ansible-runner \
     jmespath \
     aiohttp \
@@ -44,4 +57,4 @@ RUN pip install -U pip \
 RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \
     ansible-galaxy collection install ${DEVEL_COLLECTION_REPO} --force; fi"
 
-RUN pip install .[production]
+RUN ${PIP_BIN} install .[production]

--- a/minimal-decision-environment.yml
+++ b/minimal-decision-environment.yml
@@ -19,7 +19,7 @@ dependencies:
     - dpath
     - ansible-rulebook
   ansible_core:
-    package_pip: ansible-core==2.14.4
+    package_pip: ansible-core==2.16
   ansible_runner:
     package_pip: ansible-runner
   system:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,8 @@ docopt
 psutil
 requests
 ansible
-ansible-core
+ansible-core==2.16; python_version >= "3.11"
+ansible-core==2.15; python_version < "3.11"
 ansible-runner
 jmespath
 


### PR DESCRIPTION
In light of upcoming changes in ansible-core, pinning the version to 2.16 while we investigate the impact.

[AAP-43723](https://issues.redhat.com/browse/AAP-43723)

https://github.com/ansible/ansible/pull/84621