### PR TITLE
fix: gather_facts requires inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for playbook that has set_stats in it
 ### Fixed
 - Fix a bug in the processing of a playbook that has a set_fact in it
+- Fix a bug in gather_facts. It needs inventory, else its ignored
 
 
 ## [1.1.6] - 20205-04-25

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -286,7 +286,13 @@ async def run_rulesets(
     rulesets = {}
     for ruleset, _ in ruleset_queues:
         if ruleset.gather_facts and not hosts_facts:
-            hosts_facts = collect_ansible_facts(inventory)
+            if inventory:
+                hosts_facts = collect_ansible_facts(inventory)
+            else:
+                logger.warning(
+                    "Ignoring gather_facts, since it requires inventory"
+                )
+
         ruleset_names.append(ruleset.name)
         rulesets[ruleset.name] = ruleset
 

--- a/tests/examples/92_gather_facts_sans_inventory.yml
+++ b/tests/examples/92_gather_facts_sans_inventory.yml
@@ -1,0 +1,13 @@
+---
+- name: 92 gather facts sans inventory
+  hosts: all
+  gather_facts: true
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name: r1
+      condition: event.i == 1
+      action:
+        none:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -54,9 +54,16 @@ class SourceTask:
         self.task.cancel()
 
 
+RULEBOOK_NAMES = [
+    ("examples/01_noop.yml"),
+    ("examples/92_gather_facts_sans_inventory.yml"),
+]
+
+
+@pytest.mark.parametrize("rulebook", RULEBOOK_NAMES)
 @pytest.mark.asyncio
-async def test_01_noop():
-    ruleset_queues, event_log = load_rulebook("examples/01_noop.yml")
+async def test_01_noop(rulebook):
+    ruleset_queues, event_log = load_rulebook(rulebook)
 
     queue = ruleset_queues[0][1]
     queue.put_nowait(dict(i=1))


### PR DESCRIPTION
gather_facts requires inventory, when running as CLI it always has inventory but when run as Activation the inventory is missing.

Ignore the gather_facts if no inventory is provided and print a warning message.

https://issues.redhat.com/browse/AAP-47070