### PR TITLE
fix: bump drools_jpy version to 0.3.10 again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Fixed
 
 
+## [1.1.6] - 20205-04-25
+- Fix memory leak with new drools_jpy
+
+
 ## [1.1.5] - 20205-04-11
 ### Changed
 - Minor refactors

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
 	janus >=1,<2
 	ansible-runner >=2,<3
 	websockets >=10.4,<12
-	drools_jpy == 0.3.9
+	drools_jpy == 0.3.10
 	watchdog >=3,<7
 	xxhash >=3,<4
     pyyaml >=6,<7


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-42623

Update to use the new version of drools_jpy, which contains the memory leak fix.