### PR TITLE
feat: support local filter testing using -F

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 ### Added
 - Add support for eda.builtin.event_splitter filter
+- Add support for -F to specify filter directory for development
 ### Fixed
 
 

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -139,6 +139,7 @@ async def run(parsed_args: argparse.Namespace) -> None:
         startup_args.variables,
         [parsed_args.source_dir],
         parsed_args.shutdown_delay,
+        [parsed_args.filter_dir],
     )
 
     logger.info("Starting rules")
@@ -252,6 +253,7 @@ def spawn_sources(
     variables: Dict[str, Any],
     source_dirs: List[str],
     shutdown_delay: float,
+    filter_dirs: List[str],
 ) -> Tuple[List[asyncio.Task], List[RuleSetQueue]]:
     tasks = []
     ruleset_queues = []
@@ -265,6 +267,7 @@ def spawn_sources(
                     variables,
                     source_queue,
                     shutdown_delay,
+                    filter_dirs,
                 )
             )
             tasks.append(task)

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -94,6 +94,11 @@ def get_parser() -> argparse.ArgumentParser:
         help="Local event source plugins dir for development.",
     )
     parser.add_argument(
+        "-F",
+        "--filter-dir",
+        help="Local event source filters dir for development.",
+    )
+    parser.add_argument(
         "-i",
         "--inventory",
         help="Path to an inventory file, "

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -115,6 +115,7 @@ async def start_source(
     variables: Dict[str, Any],
     queue: asyncio.Queue,
     shutdown_delay: float = 60.0,
+    filter_dirs: Optional[list[str]] = None,
 ) -> None:
     all_source_queues.append(queue)
     try:
@@ -142,7 +143,21 @@ async def start_source(
 
         for source_filter in source.source_filters:
             logger.info("loading source filter %s", source_filter.filter_name)
-            if os.path.exists(
+            if (
+                filter_dirs
+                and filter_dirs[0]
+                and os.path.exists(
+                    os.path.join(
+                        filter_dirs[0], source_filter.filter_name + ".py"
+                    )
+                )
+            ):
+                source_filter_module = runpy.run_path(
+                    os.path.join(
+                        filter_dirs[0], source_filter.filter_name + ".py"
+                    )
+                )
+            elif os.path.exists(
                 os.path.join("event_filter", source_filter.filter_name + ".py")
             ):
                 source_filter_module = runpy.run_path(

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -41,6 +41,10 @@ Examples:
 | Keys in the event payload can only contain letters, numbers and underscores.
 | The period (.) is used to access nested keys.
 
+| When developing new filters you can specify the -F to specify the directory where
+| your filters are located. This wont work when you have a decision environment you would
+| have to distribute the filters via a collection.
+
 =====================
 Builtin Event Filters
 =====================

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,6 +17,7 @@ The `ansible-rulebook` CLI supports the following options:
                         [--shutdown-delay SHUTDOWN_DELAY] [--gc-after GC_AFTER] [--heartbeat HEARTBEAT]
                         [--execution-strategy {sequential,parallel}] [--hot-reload] [--skip-audit-events]
                         [--vault-password-file VAULT_PASSWORD_FILE] [--vault-id VAULT_ID] [--ask-vault-pass]
+                        [-F FILTER_DIR]
 
     optional arguments:
     -h, --help            show this help message and exit
@@ -29,6 +30,8 @@ The `ansible-rulebook` CLI supports the following options:
     --version             Show the version and exit
     -S SOURCE_DIR, --source-dir SOURCE_DIR
                             Local event source plugins dir for development.
+    -F FILTER_DIR, --filter-dir FILTER_DIR
+                            Local event filters dir for development.
     -i INVENTORY, --inventory INVENTORY
                             Path to an inventory file, can also be passed via the env var ANSIBLE_INVENTORY
     -W WEBSOCKET_URL, --websocket-url WEBSOCKET_URL, --websocket-address WEBSOCKET_URL
@@ -99,6 +102,14 @@ If you are using custom event source plugins use the following:
 
 .. note::
     Here `sources` is a directory containing your event source plugins.
+
+.. code-block:: console
+
+    ansible-rulebook --inventory inventory.yml --rulebook rules.yml -S sources/ -F my_filters/
+
+.. note::
+    Here `sources` is a directory containing your event source plugins.
+    `my_filters` is a directory containing your event filters.
 
 To run `ansible-rulebook` with worker mode enabled the `--worker` option can be used. The `--id`, and `--websocket-url` options can also be used to expose the event stream data::
 

--- a/tests/e2e/test_run_examples.py
+++ b/tests/e2e/test_run_examples.py
@@ -61,6 +61,26 @@ TEST_DATA = [
         },
         "93 event splitter",
     ),
+    (
+        {
+            "rules_triggered": 1,
+            "events_processed": 2,
+            "events_matched": 1,
+            "number_of_actions": 1,
+            "number_of_session_stats": 2,
+            "number_of_rules": 1,
+            "number_of_disabled_rules": 0,
+        },
+        utils.EXAMPLES_PATH / "94_local_filter.yml",
+        {
+            "r1": {
+                "action": "debug",
+                "event_key": "m/name",
+                "event_value": "FRED",
+            }
+        },
+        "94 local filter",
+    ),
 ]
 
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -13,6 +13,7 @@ import websockets.asyncio.server as ws_server
 
 BASE_DATA_PATH = Path(f"{__file__}").parent / Path("files")
 DEFAULT_SOURCES = Path(f"{__file__}").parent / Path("../sources")
+DEFAULT_FILTERS = Path(f"{__file__}").parent / Path("../filters")
 EXAMPLES_PATH = Path(f"{__file__}").parent / Path("../examples")
 DEFAULT_INVENTORY = BASE_DATA_PATH / "inventories/default_inventory.yml"
 
@@ -29,6 +30,7 @@ class Command:
     cwd: Path = BASE_DATA_PATH
     inventory: Optional[Path] = DEFAULT_INVENTORY
     sources: Optional[Path] = DEFAULT_SOURCES
+    filters: Optional[Path] = DEFAULT_FILTERS
     vars_file: Optional[Path] = None
     envvars: Optional[str] = None
     proc_id: Union[str, int, None] = None
@@ -68,6 +70,8 @@ class Command:
 
         if self.sources:
             result.extend(["-S", str(self.sources.absolute())])
+        if self.filters:
+            result.extend(["-F", str(self.filters.absolute())])
         if self.vars_file:
             result.extend(["--vars", str(self.vars_file.absolute())])
         if self.envvars:

--- a/tests/examples/94_local_filter.yml
+++ b/tests/examples/94_local_filter.yml
@@ -1,0 +1,19 @@
+---
+- name: 94 local filter
+  hosts: localhost
+  sources:
+    - ansible.eda.generic:
+        payload:
+          - name: Fred
+            age: 50
+            employed: True
+          - name: Barney
+            age: 50
+            employed: True
+      filters:
+        - upcase:
+  rules:
+    - name: r1
+      condition: event.name == "FRED" and event.age == 50 
+      action:
+        debug:

--- a/tests/filters/upcase.py
+++ b/tests/filters/upcase.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+DOCUMENTATION = r"""
+---
+short_description: Change the string values to upper case
+description:
+  - An event filter that convert string values to uppercase.
+    For instance, the value abc becomes ABC
+"""
+
+EXAMPLES = r"""
+- ansible.eda.alertmanager:
+    host: 0.0.0.0
+    port: 5050
+  filters:
+    - upcase:
+"""
+
+
+def main(
+    event: dict[str, Any],
+) -> dict[str, Any]:
+    """Change string values to uppercase."""
+    for key, value in event.items():
+        if isinstance(value, str):
+            event[key] = value.upper()
+    return event

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -112,7 +112,7 @@ def test_load_rulebook_missing():
 async def test_spawn_sources(create_ruleset):
     with mock.patch("ansible_rulebook.app.start_source") as mock_start_source:
         tasks, ruleset_queues = spawn_sources(
-            [create_ruleset()], dict(), ["."], 0.0
+            [create_ruleset()], dict(), ["."], 0.0, list()
         )
         for task in tasks:
             task.cancel()


### PR DESCRIPTION
When developing new filters a user might want to test the filter, they can put their filters in a directory and pass the directory name using -F.
In the rulebook the filter name should only contain the name of file. e.g if the file name is my_filter.py then when using the filter in the rulebook use **my_filter**

```
---
- name: local filter development
  hosts: localhost
  sources:
    - ansible.eda.generic:
        payload:
          - name: Fred
            age: 50
            employed: True
          - name: Barney
            age: 50
            employed: True
      filters:
        - my_filter:
  rules:
    - name: r1
      condition: event.name == "Fred" and event.age == 50
      action:
        debug:
```
https://issues.redhat.com/browse/AAPRFE-770
https://issues.redhat.com/browse/AAP-50392