### PR TITLE
chore: add .cve-fix/examples.md guidance for CVE fixer workflow

### DIFF
--- a/.cve-fix/examples.md
+++ b/.cve-fix/examples.md
@@ -1,0 +1,25 @@
+<!-- last-analyzed: 2026-05-19 | cve-merged: 0 (CVE-specific), 32 dependabot -->
+<!-- No CVE-specific fix PRs found. Only dependabot GitHub Actions bumps observed.
+     Update with /guidance.update after more CVE fixes are merged. -->
+
+## Titles
+- Dependabot pattern: `chore(deps): bump <package> from <old> to <new>` (32/32 merged PRs)
+- No manual CVE fix PRs found — use: `fix(deps): <description> (<CVE-ID>)`
+
+## Branches
+- Dependabot pattern: `dependabot/github_actions/<package>-<version>` (32/32 merged PRs)
+- For manual CVE fixes, use: `fix/cve-YYYY-NNNNN-<package>`
+
+## Files
+- Dependabot PRs modify `.github/workflows/*.yml` files
+- For Python dependency CVEs, expect `pyproject.toml` + `poetry.lock` or equivalent
+
+## Co-upgrades
+- No data available from CVE-specific PRs
+
+## PR Description
+- Include CVE ID, severity, CVSS score
+- Reference Jira issue
+
+## Don'ts
+- No rejected CVE PRs found in recent history


### PR DESCRIPTION
Adds `.cve-fix/examples.md` so the CVE fixer workflow knows how to
create fix PRs matching this repo's conventions (branch naming, files that
change together, co-upgrades, etc.).

Generated by `/onboard` — minimal CVE-specific guidance (only dependabot PRs found).
Run `/guidance.update` after more CVE fixes are merged to improve.

🤖 Generated by /onboard