### PR TITLE
feat: event splitter filter to support array of events (#820)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ## [Unreleased]
 ### Changed
 ### Added
+- Add support for eda.builtin.event_splitter filter
+### Fixed
+
+
+## [1.1.7] - 2025-06-23
+### Changed
+### Added
 - Add support for playbook that has set_stats in it
 ### Fixed
 - Fix a bug in the processing of a playbook that has a set_fact in it

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -84,10 +84,23 @@ class FilteredQueue:
         self.queue = queue
 
     async def put(self, data):
+        if not isinstance(data, list):
+            data = [data]
+
         for f, kwargs in self.filters:
             kwargs = kwargs or {}
-            data = f(data, **kwargs)
-        await self.queue.put(data)
+            flat_list = []
+            for e in data:
+                result = f(e, **kwargs)
+                if not isinstance(result, list):
+                    result = [result]
+                for r in result:
+                    flat_list.append(r)
+
+            data = flat_list
+
+        for e in data:
+            await self.queue.put(e)
 
     def put_nowait(self, data):
         for f, kwargs in self.filters:

--- a/ansible_rulebook/event_filter/event_splitter.py
+++ b/ansible_rulebook/event_filter/event_splitter.py
@@ -1,0 +1,138 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import copy
+import multiprocessing as mp
+from typing import Any, Optional
+
+import dpath
+
+DOCUMENTATION = r"""
+---
+short_description: Split an event payload to multiple events based on a key
+description: |
+  - An event filter that allows users to split an event payload which has
+    several events bundled inside.
+  - For instance, Prometheus and Big Panda send in a collection of events
+    If we know the key name that stores this array of events we can have
+    the event filter slit the payload into individual events.
+    If the splitter key doesn't exist the payload is left intact
+  - Optionally we can include other attributes from the payload into every
+    event
+  - Optionally we can add additional static data into each event
+options:
+  splitter_key:
+    description:
+      - This mandatory field specifies the key in the payload
+      - that has an array (list) of events
+      - You can use dotted notation to specify the key path.
+      - Example splitter_key: topkey1.key2.key3
+    type: str
+  attributes_key_map:
+    description:
+      - This optional field can be used to augment the event with data
+      - from the parent nodes in the event payload. The map is defined
+      - as a dictionary it contains the attribute name to add in the event and
+      - the value is the key path from the event payload.
+      - You can use dotted notation to specify the key path.
+      - Example
+      -    my_attr: payload.id
+      -    my_zone: payload.zone
+    type: dict
+  extras:
+    description:
+      - This optional field can be used to augment the event with some
+      - static data defined as key:value object
+      - Example
+      -    my_region: us-east
+      -    my_cost_center: us-east
+    type: dict
+  raise_error:
+    description:
+      - This optional field can be used to raise an error and stopping
+      - the rulebook if the splitter_key is missing.
+      - Example
+      -    raise_error: true
+    type: bool
+    default: false
+"""
+
+EXAMPLES = r"""
+- ansible.eda.alertmanager:
+    host: 0.0.0.0
+    port: 5050
+  filters:
+    eda.builtin.event_splitter:
+      splitter_key: incident.alerts
+
+- ansible.eda.alertmanager:
+    host: 0.0.0.0
+    port: 5050
+  filters:
+    eda.builtin.event_splitter:
+      splitter_key: incident.alerts
+      attributes_key_map:
+         id: incident.id
+         active: incident.active
+      extras:
+         region: us-east
+      raise_error: true
+"""
+
+
+def main(
+    event: dict[str, Any],
+    splitter_key: str,
+    attributes_key_map: Optional[dict[str, Any]] = None,
+    extras: Optional[dict[str, Any]] = None,
+    raise_error: bool = False,
+) -> list[dict[str, Any]]:
+    """Split event into an array of events."""
+    logger = mp.get_logger()
+    try:
+        event_array = dpath.get(event, splitter_key, separator=".")
+    except KeyError:
+        if raise_error:
+            logger.error(f"Key {splitter_key} doesn't exist terminating")
+            raise
+        logger.warning(
+            f"Key {splitter_key} doesn't exist leaving event intact"
+        )
+        return [event]
+
+    results = []
+    additional_dict = {}
+
+    if isinstance(attributes_key_map, dict):
+        for key, value in attributes_key_map.items():
+            try:
+                additional_dict[key] = dpath.get(event, value, separator=".")
+            except KeyError:
+                logger.warning(
+                    "Attribute Key Map %s missing, skipping.", value
+                )
+
+    if isinstance(extras, dict):
+        for key, value in extras.items():
+            additional_dict[key] = value
+
+    for item in event_array:
+        single_event = copy.deepcopy(item)
+        if additional_dict:
+            single_event.update(additional_dict)
+        results.append(single_event)
+
+    logger.debug(
+        f"Splitting event payload into {len(results)} individual events"
+    )
+    return results

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -53,6 +53,12 @@ Examples:
 | Keys in the event payload can only contain letters, numbers and underscores.
 | The period (.) is used to access nested keys.
 
+=====================
+Builtin Event Filters
+=====================
+* eda.builtin.insert_meta_info
+* eda.builtin.event_splitter
+
 | Since every event should record the origin of the event we have a filter
 | eda.builtin.insert_meta_info which will be added automatically by
 | ansible-rulebook to add the source name and type and received_at.
@@ -71,5 +77,69 @@ Examples:
 
 | The meta key is used to store metadata about the event and its needed to
 | correctly report about the events in the aap-server.
+
+
+| If the incoming event payload has multiple events wrapped inside we can
+| split the events into individual events using the eda.builtin.event_splitter
+| filter. This is prevalent with Big Panda and Prometheus alerts.
+| The filter takes in 4 parameters
+
+
+.. list-table::
+   :widths: 25 150 10
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Required
+   * - splitter_key
+     - The nested key which stores the array of events. You can use the dot delimiter to specify the path e.g incident.alerts
+     - Yes
+   * - attribute_key_map
+     - If you need to add additional attributes from the parent nodes into the event, specified as a dictionary
+     - No
+   * - extras
+     - If you need to add static attributes into the event, specified as a dictionary
+     - No
+   * - raise_error
+     - true or false. If the splitter_key is missing we can stop the source by setting raise_error as true. Default is false, we would return the event as it is if the splitter_key is missing.
+     - No
+
+
+Examples:
+
+.. code-block:: yaml
+
+  sources:
+    - name: my_prometheus
+      ansible.eda.alertmanager:
+         ...
+      filters:
+        - eda.builtin.event_splitter:
+            splitter_key: alerts 
+            attributes_key_map:
+              header: header
+              hosts: labels.instance 
+            extras:
+              region: us-east  
+
+
+.. code-block:: yaml
+
+
+  sources:
+    - name: my_bigpanda
+      ...big_panda...:
+         ...
+      filters:
+        - eda.builtin.event_splitter:
+            splitter_key: incident.alerts
+            attributes_key_map:
+               id: incident.id
+               active: incident.active
+               severity: incident.severity
+               status: incident.status
+               environments: incident.environments
+
 
 .. _collection: https://github.com/ansible/event-driven-ansible/tree/main/extensions/eda/plugins/event_filter

--- a/tests/event_filter/test_event_splitter.py
+++ b/tests/event_filter/test_event_splitter.py
@@ -1,0 +1,88 @@
+#  Copyright 2025 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import pytest
+
+from ansible_rulebook.event_filter.event_splitter import main as filter_main
+
+EVENT_DATA_1 = [
+    (
+        {"myevent": {"bundle": [{"name": "Fred"}, {"name": "Barney"}]}},
+        {"splitter_key": "myevent.bundle"},
+        [{"name": "Fred"}, {"name": "Barney"}],
+    ),
+    (
+        {"myevent": {"bundle": [{"name": "Fred"}, {"name": "Barney"}]}},
+        {"splitter_key": "myevent.missing"},
+        [{"myevent": {"bundle": [{"name": "Fred"}, {"name": "Barney"}]}}],
+    ),
+    (
+        {
+            "myevent": {
+                "bundle": [{"name": "Fred"}, {"name": "Barney"}],
+                "city": "Bedrock",
+            }
+        },
+        {
+            "splitter_key": "myevent.bundle",
+            "attributes_key_map": {"town": "myevent.city"},
+        },
+        [
+            {"name": "Fred", "town": "Bedrock"},
+            {"name": "Barney", "town": "Bedrock"},
+        ],
+    ),
+    (
+        {
+            "myevent": {
+                "bundle": [{"name": "Fred"}, {"name": "Barney"}],
+                "city": "Bedrock",
+            }
+        },
+        {
+            "splitter_key": "myevent.bundle",
+            "attributes_key_map": {"town": "myevent.city"},
+            "extras": {"zip": "07054"},
+        },
+        [
+            {"name": "Fred", "town": "Bedrock", "zip": "07054"},
+            {"name": "Barney", "town": "Bedrock", "zip": "07054"},
+        ],
+    ),
+    (
+        {
+            "myevent": {
+                "bundle": [{"name": "Fred"}, {"name": "Barney"}],
+                "city": "Bedrock",
+            }
+        },
+        {
+            "splitter_key": "myevent.bundle",
+            "attributes_key_map": {"town": "myevent.village"},
+        },
+        [{"name": "Fred"}, {"name": "Barney"}],
+    ),
+]
+
+
+@pytest.mark.parametrize("data, args, expected", EVENT_DATA_1)
+def test_filter_main(data, args, expected):
+    data = filter_main(data, **args)
+    assert data == expected
+
+
+def test_filter_main_exception():
+    data = ({"myevent": {"bundle": [{"name": "Fred"}, {"name": "Barney"}]}},)
+    args = {"splitter_key": "myevent.missing", "raise_error": True}
+    with pytest.raises(KeyError):
+        filter_main(data, **args)

--- a/tests/examples/93_event_splitter.yml
+++ b/tests/examples/93_event_splitter.yml
@@ -1,0 +1,29 @@
+---
+- name: 93 event splitter
+  hosts: localhost
+  sources:
+    - ansible.eda.generic:
+        payload:
+          - bundle:
+              employer: Slate Rock & Gravel Company
+              owner: George Slate
+              employees:
+                - name: Fred Flintstone
+                  age: 50
+                  profession: Crane Operator
+                - name: Barney Rubble
+                  age: 45
+      filters:
+        - eda.builtin.event_splitter:
+            splitter_key: bundle.employees 
+            attributes_key_map:
+              employer: bundle.employer
+              owner: bundle.owner
+            extras:
+              city: Bedrock
+  rules:
+    - name: r1
+      condition: event.name == "Fred Flintstone" and event.city == "Bedrock" and event.owner == "George Slate" and event.profession == "Crane Operator"
+      action:
+        debug:
+          msg: Found a crane operator

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2609,3 +2609,26 @@ async def test_91_debug_mask_sensitive_variables(caplog):
         assert f"'aap_password': '{MASKED_STRING}'" in caplog.text
         assert f"'postgres_db_password': '{MASKED_STRING}'" in caplog.text
         assert f"'private_key': '{MASKED_STRING}'" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_93_event_splitter():
+    ruleset_queues, event_log = load_rulebook("examples/93_event_splitter.yml")
+
+    queue = ruleset_queues[0][1]
+    rs = ruleset_queues[0][0]
+    with SourceTask(rs.sources[0], "sources", {}, queue):
+        await run_rulesets(
+            event_log,
+            ruleset_queues,
+            {},
+        )
+
+        checks = {
+            "max_events": 2,
+            "shutdown_events": 1,
+            "actions": [
+                "93 event splitter::r1::debug",
+            ],
+        }
+        await validate_events(event_log, **checks)


### PR DESCRIPTION
When we get in an event or get get back data from a filter check if its a list so we can inject them individually into Drools

We have added a new builtin filter called
* eda.builtin.event_splitter

This filter splits an event into an array of events There are 1 required and 3 optional parameters

* splitter_key (Required: string)
* attributes_key_map (Optional: Dictionary)
* extras (Optional: Dictionary)
* raise_error (bool: Optional default false)

e.g.
```
        - eda.builtin.event_splitter:
            splitter_key: bundle.employees
            attributes_key_map:
              employer: bundle.employer
              owner: bundle.owner
            extras:
              city: Bedrock
```

https://issues.redhat.com/browse/AAP-49750

Backport related to PR #820 
https://issues.redhat.com/browse/AAPRFE-1772
https://issues.redhat.com/browse/AAP-49670

One of the main driving forces behind this feature is the multiple events that get bundled in Promethus and Big Panda

For Prometheus we could have the following sources snippet

```
- ansible.eda.alertmanager:
    host: 0.0.0.0
    port: 8000
    filters:
        - eda.builtin.event_splitter:
            splitter_key: alerts
            attributes_key_map:
              header: header
              hosts: labels.instance
```

```
- bigpanda.......:
    host: 0.0.0.0
    port: 8000
    filters:
        - eda.builtin.event_splitter:
            splitter_key: incident.alerts
            attributes_key_map:
                  id: incident.id
                  active: incident.active
                  severity: incident.severity
                  status: incident.status
                  environments: incident.environments
 ```