### PR TITLE
feat: labels can be optionally added to controller actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add support for -F to specify filter directory for development
 - Add support for accumulate_within and threshold
 - Optionally support lock for job_template, workflow template, playbook, module actions
+- Add support for labels in run_job_template and run_workflow_template
 ### Fixed
 
 

--- a/ansible_rulebook/action/run_job_template.py
+++ b/ansible_rulebook/action/run_job_template.py
@@ -99,6 +99,7 @@ class RunJobTemplate:
                     self.name,
                     self.organization,
                     self.job_args,
+                    self.action_args.get("labels"),
                 )
                 if controller_job["status"] != "failed":
                     break

--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -100,6 +100,7 @@ class RunWorkflowTemplate:
                         self.name,
                         self.organization,
                         self.job_args,
+                        self.action_args.get("labels"),
                     )
                 )
                 if controller_job["status"] != "failed":

--- a/ansible_rulebook/conf.py
+++ b/ansible_rulebook/conf.py
@@ -17,6 +17,8 @@ import uuid
 
 from ansible_rulebook.vault import Vault
 
+DEFAULT_EDA_LABEL = "Activated by Event-Driven Ansible"
+
 
 class _Settings:
     def __init__(self):
@@ -33,6 +35,7 @@ class _Settings:
         self.skip_audit_events = False
         self.vault = Vault()
         self.ansible_galaxy_path = shutil.which("ansible-galaxy")
+        self.eda_labels = [DEFAULT_EDA_LABEL]
 
 
 settings = _Settings()

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -206,3 +206,7 @@ class AnsibleVaultNotFound(Exception):
 
 class InvalidUrlException(Exception):
     pass
