### PR TITLE
fix: skip labels if empty string or None (#832)

### DIFF
--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -353,8 +353,13 @@ class JobTemplateRunner:
 
         all_labels = settings.eda_labels
         if labels:
-            all_labels = settings.eda_labels + labels
-        for label in all_labels:
+            # Drop any empty strings or non str objects
+            all_labels = settings.eda_labels + list(
+                filter(lambda s: isinstance(s, str) and s != "", labels)
+            )
+
+        # Drop duplicates if any from the label list
+        for label in set(all_labels):
             label_obj = await self._get_or_create_label(
                 label, organization_obj
             )
@@ -375,7 +380,6 @@ class JobTemplateRunner:
         ask_labels_on_launch: bool,
         labels: Optional[list[str]],
     ) -> list[int]:
-
         if ask_labels_on_launch:
             return await self._get_label_ids_from_names(organization, labels)
 

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -191,7 +191,7 @@ Run a job template.
      - An optional string based lock ensures sequential execution of this action when execution strategy is set to parallel. It can also be a string field from the event payload. The locks are per ruleset, if a lock is in place all actions that use the same lock will wait till the earlier action has completed.
      - No
    * - labels
-     - Optional list of strings as labels, which can be added to the job in the controller. Requires that Prompt on launch for Labels is enabled. If its not enabled the labels are ignored. ansible-rulebook will add a default label called "Activated by Event-Driven Ansible"
+     - Optional list of strings as labels, which can be added to the job in the controller. Requires that Prompt on launch for Labels is enabled. If its not enabled the labels are ignored. ansible-rulebook will add a default label called "Activated by Event-Driven Ansible". If the label gets resolved as None or an empty string it will be dropped. If there are duplicate labels the duplicate ones will be removed. e.g {{ event.payload.my_label | default(None) }} if the attribute doesn't exist we will skip the label.
      - No
 
 run_workflow_template
@@ -255,7 +255,9 @@ Run a workflow template.
    * - lock
      - An optional string based lock ensures sequential execution of this action when execution strategy is set to parallel. It can also be a string field from the event payload. The locks are per ruleset, if a lock is in place all actions that use the same lock will wait till the earlier action has completed.
      - No
-
+   * - labels
+     - Optional list of strings as labels, which can be added to the job in the controller. Requires that Prompt on launch for Labels is enabled. If its not enabled the labels are ignored. ansible-rulebook will add a default label called "Activated by Event-Driven Ansible". If the label gets resolved as None or an empty string it will be dropped. If there are duplicate labels the duplicate ones will be removed. e.g {{ event.payload.my_label | default(None) }} if the attribute doesn't exist we will skip the label.
+     - No
 post_event
 **********
 .. list-table::  Post an event to a running rule set in the rules engine

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -188,7 +188,7 @@ def add_job_templates_pages(mocked, host, page1, page2):
             {},
         ),
         (
-            [CUSTOMER_LABEL],
+            [CUSTOMER_LABEL, "", None, "", {"a": 1}, [CUSTOMER_LABEL]],
             UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE,
             UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE,
             False,


### PR DESCRIPTION
If the labels are resolved to be empty or None they will be skipped. Also if there are duplicate labels only one of them will be added.

https://issues.redhat.com/browse/AAP-52204