### PR TITLE
fix: rollback drools_jpy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Changed
 ### Added
 ### Fixed
-- Fix memory leak with new drools_jpy
 
 
 ## [1.1.5] - 20205-04-11

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
 	janus >=1,<2
 	ansible-runner >=2,<3
 	websockets >=10.4,<12
-	drools_jpy == 0.3.10
+	drools_jpy == 0.3.9
 	watchdog >=3,<7
 	xxhash >=3,<4
     pyyaml >=6,<7


### PR DESCRIPTION
Brew build for drools_jpy is not ready yet, roll back the version