### PR TITLE
feat: [AAP-45812] Accept ansible tagged dicts in fact cache from ansible-core 2.19

### DIFF
--- a/ansible_rulebook/action/run_playbook.py
+++ b/ansible_rulebook/action/run_playbook.py
@@ -36,7 +36,11 @@ from ansible_rulebook.exception import (
     PlaybookNotFoundException,
     PlaybookStatusNotFoundException,
 )
-from ansible_rulebook.util import create_inventory, run_at
+from ansible_rulebook.util import (
+    convert_ansible_tagged_dict,
+    create_inventory,
+    run_at,
+)
 
 from .control import Control
 from .helper import Helper
@@ -234,6 +238,9 @@ class RunPlaybook:
             for host_facts in glob.glob(os.path.join(fact_folder, "*")):
                 with open(host_facts) as file_handle:
                     fact = json.loads(file_handle.read())
+                    if fact.get("__payload__"):
+                        payload = yaml.safe_load(fact["__payload__"])
+                        fact = convert_ansible_tagged_dict(payload)
                 if self.output_key:
                     if self.output_key not in fact:
                         logger.error(

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@ docopt
 psutil
 requests
 ansible
-ansible-core~=2.16.0; python_version >= "3.11"
+ansible-core~=2.19.0b4; python_version >= "3.11"
 ansible-core~=2.15.0; python_version < "3.11"
 ansible-runner
 jmespath

--- a/tests/playbooks/compare_value.yml
+++ b/tests/playbooks/compare_value.yml
@@ -7,4 +7,4 @@
   ansible.builtin.fail:
     msg: "{{ item.key }} mismatch"
   # since jinja2 doesn't preserve the type we have to do a string comparison
-  when: expected_value != item.value|string
+  when: expected_value != item.value


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-45812

The ansible-core 2.19 adds the data tagging features, which change the fact cache of artifacts into a new format with taggings. Ansible rulebook needs to handle this new format. 