### PR TITLE
ci: add stable branches in workflow triggers (#812)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - "main"
+      - "stable*"
   pull_request:
     branches:
       - "main"
+      - "stable*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Backport https://github.com/ansible/ansible-rulebook/pull/812
Stable branches were never part of the workflow triggers but we already require checks for PRs against them. We did not notice it yet because there was always a existing check associated to the revision. Now that we start to do cherry-picking we need to trigger the CI.