### PR TITLE
fix: re-raise CancelledError after cleanup in async runner

### DIFF
--- a/ansible_rulebook/action/runner.py
+++ b/ansible_rulebook/action/runner.py
@@ -104,6 +104,7 @@ class Runner:
                     await self.helper.send_status(val)
             except CancelledError:
                 logger.debug("Ansible runner Queue task cancelled")
+                raise
 
         def cancel_callback():
             return shutdown


### PR DESCRIPTION
Properly re-raise asyncio.CancelledError exception after logging in the read_queue() function to ensure correct task cancellation behavior and prevent hanging during shutdown.

Fixes SonarCloud issue AZd-jv35ZcQ1ovptJ4Sb (python:S7497)

🤖 Generated with [Claude Code](https://claude.ai/code)