### PR TITLE
fix: [AAP-74595] use subprocess stdin pipe for vault decryption

### DIFF
--- a/ansible_rulebook/vault.py
+++ b/ansible_rulebook/vault.py
@@ -14,9 +14,8 @@
 
 import getpass
 import shutil
+import subprocess
 import tempfile
-
-import pexpect
 
 from ansible_rulebook.exception import (
     AnsibleVaultNotFound,
@@ -37,19 +36,26 @@ class Vault:
         vault_ids: list[str] = None,
         ask_pass: bool = False,
     ):
-        cli_args = ""
+        cli_args = []
+        self.tempfiles = []
+
+        has_vault_config = ask_pass or password_file or vault_ids or passwords
+        if has_vault_config and not shutil.which("ansible-vault"):
+            raise AnsibleVaultNotFound
+
         if ask_pass:
-            self.secret = getpass.getpass(prompt="Vault password: ")
-            cli_args = " --ask-vault-pass"
-        else:
-            self.secret = None
+            secret = getpass.getpass(prompt="Vault password: ")
+            tmpf = tempfile.NamedTemporaryFile("w+t", suffix=".vaultpw")
+            tmpf.write(secret)
+            tmpf.flush()
+            self.tempfiles.append(tmpf)
+            cli_args += ["--vault-password-file", tmpf.name]
 
         if password_file:
-            cli_args += f" --vault-password-file {password_file}"
+            cli_args += ["--vault-password-file", password_file]
 
         if not vault_ids:
             vault_ids = []
-        self.tempfiles = []
         for item in passwords or []:
             if item["type"] == "VaultPassword":
                 tmpf = tempfile.NamedTemporaryFile("w+t")
@@ -59,34 +65,40 @@ class Vault:
                 vault_ids.append(f"{item['label']}@{tmpf.name}")
 
         for vid in vault_ids:
-            cli_args += f" --vault-id {vid}"
+            cli_args += ["--vault-id", vid]
 
         if cli_args:
-            if not shutil.which("ansible-vault"):
-                raise AnsibleVaultNotFound
-            self.cli = f"ansible-vault decrypt {cli_args}"
+            self.cli_args = ["ansible-vault", "decrypt"] + cli_args
         else:
-            self.cli = None
+            self.cli_args = None
 
     def decrypt(self, vault_text: str) -> str:
-        """Decrypt a vault text."""
-        if not self.cli:
+        """Decrypt a vault text.
+
+        Pipes ciphertext to ansible-vault via subprocess stdin.
+        subprocess.run with input= uses communicate() for coordinated
+        read/write, handling arbitrarily large payloads on all platforms.
+        """
+        if not self.cli_args:
             raise VaultDecryptException("No vault secrets were provided")
