### PR TITLE
feat: add lock support for certain actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for eda.builtin.event_splitter filter
 - Add support for -F to specify filter directory for development
 - Add support for accumulate_within and threshold
+- Optionally support lock for job_template, workflow template, playbook, module actions
 ### Fixed
 
 

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -363,6 +363,9 @@
                         },
                         "extra_vars": {
                             "type": "object"
+                        },
+                        "lock": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -420,6 +423,9 @@
                         },
                         "extra_vars": {
                             "type": "object"
+                        },
+                        "lock": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -472,6 +478,9 @@
                         "include_events": {
                             "type": "boolean",
                             "default": true
+                        },
+                        "lock": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -525,6 +534,9 @@
                         "include_events": {
                             "type": "boolean",
                             "default": true
+                        },
+                        "lock": {
+                            "type": "string"
                         }
                     },
                     "required": [

--- a/tests/examples/96_job_template_with_lock.yml
+++ b/tests/examples/96_job_template_with_lock.yml
@@ -1,0 +1,61 @@
+---
+- name: 96 job template with lock
+  hosts: all
+  execution_strategy: parallel
+  sources:
+    - ansible.eda.generic:
+        shutdown_delay: 20
+        create_index: index
+        payload:
+          - lock_name: "{{ lock1 }}"
+            trigger: true
+            job_template_name: "{{ jt1 }}"
+            test_id: one
+          - lock_name: "{{ lock2 }}"
+            trigger: true
+            job_template_name: "{{ jt2 }}"
+            test_id: two
+          - lock_name: "{{ lock3 }}"
+            trigger: true
+            job_template_name: "{{ jt3 }}"
+            test_id: three
+  rules:
+    - name: "Run job template 1"
+      condition: event.test_id == "one"
+      action:
+        run_job_template:
+          name: "{{ event.job_template_name }}"
+          organization: Default
+          job_args:
+            extra_vars:
+              hello: Fred
+          retries: 1
+          delay: 10
+          set_facts: True
+          lock: "{{ event.lock_name }}"
+    - name: "Run job template 2"
+      condition: event.test_id == "two"
+      action:
+        run_job_template:
+          name: "{{ event.job_template_name }}"
+          organization: Default
+          job_args:
+            extra_vars:
+              hello: Fred
+          retries: 1
+          delay: 10
+          set_facts: True
+          lock: "{{ event.lock_name }}"
+    - name: "Run job template 3"
+      condition: event.test_id == "three"
+      action:
+        run_job_template:
+          name: "{{ event.job_template_name }}"
+          organization: Default
+          job_args:
+            extra_vars:
+              hello: Fred
+          retries: 1
+          delay: 10
+          set_facts: True
+          lock: "{{ event.lock_name }}"


### PR DESCRIPTION
When running the rulebook with the execution strategy set to parallel you can optionally specify a lock field to ensure sequential execution of a specific action.
The lock is currently supported for
* run_playbook
* run_module
* run_job_template
* run_workflow_template

There is no e2e test for this we will be adding an ATF test for this since it would be tested against the controller in the ATF.

https://issues.redhat.com/browse/AAP-51458
