### PR TITLE
Revert "chore: pin minor version of aiohttp (#723)"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.9
 install_requires =
-	aiohttp >=3,<3.11
+	aiohttp >=3,<4
 	pyparsing >= 3.0,<4
 	jsonschema >=4,<5
 	jinja2 >=3,<4


### PR DESCRIPTION
Hopefully the incompatibility should be fixed, let's try to loosen the requirement to allow any new 3.x version..

This reverts commit 1c0b1c87ca9ef7ce6e870d4842737406e07f7be9.