### PR TITLE
feat: support for accumulate_within and threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Add support for eda.builtin.event_splitter filter
 - Add support for -F to specify filter directory for development
+- Add support for accumulate_within and threshold
 ### Fixed
 
 

--- a/ansible_rulebook/json_generator.py
+++ b/ansible_rulebook/json_generator.py
@@ -244,6 +244,9 @@ def visit_throttle(parsed_throttle: Throttle, variables: Dict):
         throttle["once_within"] = parsed_throttle.once_within
     elif parsed_throttle.once_after:
         throttle["once_after"] = parsed_throttle.once_after
+    elif parsed_throttle.accumulate_within:
+        throttle["accumulate_within"] = parsed_throttle.accumulate_within
+        throttle["threshold"] = parsed_throttle.threshold
 
     return {"throttle": throttle}
 

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -58,6 +58,8 @@ class Throttle(NamedTuple):
     group_by_attributes: List[str]
     once_within: Optional[str] = None
     once_after: Optional[str] = None
+    accumulate_within: Optional[str] = None
+    threshold: Optional[int] = None
 
 
 class Rule(NamedTuple):

--- a/ansible_rulebook/rules_parser.py
+++ b/ansible_rulebook/rules_parser.py
@@ -148,6 +148,10 @@ def parse_rules(rules: Dict, variables: Dict) -> List[rt.Rule]:
                 once_within=rule["throttle"].get("once_within", None),
                 once_after=rule["throttle"].get("once_after", None),
                 group_by_attributes=rule["throttle"]["group_by_attributes"],
+                accumulate_within=rule["throttle"].get(
+                    "accumulate_within", None
+                ),
+                threshold=rule["throttle"].get("threshold", None),
             )
         else:
             throttle = None

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -101,6 +101,13 @@
                         "once_after",
                         "group_by_attributes"
                     ]
+                },
+                {
+                    "required": [
+                        "accumulate_within",
+                        "threshold",
+                        "group_by_attributes"
+                    ]
                 }
             ],
             "properties": {
@@ -111,6 +118,14 @@
                 "once_after": {
                     "type": "string",
                     "pattern": "^\\d+\\s(milliseconds?|seconds?|minutes?|hours?|days?)$"
+                },
+                "accumulate_within": {
+                    "type": "string",
+                    "pattern": "^\\d+\\s(milliseconds?|seconds?|minutes?|hours?|days?)$"
+                },
+                "threshold": {
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "group_by_attributes": {
                     "type": "array",

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -709,6 +709,45 @@ Throttle actions to counter event storms: Passive
 | When evaluating a single event you can compare multiple
 | properties/attributes from the event using **and** or **or**
 
+Throttle actions till a specific number of events has been received
+-------------------------------------------------------------------
+
+    .. code-block:: yaml
+
+        name: Throttle with threshold
+        condition: event.code == "warning"
+        throttle:
+           accumulate_within: 5 minutes
+           threshold: 10
+           group_by_attributes:
+              - event.meta.hosts
+              - event.code
+        action:
+          run_playbook:
+            name: notify_outage.yml
+
+| This will collect events in a time window and as soon as threshold
+| is reached it will trigger the action. If we don't get enough events inside
+| of the time window the events are discarded. In the above example we are expecting
+| to get a minimum of 10 events within a 5 minute time window. If the 10 events arrive
+| within 2 minutes we will trigger the rule right away since the threshold has been met.
+| In the above example if we got only 7 events in the 5 minute window all the events will be
+| discarded since the threshold is 10.
+| The **group_by_attributes** in the throttle node allows you to specify an array of
+| attributes in the event payload which create unique event pairs. In the above example
+| we are using event.meta.hosts and event.code. If we get 2 separate events, one that had
+| event.code=warning and another one with event.code=error, they would be treated as distinct
+| events and would result in matching multiple events when the action is triggered.
+| Its mandatory to have group_by_attributes specified when using the accumulate_within option.
+| One of the advantages of the **accumulate_within** is that you can collect all the
+| unique events that match the condition and trigger a single action based on multiple
+| matching events.
+| The timeout units are **milliseconds**, **seconds**, **minutes**, **hours**, **days**.
+| The accumulate_within will only work with a single condition and doesn't support multiple conditions.
+
+| When evaluating a single event you can compare multiple
+| properties/attributes from the event using **and** or **or**
+
 String search
 -------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
 	janus >=1,<2
 	ansible-runner >=2,<3
         websockets >=15,<15.1
-	drools_jpy == 0.3.12
+	drools_jpy == 0.3.13
 	watchdog >=3,<7
 	xxhash >=3,<4
     pyyaml >=6,<7

--- a/tests/e2e/test_run_examples.py
+++ b/tests/e2e/test_run_examples.py
@@ -81,6 +81,26 @@ TEST_DATA = [
         },
         "94 local filter",
     ),
+    (
+        {
+            "rules_triggered": 1,
+            "events_processed": 6,
+            "events_matched": 1,
+            "number_of_actions": 1,
+            "number_of_session_stats": 2,
+            "number_of_rules": 1,
+            "number_of_disabled_rules": 0,
+        },
+        utils.EXAMPLES_PATH / "95_accumulate_within.yml",
+        {
+            "r1": {
+                "action": "debug",
+                "event_key": "m/level",
+                "event_value": "error",
+            }
+        },
+        "95 accumulate within",
+    ),
 ]
 
 

--- a/tests/examples/95_accumulate_within.yml
+++ b/tests/examples/95_accumulate_within.yml
@@ -1,0 +1,29 @@
+---
+- name: 95 accumulate within
+  hosts: localhost
+  sources:
+    - name: Test
+      ansible.eda.generic:
+        payload:
+          - name: alert1
+            level: error
+            code: 205
+          - name: alert2
+            level: warning
+            code: 207
+          - name: alert3
+            level: error
+            code: 205
+        event_delay: 1
+        loop_count: 2
+  rules:
+    - name: r1
+      condition: event.level == 'error'
+      throttle:
+          accumulate_within: 1 minutes
+          threshold: 3
+          group_by_attributes:
+             - event.level
+             - event.code
+      action:
+        debug:


### PR DESCRIPTION
This feature allows to throttle events till a specific number of events have been received.

https://issues.redhat.com/browse/AAPRFE-1263
https://issues.redhat.com/browse/AAP-51102

- accumulate_within
- threshold
Are the new optional parameters in a throttle node

```
rules:
    - name: r1
      condition: event.level == 'error'
      throttle:
          accumulate_within: 1 minutes
          threshold: 3
          group_by_attributes:
             - event.level
             - event.code
      action:
        debug:
```