### PR TITLE
feat: bool filter for parity with ansible core filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 
 # Changelog
+## [1.3.1]
+### Changed
+### Added
+- New jinja filters in actions: `bool`
+### Fixed
 
 ## [1.3.0]
 ### Changed

--- a/ansible_rulebook/jinja/__init__.py
+++ b/ansible_rulebook/jinja/__init__.py
@@ -13,13 +13,21 @@
 #  limitations under the License.
 from typing import Any, List
 
-from .filters import FILTERS, basename, dirname, normpath, regex_replace
+from .filters import (
+    FILTERS,
+    basename,
+    bool_filter,
+    dirname,
+    normpath,
+    regex_replace,
+)
 
 __all__: List[str] = [
     "regex_replace",
     "basename",
     "dirname",
     "normpath",
+    "bool_filter",
     "FILTERS",
     "register_filters",
 ]

--- a/ansible_rulebook/jinja/filters.py
+++ b/ansible_rulebook/jinja/filters.py
@@ -11,9 +11,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from __future__ import annotations
+
 import os
 import re
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 
 def regex_replace(
@@ -97,9 +99,45 @@ def normpath(
     return os.path.normpath(value)
 
 
-FILTERS: Dict[str, Callable[..., str]] = {
+def bool_filter(
+    value: Any,
+) -> bool:
+    """
+    Convert a string to a boolean value.
+
+    Returns True for: 'true', 'yes', '1', 'on', 't', 'y'
+        (case-insensitive)
+    Returns False for: 'false', 'no', '0', 'off', 'f', 'n', ''
+        (case-insensitive)
+    For other types, returns the Python bool() evaluation.
+    """
+    if value is None:
+        return False
+
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, str):
+        lower_value = value.lower().strip()
+        if lower_value in ("true", "yes", "1", "on", "t", "y"):
+            return True
+        elif lower_value in ("false", "no", "0", "off", "f", "n", ""):
+            return False
+        else:
+            # For any other string, raise an error for clarity
+            raise ValueError(
+                f"Cannot convert '{value}' to boolean. "
+                "Expected: true/false, yes/no, 1/0, on/off, t/f, y/n"
+            )
+
+    # For other types (int, list, etc.), use Python's bool()
+    return bool(value)
+
+
+FILTERS: dict[str, Callable[..., str | bool]] = {
     "regex_replace": regex_replace,
     "basename": basename,
     "dirname": dirname,
     "normpath": normpath,
+    "bool": bool_filter,
 }

--- a/tests/jinja/test_filters.py
+++ b/tests/jinja/test_filters.py
@@ -1,8 +1,10 @@
 import pytest
 from jinja2 import Environment
+from jinja2.nativetypes import NativeEnvironment
 
 from ansible_rulebook.jinja import (
     basename,
+    bool_filter,
     dirname,
     normpath,
     regex_replace,
@@ -184,3 +186,183 @@ def test_dirname(value, expected):
 )
 def test_normpath(value, expected):
     assert normpath(value) == expected
+
+
+# Tests for bool_filter
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # String values - truthy
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("Yes", True),
+        ("YES", True),
+        ("1", True),
+        ("on", True),
+        ("On", True),
+        ("ON", True),
+        # Single-character truthy values
+        ("t", True),
+        ("T", True),
+        ("y", True),
+        ("Y", True),
+        # String values - falsy
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        ("no", False),
+        ("No", False),
+        ("NO", False),
+        ("0", False),
+        ("off", False),
+        ("Off", False),
+        ("OFF", False),
+        ("", False),
+        # Single-character falsy values
+        ("f", False),
+        ("F", False),
+        ("n", False),
+        ("N", False),
+        # String values with whitespace
+        ("  true  ", True),
+        ("  false  ", False),
+        ("  yes  ", True),
+        ("  no  ", False),
+        ("  t  ", True),
+        ("  f  ", False),
+        ("  y  ", True),
+        ("  n  ", False),
+        # Boolean values
+        (True, True),
+        (False, False),
+        # None
+        (None, False),
+        # Other types
+        (1, True),
+        (0, False),
+        ([], False),
+        ([1, 2], True),
+        ({}, False),
+        ({"a": 1}, True),
+    ],
+)
+def test_bool_filter(value, expected):
+    assert bool_filter(value) == expected
+
+
+def test_bool_filter_invalid_string():
+    # Test that invalid string values raise ValueError
+    with pytest.raises(ValueError, match="Cannot convert 'maybe' to boolean"):
+        bool_filter("maybe")
+
+    with pytest.raises(
+        ValueError, match="Cannot convert 'invalid' to boolean"
+    ):
+        bool_filter("invalid")
+
+
+def test_bool_filter_jinja_integration():
+    env = Environment()
+    register_filters(env)
+
+    # Test truthy string
+    template = env.from_string("{{ 'yes' | bool }}")
+    assert template.render() == "True"
+
+    # Test falsy string
+    template = env.from_string("{{ 'no' | bool }}")
+    assert template.render() == "False"
+
+    # Test with variable
+    template = env.from_string(
+        "{% if enabled | bool %}enabled{% else %}disabled{% endif %}"
+    )
+    assert template.render(enabled="true") == "enabled"
+    assert template.render(enabled="false") == "disabled"
+    assert template.render(enabled="1") == "enabled"
+    assert template.render(enabled="0") == "disabled"
+
+
+def test_bool_filter_native_environment():
+    """Test bool filter with NativeEnvironment to get actual boolean values."""
+    env = NativeEnvironment()
+    register_filters(env)
+
+    # Test truthy string - should return actual boolean True
+    template = env.from_string("{{ 'yes' | bool }}")
+    result = template.render()
+    assert result is True
+    assert isinstance(result, bool)
+
+    # Test falsy string - should return actual boolean False
+    template = env.from_string("{{ 'no' | bool }}")
+    result = template.render()
+    assert result is False
+    assert isinstance(result, bool)
+
+    # Test various truthy strings
+    for truthy_value in [
+        "true",
+        "True",
+        "TRUE",
+        "yes",
+        "Yes",
+        "1",
+        "on",
+        "ON",
+        "t",
+        "T",
+        "y",
+        "Y",
+    ]:
+        template = env.from_string("{{ value | bool }}")
+        result = template.render(value=truthy_value)
+        assert (
+            result is True
+        ), f"Expected True for '{truthy_value}', got {result}"
+        assert isinstance(result, bool)
+
+    # Test various falsy strings
+    for falsy_value in [
+        "false",
+        "False",
+        "FALSE",
+        "no",
+        "No",
+        "0",
+        "off",
+        "OFF",
+        "",
+        "f",
+        "F",
+        "n",
+        "N",
+    ]:
+        template = env.from_string("{{ value | bool }}")
+        result = template.render(value=falsy_value)
+        assert (
+            result is False
+        ), f"Expected False for '{falsy_value}', got {result}"
+        assert isinstance(result, bool)
+
+    # Test with conditional logic
+    template = env.from_string(
+        "{% if enabled | bool %}enabled{% else %}disabled{% endif %}"
+    )
+    assert template.render(enabled="true") == "enabled"
+    assert template.render(enabled="false") == "disabled"
+    assert template.render(enabled="1") == "enabled"
+    assert template.render(enabled="0") == "disabled"
+
+    # Test that boolean values can be used in expressions
+    template = env.from_string("{{ ('yes' | bool) and ('true' | bool) }}")
+    result = template.render()
+    assert result is True
+    assert isinstance(result, bool)
+
+    template = env.from_string("{{ ('yes' | bool) and ('false' | bool) }}")
+    result = template.render()
+    assert result is False
+    assert isinstance(result, bool)


### PR DESCRIPTION
ansible supports a bool filter which converts a string to a boolean.
This gets used in source plugins where we need to have a boolean value
https://redhat.atlassian.net/browse/AAP-74795

e.g.
```
caching_enabled : "{{ my_caching_var | default("false") | bool }}"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Jinja "bool" filter to convert values to boolean, handling nulls, booleans, trimmed case-insensitive truthy/falsy strings, numeric/collection inputs, and standard coercion.

* **Tests**
  * Added comprehensive tests for many inputs, invalid-string error cases, and template integration that produces true boolean values.

* **Documentation**
  * Changelog updated to document the new release and addition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->