### PR TITLE
fix: race condition on exit while sending stats

### DIFF
--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -317,15 +317,16 @@ def run_at() -> str:
 
 
 async def send_session_stats(event_log: asyncio.Queue, stats: Dict):
-    await event_log.put(
-        dict(
-            type="SessionStats",
-            activation_id=settings.identifier,
-            activation_instance_id=settings.identifier,
-            stats=stats,
-            reported_at=run_at(),
+    if stats:
+        await event_log.put(
+            dict(
+                type="SessionStats",
+                activation_id=settings.identifier,
+                activation_instance_id=settings.identifier,
+                stats=stats,
+                reported_at=run_at(),
+            )
         )
-    )
 
 
 def create_inventory(runner_inventory_dir: str, inventory: str) -> str:


### PR DESCRIPTION
When the program is exiting in certain situations if the heartbeat task wakes up it will send an empty stats. By that point we have cleared the session stats in Drools.

https://github.com/ansible/ansible-rulebook/actions/runs/16843556694/job/47720246863?pr=826