### PR TITLE
refactor: improve missing source plugin exception message AAP-42108

### DIFF
--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -21,6 +21,12 @@ import sys
 from typing import List
 
 import ansible_rulebook.util as util
+from ansible_rulebook.exception import (
+    SourceFilterNotFoundException,
+    SourcePluginMainMissingException,
+    SourcePluginNotAsyncioCompatibleException,
+    SourcePluginNotFoundException,
+)
 from ansible_rulebook.messages import DEFAULT_SHUTDOWN_DELAY
 from ansible_rulebook.vault import Vault
 
@@ -353,8 +359,16 @@ def main(args: List[str] = None) -> int:
         asyncio.run(app.run(args))
     except KeyboardInterrupt:
         return 0
+    except (
+        SourcePluginNotFoundException,
+        SourceFilterNotFoundException,
+        SourcePluginMainMissingException,
+        SourcePluginNotAsyncioCompatibleException,
+    ) as err:
+        logger.error("Terminating due to source error: %s", str(err))
+        return 1
     except Exception as err:
-        logger.error("Terminating %s", str(err))
+        logger.error("Terminating: %s", str(err))
         return 1
     finally:
         settings.vault.close()

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -121,9 +121,7 @@ async def start_source(
                 find_source(*split_collection_name(source.source_name))
             )
         else:
-            raise SourcePluginNotFoundException(
-                f"Could not find source plugin for {source.source_name}"
-            )
+            raise SourcePluginNotFoundException(source_name=source.source_name)
 
         source_filters = []
 
@@ -153,8 +151,7 @@ async def start_source(
                 )
             else:
                 raise SourceFilterNotFoundException(
-                    f"Could not find source filter plugin "
-                    f"for {source_filter.filter_name}"
+                    source_filter_name=source_filter.filter_name
                 )
             source_filters.append(
                 (source_filter_module["main"], source_filter.filter_args)
@@ -171,13 +168,13 @@ async def start_source(
             entrypoint = module["main"]
         except KeyError:
             raise SourcePluginMainMissingException(
-                "Entrypoint missing. Source module must have function 'main'."
+                source_name=source.source_name
             )
 
         # NOTE(cutwater): This check may be unnecessary.
         if not asyncio.iscoroutinefunction(entrypoint):
             raise SourcePluginNotAsyncioCompatibleException(
-                "Entrypoint is not a coroutine function."
+                source_name=source.source_name
             )
 
         await entrypoint(fqueue, args)
@@ -213,9 +210,7 @@ async def start_source(
                 f"'{error_msg}'"
             )
         logger.error("Source error: %s", user_msg)
-        shutdown_msg = (
-            f"Shutting down source: {source.source_name} error: {user_msg}"
-        )
+        shutdown_msg = f"Shutting down source: {source.source_name}"
         logger.error(shutdown_msg)
         raise
     finally:

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -88,19 +88,72 @@ class RulebookNotFoundException(Exception):
 
 
 class SourcePluginNotFoundException(Exception):
-    pass
+    """Exception class for source plugin not found."""
+
+    def __init__(
+        self: "SourcePluginNotFoundException",
+        source_name: str,
+        message: str = None,
+    ) -> None:
+        """Class constructor with not found source plugin"""
+        if message is None:
+            message = (
+                f"Could not find source plugin for {source_name}. "
+                f"Please ensure that the appropriate Ansible collection is "
+                f"installed. If you're running from the CLI, you can use "
+                f"the -S option to specify additional source directories."
+            )
+        super().__init__(message)
 
 
 class SourceFilterNotFoundException(Exception):
-    pass
+    """Exception class for source filter not found."""
+
+    def __init__(
+        self: "SourceFilterNotFoundException",
+        source_filter_name: str,
+        message: str = None,
+    ) -> None:
+        """Class constructor with not found source filter"""
+        if message is None:
+            message = (
+                f"Could not find source filter plugin {source_filter_name}"
+            )
+        super().__init__(message)
 
 
 class SourcePluginMainMissingException(Exception):
-    pass
+    """Exception class for plugin main function not found."""
+
+    def __init__(
+        self: "SourcePluginMainMissingException",
+        source_name: str,
+        message: str = None,
+    ) -> None:
+        """Class constructor with not found main function in plugin"""
+        if message is None:
+            message = (
+                f"Entrypoint missing. "
+                f"Source module {source_name} must have function 'main'."
+            )
+        super().__init__(message)
 
 
 class SourcePluginNotAsyncioCompatibleException(Exception):
-    pass
+    """Exception class for plugin not compatible with asyncio functionality"""
+
+    def __init__(
+        self: "SourcePluginNotAsyncioCompatibleException",
+        source_name: str,
+        message: str = None,
+    ) -> None:
+        """Class constructor with plugin not compatible with asyncio"""
+        if message is None:
+            message = (
+                f"Entrypoint from {source_name} is not a coroutine "
+                f"function."
+            )
+        super().__init__(message)
 
 
 class ControllerNeededException(Exception):


### PR DESCRIPTION
subj: https://issues.redhat.com/browse/AAP-42108

This PR improves the missing source plugin error message, by modifying the message that is thrown by SourcePluginNotFoundException. Also, we prevent the error message from being spammed multiple times by ansible_rulebook.engine and ansible_rulebook.app and log the error message just once.

Before:
```
2025-04-28 14:50:35,653 - ansible_rulebook.engine - ERROR - Source error: SourcePluginNotFoundException: Source plugin failed with error message: 'Could not find source plugin for ansible.eda.non_existing_plugin. Please ensure that the appropriate Ansible collection is installed. If you're running from the CLI, you can use the -S option to specify additional source directories.'
2025-04-28 14:50:35,653 - ansible_rulebook.engine - ERROR - Shutting down source: ansible.eda.non_existing_plugin error: SourcePluginNotFoundException: Source plugin failed with error message: 'Could not find source plugin for ansible.eda.non_existing_plugin. Please ensure that the appropriate Ansible collection is installed. If you're running from the CLI, you can use the -S option to specify additional source directories.'
2025-04-28 14:50:35,667 - ansible_rulebook.app - ERROR - SourcePluginNotFoundException: Could not find source plugin for ansible.eda.non_existing_plugin. Please ensure that the appropriate Ansible collection is installed. If you're running from the CLI, you can use the -S option to specify additional source directories.
2025-04-28 14:50:35,667 - ansible_rulebook.app - ERROR - /tmp/venv/lib/python3.13/site-packages/ansible_rulebook/engine.py:124 start_source
2025-04-28 14:50:35,669 - ansible_rulebook.cli - ERROR - Terminating: One of the source plugins failed
```

Now:
```
2025-04-28 15:10:47,581 - ansible_rulebook.engine - ERROR - Source error: SourcePluginNotFoundException: Source plugin failed with error message: 'Could not find source plugin for ansible.eda.non_existing_plugin. Please ensure that the appropriate Ansible collection is installed. If you're running from the CLI, you can use the -S option to specify additional source directories.'
2025-04-28 15:10:47,582 - ansible_rulebook.engine - ERROR - Shutting down source: ansible.eda.non_existing_plugin
2025-04-28 15:10:47,602 - ansible_rulebook.app - ERROR - SourcePluginNotFoundException
2025-04-28 15:10:47,603 - ansible_rulebook.app - ERROR - /tmp/venv/lib/python3.13/site-packages/ansible_rulebook/engine.py:124 start_source
2025-04-28 15:10:47,605 - ansible_rulebook.cli - ERROR - Terminating: One of the source plugins failed
```