### PR TITLE
fix: upgrade to newer drools which fixes memory leak

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
 	janus >=1,<2
 	ansible-runner >=2,<3
         websockets >=15,<15.1
-	drools_jpy == 0.3.10
+	drools_jpy == 0.3.12
 	watchdog >=3,<7
 	xxhash >=3,<4
     pyyaml >=6,<7


### PR DESCRIPTION
There was a memory leak in Drools ansible integration, the newer version of drools_jpy fixes that issue.
Upgrading to drools_jpy 0.3.12
https://issues.redhat.com/browse/AAP-46573