### PR TITLE
chore: revamp minimal decision environment

### DIFF
--- a/minimal-decision-environment.yml
+++ b/minimal-decision-environment.yml
@@ -1,26 +1,25 @@
+---
 version: 3
 
 images:
   base_image:
-    name: 'registry.access.redhat.com/ubi9/python-311:latest'
+    name: "registry.access.redhat.com/ubi9/python-312-minimal:latest"
+
+options:
+  package_manager_path: /usr/bin/microdnf
 
 dependencies:
+  python_interpreter:
+    python_path: /usr/bin/python3.12
   galaxy:
     collections:
-      - ansible.eda
+      - "ansible.eda:>=2.12.0"
   python:
-    - azure-servicebus
-    - aiobotocore
-    - aiohttp
-    - aiokafka
-    - gssapi
-    - watchdog
-    - systemd-python
-    - dpath
     - ansible-rulebook
   ansible_core:
     package_pip: ansible-core~=2.16.0
   ansible_runner:
     package_pip: ansible-runner
   system:
-    - java-17-openjdk-devel [platform:rpm]
+    - java-17-openjdk-headless [platform:rpm]
+    - python3.12-devel [compile platform:rpm]


### PR DESCRIPTION
While the existing configuration for ansible-builder builds a decision environment that works, there are few drawbacks:
- the base image is based on Python 3.11, whereas now Python 3.12 is considered "the default one"
- the base image is not a minimal image, and its base size is 1.1 GB (!)
- the dependencies of the `ansible.eda` collection are manually specified, even though `ansible-builder` can detect them from the collection itself
- the development bits for OpenJDK are installed, even though only the runtime is needed which make the resulting container image currently more than 1.5 GB.

Revamp the configuration a bit:
- switch the base image to one based on Python 3.12; this requires setting the path to the interpreter, as it is not the default one
- switch the base image to a minimal UBI; this requires setting `microdnf` as the package manager
- require an `ansible.eda` version that has working bindeps
- drop all the manually specified Python dependencies, leaving only `ansible-rulebook`
- install the development package for Python when building, needed to rebuild few binary wheels
- install only the runtime of OpenJDK
- minor nitpicks: put the YAML document start at the beginning, and use double quotes when needed

The result is a configuration that works again, and produces a container image which is around 650 MB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the decision environment base image to Python 3.12
  * Updated Ansible Galaxy collection requirements with version constraints
  * Optimized system package dependencies by adjusting package types and reducing the overall dependency footprint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->