### PR TITLE
test: pytest-jira failures due to marshmallow

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,6 +13,7 @@ pytest-timeout
 pytest-xdist
 pytest-cov
 pytest-check
+marshmallow==3.26.1
 pytest-jira
 dynaconf==3.1.11
 freezegun


### PR DESCRIPTION
Pinning the version of marshmallow to account for pytest-jira failure when running tests.

https://github.com/rhevm-qe-automation/pytest_jira/issues/153