-        child = pexpect.spawn(self.cli)
-        if self.secret:
-            child.expect("Vault password: ")
-            child.sendline(self.secret)
-        child.expect("Reading ciphertext input from stdin")
-        child.sendline(vault_text)
-        child.sendcontrol("D")
-        i = child.expect(["Decryption successful", "ERROR"])
-        if i == 0:
-            child.readline()
-            decrypted_text = "".join(line.decode() for line in child)
-            return decrypted_text.strip()
-        else:
-            error_msg = child.readline()
-            raise VaultDecryptException(error_msg.decode())
+
+        try:
+            result = subprocess.run(
+                self.cli_args,
+                capture_output=True,
+                input=vault_text,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise VaultDecryptException(
+                "ansible-vault decrypt timed out"
+            ) from exc
+
+        if result.returncode != 0:
+            raise VaultDecryptException(result.stderr.strip())
+
+        return result.stdout.rstrip("\n")
 
     @staticmethod
     def is_encrypted(vault_text: str) -> bool:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,6 +6,7 @@ ansible
 ansible-core~=2.16.0; python_version >= "3.11"
 ansible-core~=2.15.0; python_version < "3.11"
 ansible-runner
+pexpect
 jmespath
 
 pytest

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -13,10 +13,17 @@
 #  limitations under the License.
 
 import os
+import random
+import string
+import subprocess
+from unittest.mock import patch
 
 import pytest
 
-from ansible_rulebook.exception import VaultDecryptException
+from ansible_rulebook.exception import (
+    AnsibleVaultNotFound,
+    VaultDecryptException,
+)
 from ansible_rulebook.vault import Vault
 
 
@@ -84,8 +91,108 @@ def test_decrypt_vault_id(encrypt_hello, encrypt_world):
 def test_decrypt_error(encrypt_world):
     os.chdir(HERE)
     myvault = Vault(password_file="./pass1.txt")
-    with pytest.raises(VaultDecryptException):
-        try:
+    try:
+        with pytest.raises(VaultDecryptException):
             myvault.decrypt(encrypt_world)
-        finally:
-            myvault.close()
+    finally:
+        myvault.close()
+
+
+def _vault_encrypt(plaintext: str, password_file: str) -> str:
+    """Helper to vault-encrypt a string and return cleaned ciphertext."""
+    result = subprocess.run(
+        [
+            "ansible-vault",
+            "encrypt_string",
+            "--vault-password-file",
+            password_file,
+        ],
+        input=plaintext,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    idx = output.find("$ANSIBLE_VAULT")
+    assert idx != -1, output
+    vault_text = output[idx:].strip()
+    lines = vault_text.splitlines()
+    return "\n".join([lines[0]] + [line.strip() for line in lines[1:]])
+
+
+@pytest.mark.parametrize("size", [100, 1024, 2048, 4096, 5120, 8192])
+def test_decrypt_various_payload_sizes(size):
+    """Verify decryption works for payloads of various sizes."""
+    os.chdir(HERE)
+    random.seed(size)
+    plaintext = "".join(
+        random.choices(string.ascii_letters + string.digits, k=size)
+    )
+
+    vault_text = _vault_encrypt(plaintext, "./pass1.txt")
+
+    myvault = Vault(password_file="./pass1.txt")
+    try:
+        decrypted = myvault.decrypt(vault_text)
+        assert decrypted == plaintext
+    finally:
+        myvault.close()
+
+
+def test_decrypt_multiline_payload():
+    """Verify decryption of a multiline plaintext value."""
+    os.chdir(HERE)
+    multiline_text = "line1\nline2\nline3\nfinal"
+    vault_text = _vault_encrypt(multiline_text, "./pass1.txt")
+
+    myvault = Vault(password_file="./pass1.txt")
+    try:
+        decrypted = myvault.decrypt(vault_text)
+        assert decrypted == multiline_text
+    finally:
+        myvault.close()
+
+
+def test_decrypt_whitespace_preserved():
+    """Verify leading and trailing whitespace is preserved after decryption."""
+    os.chdir(HERE)
+    plaintext = "  hello world  "
+    vault_text = _vault_encrypt(plaintext, "./pass1.txt")
+
+    myvault = Vault(password_file="./pass1.txt")
+    try:
+        decrypted = myvault.decrypt(vault_text)
+        assert decrypted == plaintext
+    finally:
+        myvault.close()
+
+
+def test_decrypt_no_vault_secrets():
+    """Verify proper error when no vault secrets are configured."""
+    myvault = Vault()
+    with pytest.raises(VaultDecryptException, match="No vault secrets"):
+        myvault.decrypt("$ANSIBLE_VAULT;1.1;AES256\nabc123")
+
+
+def test_decrypt_ask_pass(encrypt_hello):
+    """Verify ask_pass writes password to a temp file."""
+    os.chdir(HERE)
+    with patch("ansible_rulebook.vault.getpass.getpass", return_value="pass1"):
+        myvault = Vault(ask_pass=True)
+
+    assert len(myvault.tempfiles) == 1
+    assert "--vault-password-file" in myvault.cli_args
+    assert "--ask-vault-pass" not in myvault.cli_args
+
+    try:
+        decrypted = myvault.decrypt(encrypt_hello)
+        assert decrypted == "hello"
+    finally:
+        myvault.close()
+
+
+def test_vault_not_found():
+    """Verify AnsibleVaultNotFound when ansible-vault is not installed."""
+    with patch("ansible_rulebook.vault.shutil.which", return_value=None):
+        with pytest.raises(AnsibleVaultNotFound):
+            Vault(password_file="./pass1.txt")


### PR DESCRIPTION
Replace pexpect pty-based vault decryption with subprocess.run using stdin pipe. The pty approach silently truncates ciphertext exceeding the ~4KB pty buffer, causing decryption failures for large secret:true credential values (e.g. vault-encrypted JWTs, certificates).

subprocess.run with input= uses communicate() for coordinated I/O, handling arbitrarily large payloads on all platforms.

For the --ask-vault-pass code path, the vault password is written to a temporary file (consistent with existing VaultPassword handling in `__init__`) since stdin is occupied by the ciphertext.

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated vault decryption to use non-interactive `ansible-vault decrypt` execution and improved timeout/non-zero-exit error handling.
  * Enhanced password handling for ask-pass by using a vault password file and passing vault IDs consistently.

* **Tests**
  * Expanded coverage for encryption/decryption across varied sizes, multiline content, and leading/trailing whitespace preservation.
  * Added scenarios for missing vault secrets and when `ansible-vault` is unavailable.

* **Chores**
  * Updated test dependencies by adding an additional pinned requirement for the vault test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->