+
+
+class ControllerObjectCreateException(Exception):
+    pass

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -481,6 +481,12 @@
                         },
                         "lock": {
                             "type": "string"
+                        },
+                        "labels": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     },
                     "required": [
@@ -537,6 +543,12 @@
                         },
                         "lock": {
                             "type": "string"
+                        },
+                        "labels": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     },
                     "required": [

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -122,6 +122,9 @@ Run an Ansible module
    * - lock
      - An optional string based lock ensures sequential execution of this action when execution strategy is set to parallel. It can also be a string field from the event payload. The locks are per ruleset, if a lock is in place all actions that use the same lock will wait till the earlier action has completed.
      - No
+   * - labels
+     - Optional list of strings as labels, which can be added to the job in the controller. Requires that Prompt on launch for Labels is enabled. If its not enabled the labels are ignored. ansible-rulebook will add a default label called "Activated by Event-Driven Ansible"
+     - No
 
 run_job_template
 ****************
@@ -186,6 +189,9 @@ Run a job template.
      - No
    * - lock
      - An optional string based lock ensures sequential execution of this action when execution strategy is set to parallel. It can also be a string field from the event payload. The locks are per ruleset, if a lock is in place all actions that use the same lock will wait till the earlier action has completed.
+     - No
+   * - labels
+     - Optional list of strings as labels, which can be added to the job in the controller. Requires that Prompt on launch for Labels is enabled. If its not enabled the labels are ignored. ansible-rulebook will add a default label called "Activated by Event-Driven Ansible"
      - No
 
 run_workflow_template

--- a/tests/data/awx_test_data.py
+++ b/tests/data/awx_test_data.py
@@ -1,27 +1,54 @@
+from urllib.parse import urlencode
+
+from ansible_rulebook.conf import DEFAULT_EDA_LABEL
+
 UNIFIED_JOB_TEMPLATE_COUNT = 2
 ORGANIZATION_NAME = "Default"
 JOB_TEMPLATE_NAME_1 = "JT1"
 JOB_TEMPLATE_1_LAUNCH_SLUG = "api/v2/job_templates/255/launch/"
 JOB_TEMPLATE_2_LAUNCH_SLUG = "api/v2/workflow_job_templates/300/launch/"
 
-JOB_TEMPLATE_1 = dict(
-    type="job_template",
-    name=JOB_TEMPLATE_NAME_1,
-    ask_limit_on_launch=False,
-    ask_variables_on_launch=False,
-    ask_inventory_on_launch=False,
-    related=dict(launch=JOB_TEMPLATE_1_LAUNCH_SLUG),
-    summary_fields=dict(organization=dict(name=ORGANIZATION_NAME)),
-)
+JOB_TEMPLATE_1 = {
+    "type": "job_template",
+    "name": JOB_TEMPLATE_NAME_1,
+    "ask_limit_on_launch": False,
+    "ask_variables_on_launch": False,
+    "ask_inventory_on_launch": False,
+    "ask_labels_on_launch": True,
+    "related": {"launch": JOB_TEMPLATE_1_LAUNCH_SLUG},
+    "summary_fields": {"organization": {"name": ORGANIZATION_NAME}},
+}
 
-JOB_TEMPLATE_2 = dict(
-    type="workflow_job_template",
-    name=JOB_TEMPLATE_NAME_1,
-    ask_limit_on_launch=False,
-    ask_variables_on_launch=False,
-    ask_inventory_on_launch=False,
-    related=dict(launch=JOB_TEMPLATE_2_LAUNCH_SLUG),
-)
+JOB_TEMPLATE_1_NO_LABELS = {
+    "type": "job_template",
+    "name": JOB_TEMPLATE_NAME_1,
+    "ask_limit_on_launch": False,
+    "ask_variables_on_launch": False,
+    "ask_inventory_on_launch": False,
+    "ask_labels_on_launch": False,
+    "related": {"launch": JOB_TEMPLATE_1_LAUNCH_SLUG},
+    "summary_fields": {"organization": {"name": ORGANIZATION_NAME}},
+}
+
+JOB_TEMPLATE_2 = {
+    "type": "workflow_job_template",
+    "name": JOB_TEMPLATE_NAME_1,
+    "ask_limit_on_launch": False,
+    "ask_variables_on_launch": False,
+    "ask_inventory_on_launch": True,
+    "ask_labels_on_launch": True,
+    "related": {"launch": JOB_TEMPLATE_2_LAUNCH_SLUG},
+}
+
+JOB_TEMPLATE_2_NO_LABELS = {
+    "type": "workflow_job_template",
+    "name": JOB_TEMPLATE_NAME_1,
+    "ask_limit_on_launch": False,
+    "ask_variables_on_launch": False,
+    "ask_inventory_on_launch": True,
+    "ask_labels_on_launch": False,
+    "related": {"launch": JOB_TEMPLATE_2_LAUNCH_SLUG},
+}
 
 UNIFIED_JOB_TEMPLATE_PAGE1_SLUG = (
     f"api/v2/unified_job_templates/?name={JOB_TEMPLATE_NAME_1}"
@@ -29,26 +56,40 @@ UNIFIED_JOB_TEMPLATE_PAGE1_SLUG = (
 UNIFIED_JOB_TEMPLATE_PAGE2_SLUG = (
     f"api/v2/unified_job_templates/?name={JOB_TEMPLATE_NAME_1}&page=2"
 )
-UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE = dict(
-    count=UNIFIED_JOB_TEMPLATE_COUNT,
-    next=UNIFIED_JOB_TEMPLATE_PAGE2_SLUG,
-    previous=None,
-    results=[JOB_TEMPLATE_1],
-)
+UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE = {
+    "count": UNIFIED_JOB_TEMPLATE_COUNT,
+    "next": UNIFIED_JOB_TEMPLATE_PAGE2_SLUG,
+    "previous": None,
+    "results": [JOB_TEMPLATE_1],
+}
 
-NO_JOB_TEMPLATE_PAGE1_RESPONSE = dict(
-    count=0,
-    next=None,
-    previous=None,
-    results=[],
-)
+UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE_NO_LABELS = {
+    "count": UNIFIED_JOB_TEMPLATE_COUNT,
+    "next": UNIFIED_JOB_TEMPLATE_PAGE2_SLUG,
+    "previous": None,
+    "results": [JOB_TEMPLATE_1_NO_LABELS],
+}
 
-UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE = dict(
-    count=UNIFIED_JOB_TEMPLATE_COUNT,
-    previous=UNIFIED_JOB_TEMPLATE_PAGE1_SLUG,
-    next=None,
-    results=[JOB_TEMPLATE_2],
-)
+NO_JOB_TEMPLATE_PAGE1_RESPONSE = {
+    "count": 0,
+    "next": None,
+    "previous": None,
+    "results": [],
+}
+
+UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE = {
+    "count": UNIFIED_JOB_TEMPLATE_COUNT,
+    "previous": UNIFIED_JOB_TEMPLATE_PAGE1_SLUG,
+    "next": None,
+    "results": [JOB_TEMPLATE_2],
+}
+
+UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE_NO_LABELS = {
+    "count": UNIFIED_JOB_TEMPLATE_COUNT,
+    "previous": UNIFIED_JOB_TEMPLATE_PAGE1_SLUG,
+    "next": None,
+    "results": [JOB_TEMPLATE_2_NO_LABELS],
+}
 
 JOB_STATUS_RUNNING = "running"
 JOB_STATUS_FAILED = "failed"
@@ -59,12 +100,13 @@ JOB_ARTIFACTS = {
 }
 JOB_ID_1 = 909
 JOB_1_SLUG = f"api/v2/jobs/{JOB_ID_1}/"
-JOB_TEMPLATE_POST_RESPONSE = dict(
-    job=JOB_ID_1,
-    url=JOB_1_SLUG,
-    status=JOB_STATUS_SUCCESSFUL,
-    artifacts=JOB_ARTIFACTS,
-)
+JOB_TEMPLATE_POST_RESPONSE = {
+    "job": JOB_ID_1,
+    "url": JOB_1_SLUG,
+    "status": JOB_STATUS_SUCCESSFUL,
+    "artifacts": JOB_ARTIFACTS,
+}
+
 JOB_1_RUNNING = dict(
     job=JOB_ID_1,
     url=JOB_1_SLUG,
@@ -77,3 +119,41 @@ JOB_1_SUCCESSFUL = dict(
     status=JOB_STATUS_SUCCESSFUL,
     artifacts=JOB_ARTIFACTS,
 )
+
+ORGANIZATION_SLUG = f"api/v2/organizations/?name={ORGANIZATION_NAME}"
+
+ORGANIZATION_DATA = {"id": 1, "name": ORGANIZATION_NAME}
+
+ORGANIZATION_RESPONSE = {
+    "count": 1,
+    "next": None,
+    "results": [ORGANIZATION_DATA],
+}
+
+LABEL_QUERY_PARAMS = {"name": DEFAULT_EDA_LABEL}
+DEFAULT_LABEL_SLUG = f"api/v2/labels/?{urlencode(LABEL_QUERY_PARAMS)}"
+DEFAULT_LABEL_DATA = {"id": 1, "name": DEFAULT_EDA_LABEL}
+
+DEFAULT_LABEL_RESPONSE = {
+    "count": 1,
+    "next": "None",
+    "results": [DEFAULT_LABEL_DATA],
+}
+
+LABEL_POST_SLUG = "api/v2/labels/"
+CUSTOMER_LABEL = "This is for Slate&Rock \nCompany"
+CUSTOMER_LABEL_QUERY_PARAMS = {"name": CUSTOMER_LABEL}
+CUSTOMER_LABEL_SLUG = (
+    f"api/v2/labels/?{urlencode(CUSTOMER_LABEL_QUERY_PARAMS)}"
+)
+
+NO_SUCH_LABEL = NO_JOB_TEMPLATE_PAGE1_RESPONSE
+NO_SUCH_ORGANIZATION = NO_JOB_TEMPLATE_PAGE1_RESPONSE
+
+CUSTOMER_LABEL_DATA = {"id": 2, "name": CUSTOMER_LABEL}
+
+CUSTOMER_LABEL_RESPONSE = {
+    "count": 1,
+    "next": None,
+    "results": [CUSTOMER_LABEL_DATA],
+}

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2711,7 +2711,7 @@ async def test_96_job_template_with_lock(response, my_vars, expected_order):
 
     order_of_templates = []
 
-    async def dummy_template_runner(arg1, arg2, arg3):
+    async def dummy_template_runner(arg1, arg2, arg3, arg4):
         order_of_templates.append(arg1)
         if arg1 in response:
             obj = response[arg1]

--- a/tests/unit/action/test_run_job_template.py
+++ b/tests/unit/action/test_run_job_template.py
@@ -98,6 +98,7 @@ async def test_run_job_template_exception(err_msg, err):
         "retries": 0,
         "retry": True,
         "delay": 0,
+        "labels": ["Slate Rock Company"],
     }
     with patch(
         "ansible_rulebook.action.run_job_template."


### PR DESCRIPTION
If Labels in Job Template/Workflow Template have Prompt on launch enabled a customer can add labels to the jobs they run.

The following actions support labels

 * run_job_template
 * run_workflow_template

By default ansible-rulebook uses a label called
"Activated by Event-Driven Ansible"

https://issues.redhat.com/browse/AAP-51460

<img width="472" height="89" alt="Screenshot 2025-08-14 at 11 15 17 AM" src="https://github.com/user-attachments/assets/cd45b9b7-6d89-4787-8d85-3661d031b47c" />

<img width="1375" height="773" alt="Screenshot 2025-08-14 at 10 53 13 AM" src="https://github.com/user-attachments/assets/3ef016d0-8063-4389-b052-0b25dade5215" />
