### PR TITLE
[AAP-76070] feat: add back pressure, shared job monitor, and concurrent action controls

### DIFF
--- a/ansible_rulebook/action/helper.py
+++ b/ansible_rulebook/action/helper.py
@@ -266,3 +266,47 @@ class Helper:
             return job_url
 
         return None
+
+    def log_completion(
+        self, template_type: str, template_name: str, controller_job: dict
+    ) -> None:
+        """Log job or workflow completion at the appropriate level.
+
+        Args:
+            template_type: Type of template (e.g., "Job template",
+                "Workflow template")
+            template_name: Name of the template
+            controller_job: Job data dictionary containing status and id
+        """
+        status = controller_job["status"]
+        job_id = controller_job.get("id")
+        if status == "successful":
+            logger.info(
+                "%s '%s' completed successfully (job_id: %s)",
+                template_type,
+                template_name,
+                job_id,
+            )
+        elif status in ["failed", "error"]:
+            logger.error(
+                "%s '%s' %s (job_id: %s)",
+                template_type,
+                template_name,
+                status,
+                job_id,
+            )
+        elif status == "canceled":
+            logger.warning(
+                "%s '%s' was canceled (job_id: %s)",
+                template_type,
+                template_name,
+                job_id,
+            )
+        else:
+            logger.debug(
+                "%s '%s' completed with unexpected status: %s (job_id: %s)",
+                template_type,
+                template_name,
+                status,
+                job_id,
+            )

--- a/ansible_rulebook/action/run_job_template.py
+++ b/ansible_rulebook/action/run_job_template.py
@@ -83,9 +83,25 @@ class RunJobTemplate:
         await self._run()
 
     async def _run(self):
+        try:
+            controller_job = await self._run_with_retries()
+        except (ControllerApiException, JobTemplateNotFoundException) as ex:
+            logger.error(ex)
+            controller_job = {
+                "status": "failed",
+                "created": run_at(),
+                "error": str(ex),
+            }
+
+        self.controller_job = controller_job
+        await self._post_process()
+
+    async def _run_with_retries(self):
         retries = self.action_args.get("retries", 0)
         if self.action_args.get("retry", False):
-            retries = max(self.action_args.get("retries", 0), 1)
+            retries = max(retries, 1)
+        # Ensure retries is never negative to prevent skipping loop body
+        retries = max(retries, 0)
         delay = self.action_args.get("delay", 0)
         add_event_uuid_label = self.action_args.get(
             "add_event_uuid_label", False
@@ -94,52 +110,43 @@ class RunJobTemplate:
         if add_event_uuid_label:
             job_labels.append(self.helper.get_event_uuid_label())
 
-        try:
-            job_url = await self.helper.get_old_job_url(
-                self.name,
-                self.organization,
-                JOB_TEMPLATE_TYPE,
-                add_event_uuid_label,
-            )
-            for i in range(retries + 1):
-                if i > 0:
-                    if delay > 0:
-                        await asyncio.sleep(delay)
-                    logger.warning(
-                        "Previous run_job_template failed. Retry %d of %d",
-                        i,
-                        retries,
-                    )
-                # Launch the job and get URL immediately
-                if not job_url:
-                    job_url = await job_template_runner.launch_job_template(
-                        self.name,
-                        self.organization,
-                        self.job_args,
-                        job_labels,
-                    )
-                    logger.info(f"Job Launched, url: {job_url}")
-                    self.helper.update_action_state({"job_url": job_url})
+        job_url = await self.helper.get_old_job_url(
+            self.name,
+            self.organization,
+            JOB_TEMPLATE_TYPE,
+            add_event_uuid_label,
+        )
+        last_job = None
+        for i in range(retries + 1):
+            if i > 0:
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                logger.warning(
+                    "Previous run_job_template failed. Retry %d of %d",
+                    i,
+                    retries,
+                )
 
-                # Monitor the job until completion
-                controller_job = await job_template_runner.monitor_job(job_url)
+            if not job_url:
+                job_url = await job_template_runner.launch_job_template(
+                    self.name,
+                    self.organization,
+                    self.job_args,
+                    job_labels,
+                )
+                logger.info(f"Job Launched, url: {job_url}")
+                self.helper.update_action_state({"job_url": job_url})
 
-                if controller_job["status"] != "failed":
-                    break
+            last_job = await job_template_runner.monitor_job(job_url)
+            self.helper.log_completion("Job template", self.name, last_job)
 
-                # Reset job_url to launch a new job on retry
-                job_url = None
-                self.helper.update_action_state({"job_url": None})
+            if last_job["status"] != "failed":
+                return last_job
 
-        except (ControllerApiException, JobTemplateNotFoundException) as ex:
-            logger.error(ex)
-            controller_job = {}
-            controller_job["status"] = "failed"
-            controller_job["created"] = run_at()
-            controller_job["error"] = str(ex)
+            job_url = None
+            self.helper.update_action_state({"job_url": None})
 
-        self.controller_job = controller_job
-        await self._post_process()
+        return last_job
 
     async def _post_process(self) -> None:
         a_log = {

--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -82,9 +82,28 @@ class RunWorkflowTemplate:
         await self._run()
 
     async def _run(self):
+        try:
+            controller_job = await self._run_with_retries()
+        except (
+            ControllerApiException,
+            WorkflowJobTemplateNotFoundException,
+        ) as ex:
+            logger.error(ex)
+            controller_job = {
+                "status": "failed",
+                "created": run_at(),
+                "error": str(ex),
+            }
+
+        self.controller_job = controller_job
+        await self._post_process()
+
+    async def _run_with_retries(self):
         retries = self.action_args.get("retries", 0)
         if self.action_args.get("retry", False):
-            retries = max(self.action_args.get("retries", 0), 1)
+            retries = max(retries, 1)
+        # Ensure retries is never negative to prevent skipping loop body
+        retries = max(retries, 0)
         delay = self.action_args.get("delay", 0)
         add_event_uuid_label = self.action_args.get(
             "add_event_uuid_label", False
@@ -93,56 +112,47 @@ class RunWorkflowTemplate:
         if add_event_uuid_label:
             job_labels.append(self.helper.get_event_uuid_label())
 
-        try:
-            job_url = await self.helper.get_old_job_url(
-                self.name,
-                self.organization,
-                WORKFLOW_TEMPLATE_TYPE,
-                add_event_uuid_label,
+        job_url = await self.helper.get_old_job_url(
+            self.name,
+            self.organization,
+            WORKFLOW_TEMPLATE_TYPE,
+            add_event_uuid_label,
+        )
+        last_job = None
+        for i in range(retries + 1):
+            if i > 0:
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                logger.warning(
+                    "Previous run_workflow_template failed. Retry %d of %d",
+                    i,
+                    retries,
+                )
+
+            if not job_url:
+                job_url = (
+                    await job_template_runner.launch_workflow_job_template(
+                        self.name,
+                        self.organization,
+                        self.job_args,
+                        job_labels,
+                    )
+                )
+                logger.info(f"Workflow launched, URL: {job_url}")
+                self.helper.update_action_state({"job_url": job_url})
+
+            last_job = await job_template_runner.monitor_job(job_url)
+            self.helper.log_completion(
+                "Workflow template", self.name, last_job
             )
-            for i in range(retries + 1):
-                if i > 0:
-                    if delay > 0:
-                        await asyncio.sleep(delay)
-                    logger.warning(
-                        "Previous run_workflow_template failed. "
-                        "Retry %d of %d",
-                        i,
-                        retries,
-                    )
-                # Launch the workflow and get URL immediately
-                if not job_url:
-                    job_url = (
-                        await job_template_runner.launch_workflow_job_template(
-                            self.name,
-                            self.organization,
-                            self.job_args,
-                            job_labels,
-                        )
-                    )
-                    logger.info(f"Workflow launched, URL: {job_url}")
-                    self.helper.update_action_state({"job_url": job_url})
 
-                # Monitor the job until completion
-                controller_job = await job_template_runner.monitor_job(job_url)
-                if controller_job["status"] != "failed":
-                    break
+            if last_job["status"] != "failed":
+                return last_job
 
-                # Reset job_url to launch a new job on retry
-                job_url = None
-                self.helper.update_action_state({"job_url": None})
-        except (
-            ControllerApiException,
-            WorkflowJobTemplateNotFoundException,
-        ) as ex:
-            logger.error(ex)
-            controller_job = {}
-            controller_job["status"] = "failed"
-            controller_job["created"] = run_at()
-            controller_job["error"] = str(ex)
+            job_url = None
+            self.helper.update_action_state({"job_url": None})
 
-        self.controller_job = controller_job
-        await self._post_process()
+        return last_job
 
     async def _post_process(self) -> None:
         a_log = {

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -30,7 +30,7 @@ from ansible_rulebook.collection import (
     split_collection_name,
 )
 from ansible_rulebook.common import StartupArgs
-from ansible_rulebook.conf import settings
+from ansible_rulebook.conf import DEFAULT_MAX_CONCURRENT_ACTIONS, settings
 from ansible_rulebook.engine import run_rulesets, start_source
 from ansible_rulebook.job_template_runner import job_template_runner
 from ansible_rulebook.rule_types import EventSource, RuleSet, RuleSetQueue
@@ -39,6 +39,7 @@ from ansible_rulebook.util import (
     decrypted_context,
     startup_logging,
     substitute_variables,
+    validate_file_path,
     validate_url,
 )
 from ansible_rulebook.validators import Validate
@@ -61,11 +62,23 @@ from .exception import (
 
 
 class NullQueue:
+    """A no-op queue that discards all data.
+
+    Used when no websocket_url is configured (no EDA Server).
+    Implements asyncio.Queue interface for compatibility.
+    """
+
+    def __init__(self):
+        self.maxsize = 0
+
     async def put(self, _data):
         pass
 
     def qsize(self):
         return 0
+
+    def full(self):
+        return False
 
 
 logger = logging.getLogger(__name__)
@@ -127,11 +140,16 @@ async def run(parsed_args: argparse.Namespace) -> None:
     for k, v in startup_args.env_vars.items():
         os.environ[k] = str(v)
 
+    # Update the settings from env in worker mode
+    if parsed_args.worker:
+        settings.update_from_env()
+
+    setup_semaphores()
     if startup_args.check_controller_connection:
         await validate_controller_params(startup_args)
 
     if parsed_args.websocket_url:
-        event_log = asyncio.Queue()
+        event_log = asyncio.Queue(settings.max_reporting_queue_size)
     else:
         event_log = NullQueue()
 
@@ -163,11 +181,22 @@ async def run(parsed_args: argparse.Namespace) -> None:
         file_monitor,
     )
 
-    await event_log.put(dict(type="Exit"))
     if feedback_task:
+        try:
+            await asyncio.wait_for(
+                event_log.put({"type": "Exit"}),
+                timeout=settings.max_feedback_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timed out sending Exit to event log, "
+                "cancelling feedback task"
+            )
         await asyncio.wait(
             [feedback_task], timeout=settings.max_feedback_timeout
         )
+    else:
+        await event_log.put({"type": "Exit"})
 
     logger.info("Cancelling event source tasks")
     for task in tasks:
@@ -197,7 +226,10 @@ async def run(parsed_args: argparse.Namespace) -> None:
 def load_vars(parsed_args) -> Dict[str, str]:
     variables = dict()
     if parsed_args.vars:
-        with open(parsed_args.vars) as f:
+        validated_vars_file = validate_file_path(
+            parsed_args.vars, "Variables file"
+        )
+        with open(validated_vars_file) as f:
             variables.update(yaml.safe_load(f.read()))
 
     if parsed_args.env_vars:
@@ -224,7 +256,10 @@ def load_rulebook(
         logger.debug(
             "Loading rules from the file system %s", parsed_args.rulebook
         )
-        with open(parsed_args.rulebook, "rb") as f:
+        validated_rulebook_file = validate_file_path(
+            parsed_args.rulebook, "Rulebook file"
+        )
+        with open(validated_rulebook_file, "rb") as f:
             raw_data = f.read()
             if startup_args:
                 startup_args.check_vault = has_vaulted_str(raw_data)
@@ -368,3 +403,22 @@ async def validate_controller_params(startup_args: StartupArgs) -> None:
 
         data = await job_template_runner.get_config()
         logger.info("AAP Version %s", data["version"])
+
+
+def setup_semaphores():
+    # The semaphore is always created because individual rulesets can
+    # override the global default_execution_strategy to parallel in
+    # the rulebook YAML.  _call_action_with_semaphore only acquires
+    # when the semaphore exists, and actions only run concurrently
+    # under a parallel ruleset, so creating it is harmless for
+    # sequential rulesets.
+    if settings.max_concurrent_actions == 0:
+        settings.max_concurrent_actions = DEFAULT_MAX_CONCURRENT_ACTIONS
+
+    logger.info(
+        "max_concurrent_actions=%d",
+        settings.max_concurrent_actions,
+    )
+    settings.max_actions_semaphore = asyncio.Semaphore(
+        settings.max_concurrent_actions
+    )

--- a/ansible_rulebook/back_pressure.py
+++ b/ansible_rulebook/back_pressure.py
@@ -1,0 +1,241 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Back pressure management for ansible-rulebook.
+
+This module provides back pressure mechanisms to prevent system overload
+when actions or reporting queues reach capacity.
+"""
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+from ansible_rulebook.conf import settings
+from ansible_rulebook.exception import (
+    TimedOutActionsException,
+    TimedOutReportingException,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BackPressureManager:
+    """Manages back pressure for actions and reporting queues.
+
+    This class implements back pressure mechanisms to prevent the system
+    from being overwhelmed when:
+    - Too many actions are running concurrently
+    - The reporting queue is full and cannot drain to EDA Server
+
+    Attributes:
+        event_log: AsyncIO Queue for reporting/audit events
+    """
+
+    def __init__(self, event_log: Optional[asyncio.Queue] = None):
+        """Initialize the BackPressureManager.
+
+        Args:
+            event_log: Optional asyncio.Queue for reporting events.
+                      If None, reporting back pressure is skipped.
+        """
+        self.event_log = event_log
+
+    async def _wait_for_reporting_capacity(self) -> None:
+        """Wait until reporting queue has capacity."""
+        blocked = False
+        once = False
+
+        while self.event_log.full():
+            if not once:
+                logger.info(
+                    "Waiting on %d reporting objects to flush, queue "
+                    "capacity %d. back pressure applied",
+                    self.event_log.qsize(),
+                    self.event_log.maxsize,
+                )
+                once = True
+            blocked = True
+            await asyncio.sleep(1)
+
+        if blocked:
+            logger.info(
+                "Back pressure due to reporting released. Free slots %d "
+                "Queue capacity %d",
+                self.event_log.maxsize - self.event_log.qsize(),
+                self.event_log.maxsize,
+            )
+
+    def _should_skip_reporting_back_pressure(self) -> bool:
+        """Check if reporting back pressure should be skipped."""
+        if settings.skip_audit_events or self.event_log is None:
+            return True
+
+        # Skip if queue has no size limit (unbounded or NullQueue)
+        if (
+            not hasattr(self.event_log, "maxsize")
+            or self.event_log.maxsize == 0
+        ):
+            return True
+
+        return False
+
+    async def apply_reporting_back_pressure(self) -> None:
+        """Apply back pressure based on reporting queue capacity.
+
+        Blocks event processing if the reporting queue is full, waiting
+        for audit events to drain to the EDA Server before allowing
+        new events to be processed.
+
+        Uses asyncio.wait_for() with timeout from settings.
+
+        Raises:
+            TimedOutReportingException: If queue doesn't drain within timeout
+        """
+        if self._should_skip_reporting_back_pressure():
+            return
+
+        if not self.event_log.full():
+            return
+
+        try:
+            await asyncio.wait_for(
+                self._wait_for_reporting_capacity(),
+                timeout=settings.max_back_pressure_timeout,
+            )
+        except asyncio.TimeoutError:
+            raise TimedOutReportingException(
+                "Reporting objects did not drain in "
+                f"{settings.max_back_pressure_timeout} seconds hence aborting"
+            )
+
+    async def _wait_for_action_capacity(self) -> None:
+        """Wait until action semaphore has capacity."""
+        blocked = False
+        once = False
+
+        while settings.max_actions_semaphore._value <= 0:
+            if not once:
+                logger.info(
+                    "Waiting on %d actions to finish, "
+                    "back pressure applied",
+                    settings.max_concurrent_actions,
+                )
+                once = True
+            blocked = True
+            await asyncio.sleep(1)
+
+        if blocked:
+            logger.info(
+                "Back pressure released. Free slots %d",
+                settings.max_actions_semaphore._value,
+            )
+
+    async def apply_actions_back_pressure(self) -> None:
+        """Apply back pressure based on concurrent action capacity.
+
+        Blocks event processing if max concurrent actions limit is reached,
+        waiting for running actions to complete before allowing new events
+        to be processed.
+
+        Uses asyncio.wait_for() with timeout from settings.
+
+        Raises:
+            TimedOutActionsException: If actions don't complete within timeout
+        """
+        if settings.max_actions_semaphore is None:
+            return
+
+        if settings.max_actions_semaphore._value > 0:
+            return
+
+        try:
+            await asyncio.wait_for(
+                self._wait_for_action_capacity(),
+                timeout=settings.max_back_pressure_timeout,
+            )
+        except asyncio.TimeoutError:
+            raise TimedOutActionsException(
+                "Actions failed to end in "
+                f"{settings.max_back_pressure_timeout} seconds hence aborting"
+            )
+
+    def _check_timeout_budget_exhausted(
+        self, remaining_timeout: float, actions_elapsed: float
+    ) -> None:
+        """Check if timeout budget is exhausted and raise if needed."""
+        if remaining_timeout <= 0 and self.event_log and self.event_log.full():
+            raise TimedOutReportingException(
+                f"Timeout budget exhausted after actions phase "
+                f"({actions_elapsed: .1f}s). No time remaining for "
+                f"reporting back pressure."
+            )
+
+    async def _apply_reporting_with_remaining_timeout(
+        self,
+        remaining_timeout: float,
+        start_time: float,
+        actions_elapsed: float,
+    ) -> None:
+        """Apply reporting back pressure with remaining timeout budget."""
+        if self._should_skip_reporting_back_pressure():
+            return
+
+        if not self.event_log.full():
+            return
+
+        try:
+            await asyncio.wait_for(
+                self._wait_for_reporting_capacity(),
+                timeout=remaining_timeout,
+            )
+        except asyncio.TimeoutError:
+            total_elapsed = time.monotonic() - start_time
+            raise TimedOutReportingException(
+                f"Reporting objects did not drain within remaining timeout "
+                f"({remaining_timeout: .1f}s of "
+                f"{settings.max_back_pressure_timeout}s total). "
+                f"Actions phase took {actions_elapsed: .1f}s, "
+                f"total elapsed {total_elapsed: .1f}s"
+            )
+
+    async def apply_all_back_pressure(self) -> None:
+        """Apply both actions and reporting back pressure.
+
+        Checks both back pressure mechanisms sequentially before
+        allowing event processing to continue. The timeout budget is
+        shared between both phases.
+
+        Raises:
+            TimedOutActionsException: If actions don't complete within timeout
+            TimedOutReportingException: If reporting queue doesn't drain
+        """
+        start_time = time.monotonic()
+
+        # Apply actions back pressure with full timeout
+        await self.apply_actions_back_pressure()
+
+        actions_elapsed = time.monotonic() - start_time
+        remaining_timeout = max(
+            0, settings.max_back_pressure_timeout - actions_elapsed
+        )
+
+        self._check_timeout_budget_exhausted(
+            remaining_timeout, actions_elapsed
+        )
+
+        # Apply reporting back pressure with remaining timeout
+        await self._apply_reporting_with_remaining_timeout(
+            remaining_timeout, start_time, actions_elapsed
+        )

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -288,6 +288,43 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "-m",
+        "--max-concurrent-actions",
+        help="For parallel execution strategy the maximum number of "
+        "concurrent actions. Default is 25 when using parallel strategy. "
+        "Only applies to parallel execution strategy. "
+        "It can also be passed via the env var EDA_MAX_CONCURRENT_ACTIONS",
+        default=os.environ.get("EDA_MAX_CONCURRENT_ACTIONS", "0"),
+        type=int,
+    )
+    parser.add_argument(
+        "--max-back-pressure-timeout",
+        help="When a back pressure is applied due to actions or reporting "
+        "objects being at capacity, how long should we wait before failing "
+        "Default is 3600 seconds. It can also "
+        "be passed via the env var EDA_MAX_BACK_PRESSURE_TIMEOUT",
+        default=os.environ.get("EDA_MAX_BACK_PRESSURE_TIMEOUT", "3600"),
+        type=int,
+    )
+    parser.add_argument(
+        "--max-reporting-queue-size",
+        help="For rule audits we send back reporting objects, this queue "
+        "size is to specify the backlog of reporting objects to be flushed "
+        "to the EDA Server default is 50. Increasing this may cause OOM "
+        "It can be passed via the env var EDA_MAX_REPORTING_QUEUE_SIZE",
+        default=os.environ.get("EDA_MAX_REPORTING_QUEUE_SIZE", "50"),
+        type=int,
+    )
+    parser.add_argument(
+        "--max-batch-job-polling-size",
+        help="Maximum number of jobs to include in a single batch polling "
+        "request to the controller. Default is 25. "
+        "It can be passed via the env var EDA_MAX_BATCH_JOB_POLLING_SIZE",
+        default=os.environ.get("EDA_MAX_BATCH_JOB_POLLING_SIZE", "25"),
+        type=int,
+    )
+
     return parser
 
 
@@ -320,9 +357,19 @@ def setup_logging_and_display(args: argparse.Namespace) -> None:
 
 
 def update_settings(args: argparse.Namespace) -> None:
+    """Update settings from CLI arguments.
+
+    Since argparse already uses env vars as defaults, we directly assign
+    values from args to settings. CLI args take priority over env vars.
+
+    Note: Do NOT call settings.update_from_env() here - that's only for
+    when the websocket handler updates env vars later.
+    """
+    # Special case: identifier is not in ENV_MAP but can be set via CLI
     if args.id:
         settings.identifier = args.id
 
+    # Direct assignments - argparse already handled env var defaults
     if args.gc_after is not None:
         settings.gc_after = args.gc_after
 
@@ -332,6 +379,9 @@ def update_settings(args: argparse.Namespace) -> None:
     if args.persistence_id:
         settings.persistence_id = args.persistence_id
 
+    if args.max_concurrent_actions > 0:
+        settings.max_concurrent_actions = args.max_concurrent_actions
+
     settings.print_events = args.print_events
     settings.websocket_url = args.websocket_url
     settings.websocket_ssl_verify = args.websocket_ssl_verify
@@ -339,6 +389,9 @@ def update_settings(args: argparse.Namespace) -> None:
     settings.websocket_access_token = args.websocket_access_token
     settings.websocket_refresh_token = args.websocket_refresh_token
     settings.skip_audit_events = args.skip_audit_events
+    settings.max_back_pressure_timeout = args.max_back_pressure_timeout
+    settings.max_reporting_queue_size = args.max_reporting_queue_size
+    settings.max_batch_job_polling_size = args.max_batch_job_polling_size
     settings.controller_retry_max_timeout = float(
         args.controller_retry_max_timeout
     )
@@ -355,15 +408,42 @@ def parse_vault_passwords(args: argparse.Namespace) -> None:
         return
 
     secret_files = []
+    validated_password_file = None
+    validated_vault_ids = []
 
+    # Validate vault password file
     if args.vault_password_file:
-        secret_files.append(args.vault_password_file)
+        try:
+            validated_password_file = util.validate_file_path(
+                args.vault_password_file, "Vault password file"
+            )
+            secret_files.append(validated_password_file)
+        except ValueError as e:
+            logger.error(f"Invalid vault password file: {e}")  # NOSONAR
+            sys.exit(1)
 
-    secret_files += args.vault_id
+    # Validate vault ID files (format: label@filename)
+    for vault_id in args.vault_id:
+        if "@" in vault_id:
+            label, filename = vault_id.split("@", 1)
+            try:
+                validated_filename = util.validate_file_path(
+                    filename, "Vault ID file"
+                )
+                validated_vault_id = f"{label}@{validated_filename}"
+                validated_vault_ids.append(validated_vault_id)
+                secret_files.append(validated_filename)
+            except ValueError as e:
+                logger.error(  # NOSONAR
+                    f"Invalid vault ID file '{vault_id}': {e}"
+                )
+                sys.exit(1)
+        else:
+            validated_vault_ids.append(vault_id)
 
     settings.vault = Vault(
-        password_file=args.vault_password_file,
-        vault_ids=args.vault_id,
+        password_file=validated_password_file,
+        vault_ids=validated_vault_ids,
         ask_pass=args.ask_vault_pass,
     )
 

--- a/ansible_rulebook/conf.py
+++ b/ansible_rulebook/conf.py
@@ -12,16 +12,64 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import json
+import logging
+import os
 import shutil
 import uuid
+from typing import Any, Type
 
 from ansible_rulebook.vault import Vault
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_EDA_LABEL = "Activated by Event-Driven Ansible"
+DEFAULT_MAX_CONCURRENT_ACTIONS = 25
 
 
 class _Settings:
+    # Simple map: attribute_name -> (env_var_name, type)
+    # Only these settings can be updated from environment variables
+    ENV_MAP = {
+        "gc_after": ("EDA_GC_AFTER", int),
+        "default_execution_strategy": ("EDA_EXECUTION_STRATEGY", str),
+        "max_feedback_timeout": ("EDA_MAX_FEEDBACK_TIMEOUT", int),
+        "print_events": ("EDA_PRINT_EVENTS", bool),
+        "websocket_url": ("EDA_WEBSOCKET_URL", str),
+        "websocket_ssl_verify": ("EDA_WEBSOCKET_SSL_VERIFY", str),
+        "websocket_token_url": ("EDA_WEBSOCKET_TOKEN_URL", str),
+        "websocket_access_token": ("EDA_WEBSOCKET_ACCESS_TOKEN", str),
+        "websocket_refresh_token": ("EDA_WEBSOCKET_REFRESH_TOKEN", str),
+        "skip_audit_events": ("EDA_SKIP_AUDIT_EVENTS", bool),
+        "persistence_enabled": ("EDA_PERSISTENCE_ENABLED", bool),
+        "persistence_id": ("EDA_PERSISTENCE_ID", str),
+        "max_concurrent_actions": ("EDA_MAX_CONCURRENT_ACTIONS", int),
+        "max_actions_timeout": ("EDA_MAX_ACTIONS_TIMEOUT", int),
+        "max_back_pressure_timeout": ("EDA_MAX_BACK_PRESSURE_TIMEOUT", int),
+        "max_reporting_queue_size": ("EDA_MAX_REPORTING_QUEUE_SIZE", int),
+        "max_batch_job_polling_size": (
+            "EDA_MAX_BATCH_JOB_POLLING_SIZE",
+            int,
+        ),
+        "eda_labels": ("EDA_LABELS", list),
+    }
+
+    # Settings that must be positive integers (>= 1)
+    # Note: max_concurrent_actions is NOT in this set because 0 is a valid
+    # sentinel value meaning "use default of 25"
+    POSITIVE_INT_SETTINGS = frozenset(
+        {
+            "max_actions_timeout",
+            "max_back_pressure_timeout",
+            "max_reporting_queue_size",
+            "max_batch_job_polling_size",
+            "gc_after",
+            "max_feedback_timeout",
+        }
+    )
+
     def __init__(self):
+        # Set defaults first
         self.identifier = str(uuid.uuid4())
         self.gc_after = 1000
         self.default_execution_strategy = "sequential"
@@ -40,6 +88,91 @@ class _Settings:
         self.persistence_id = None
         self.controller_retry_max_timeout = 60.0
         self.controller_retry_attempts = 5
+        # max_concurrent_actions: 0 is a sentinel for "use default of 25"
+        # This allows setup_semaphores() to apply the default
+        # if not explicitly set
+        self.max_concurrent_actions = 0
+        self.max_actions_semaphore = None
+        self.max_actions_timeout = 3600
+        self.max_back_pressure_timeout = 3600
+        self.max_reporting_queue_size = 50
+        self.max_batch_job_polling_size = 25
+
+        self.update_from_env()
+
+    def update_from_env(self):
+        """Update settings from environment variables (only if env var exists)
+
+        This is called:
+        1. On initialization to read initial env vars
+        2. After websocket handler sets new env vars
+        """
+        for attr_name, (env_key, type_class) in self.ENV_MAP.items():
+            env_value = os.environ.get(env_key)
+            if env_value is not None:
+                try:
+                    converted_value = self._convert_type(env_value, type_class)
+                    if (
+                        attr_name in self.POSITIVE_INT_SETTINGS
+                        and converted_value < 1
+                    ):
+                        logger.warning(
+                            "Env var %s=%s must be >= 1, using default %s",
+                            env_key,
+                            env_value,
+                            getattr(self, attr_name),
+                        )
+                        continue
+                    # Special validation for max_concurrent_actions:
+                    # 0 is valid (sentinel for "use default"),
+                    # but negative is not
+                    if (
+                        attr_name == "max_concurrent_actions"
+                        and converted_value < 0
+                    ):
+                        logger.warning(
+                            "Env var %s=%s must be >= 0, using default %s",
+                            env_key,
+                            env_value,
+                            getattr(self, attr_name),
+                        )
+                        continue
+                    setattr(self, attr_name, converted_value)
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        f"Failed to convert env var {env_key}={env_value!r} "
+                        f"to type {type_class.__name__}: {e}"
+                    )
+
+    @staticmethod
+    def _convert_to_list(value: Any) -> list:
+        if isinstance(value, list):
+            return value
+        if not isinstance(value, str):
+            return [value]
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return [value]
+        return parsed if isinstance(parsed, list) else [parsed]
+
+    @staticmethod
+    def _convert_type(value: Any, target_type: Type) -> Any:
+        if isinstance(value, target_type):
+            return value
+
+        if target_type == bool:
+            if isinstance(value, str):
+                return value.lower() in ("true", "1", "yes", "on")
+            return bool(value)
+        elif target_type == list:
+            return _Settings._convert_to_list(value)
+        elif target_type == int:
+            return int(value)
+        elif target_type == str:
+            return str(value)
+
+        return value
 
 
 settings = _Settings()

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -87,6 +87,14 @@ class RulebookNotFoundException(Exception):
     pass
 
 
+class TimedOutActionsException(Exception):
+    pass
+
+
+class TimedOutReportingException(Exception):
+    pass
+
+
 class SourcePluginNotFoundException(Exception):
     """Exception class for source plugin not found."""
 

--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import asyncio
 import json
 import logging
 import os
@@ -34,6 +33,7 @@ from ansible_rulebook.exception import (
     JobTemplateNotFoundException,
     WorkflowJobTemplateNotFoundException,
 )
+from ansible_rulebook.shared_job_monitor import SharedJobMonitor
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,9 @@ class JobTemplateRunner:
             os.environ.get("EDA_JOB_TEMPLATE_REFRESH_DELAY", 10.0)
         )
         self._session = None
+        self._raw_session = None
         self._controller_available = True
+        self._job_monitor = SharedJobMonitor(self)
         self._config_slug = self.LEGACY_CONFIG_SLUG
         self._unified_job_template_slug = self.LEGACY_UNIFIED_TEMPLATE_SLUG
         self._labels_slug = self.LEGACY_LABELS_SLUG
@@ -92,6 +94,9 @@ class JobTemplateRunner:
         if self._session:
             await self._session.close()
             self._session = None
+        if self._raw_session:
+            await self._raw_session.close()
+            self._raw_session = None
 
     def _create_session(self):
         if self._session is None:
@@ -101,6 +106,8 @@ class JobTemplateRunner:
                 headers=self._auth_headers(),
                 auth=self._basic_auth(),
             )
+            # Store the raw session for use in no-retry operations
+            self._raw_session = client_session
             retry_options = ExponentialRetry(
                 attempts=settings.controller_retry_attempts,
                 start_timeout=2.0,
@@ -182,6 +189,59 @@ class JobTemplateRunner:
                     e,
                 )
             logger.error(CLIENT_CONNECT_ERROR_STRING, str(e))  # NOSONAR
+            raise ControllerApiException(str(e))
+
+    async def _get_page_no_retry(self, href_slug: str, params: dict) -> dict:
+        """Get page without retry logic - used for polling operations.
+
+        For operations like job monitoring that happen frequently,
+        we don't want aggressive retries that could overload the controller.
+        Transient errors during polling will be handled by the next poll cycle.
+        """
+        url = urljoin(self.host, href_slug)
+        try:
+            self._create_session()
+            # Use the raw session directly to bypass retry logic
+            async with self._raw_session.get(
+                url, params=params, ssl=self._sslcontext
+            ) as response:
+                response.raise_for_status()
+                response_text = await response.text()
+                try:
+                    result = json.loads(response_text)
+                    logger.debug(
+                        "Successfully polled page from %s (status: %d)",
+                        url,
+                        response.status,
+                    )
+                    return result
+                except json.JSONDecodeError as json_err:
+                    logger.error(
+                        "Failed to parse JSON response from %s. "
+                        "Response status: %d, Response body: %s",
+                        url,
+                        response.status,
+                        response_text[:500],
+                    )
+                    raise ControllerApiException(
+                        f"Invalid JSON response from controller: {json_err}"
+                    )
+        except aiohttp.ClientResponseError as e:
+            logger.debug(
+                "Polling error at %s (will retry on next poll cycle). "
+                "Status: %s, Message: %s",
+                url,
+                e.status,
+                e.message,
+            )
+            raise ControllerApiException(str(e))
+        except (aiohttp.ClientError, ConnectionError) as e:
+            logger.debug(
+                "Polling connection error at %s "
+                "(will retry on next poll cycle): %s",
+                url,
+                str(e),
+            )
             raise ControllerApiException(str(e))
 
     async def get_config(self) -> dict:
@@ -428,9 +488,11 @@ class JobTemplateRunner:
     async def monitor_job(self, url) -> dict:
         """Monitor a running job until it reaches a completion status.
 
-        This method polls the controller for job status updates at regular
-        intervals until the job reaches a terminal state (successful, failed,
-        error, or canceled).
+        This method uses the shared batch monitor to efficiently poll
+        multiple jobs with fewer API calls. The monitor batches job IDs
+        into chunked requests and polls at regular intervals until each
+        job reaches a terminal state (successful, failed, error, or
+        canceled).
 
         Args:
             url: The job URL to monitor (can be a regular job or workflow job)
@@ -439,13 +501,8 @@ class JobTemplateRunner:
             dict: The final job status information when the job completes,
                 including status, artifacts, and other job metadata
         """
-        while True:
-            # fetch and process job status
-            json_body = await self._get_page(url, {})
-            if json_body["status"] in self.JOB_COMPLETION_STATUSES:
-                return json_body
-
-            await asyncio.sleep(self.refresh_delay)
+        future = await self._job_monitor.register_job(url)
+        return await future
 
     async def _launch(self, job_params: dict, url: str) -> dict:
         body = None

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -49,6 +49,7 @@ from ansible_rulebook.action.run_playbook import RunPlaybook
 from ansible_rulebook.action.run_workflow_template import RunWorkflowTemplate
 from ansible_rulebook.action.set_fact import SetFact
 from ansible_rulebook.action.shutdown import Shutdown as ShutdownAction
+from ansible_rulebook.back_pressure import BackPressureManager
 from ansible_rulebook.conf import settings
 from ansible_rulebook.exception import (
     ShutdownException,
@@ -119,6 +120,7 @@ class RuleSetRunner:
         self.event_counter = 0
         self.display = terminal.Display()
         self.locks = defaultdict(asyncio.Lock)
+        self.back_pressure_manager = BackPressureManager(event_log)
 
     async def run_ruleset(self):
         tasks = []
@@ -225,6 +227,7 @@ class RuleSetRunner:
         logger.info("Waiting for events, ruleset: %s", self.name)
         try:
             while True:
+                await self.back_pressure_manager.apply_all_back_pressure()
                 data = await self.ruleset_queue_plan.source_queue.get()
                 # Default to output events at debug level.
                 level = logging.DEBUG
@@ -459,7 +462,7 @@ class RuleSetRunner:
         )
 
         task = asyncio.create_task(
-            self._call_action(
+            self._call_action_with_semaphore(
                 metadata,
                 action.action,
                 MappingProxyType(action.action_args),
@@ -473,6 +476,38 @@ class RuleSetRunner:
         self.active_actions.add(task)
         task.add_done_callback(self._handle_action_completion)
         return task
+
+    async def _call_action_with_semaphore(
+        self,
+        metadata: Metadata,
+        action: str,
+        immutable_action_args: MappingProxyType,
+        variables: Dict,
+        inventory: str,
+        hosts: List,
+        rules_engine_result,
+    ) -> None:
+        if settings.max_actions_semaphore:
+            async with settings.max_actions_semaphore:
+                await self._call_action(
+                    metadata,
+                    action,
+                    immutable_action_args,
+                    variables,
+                    inventory,
+                    hosts,
+                    rules_engine_result,
+                )
+        else:
+            await self._call_action(
+                metadata,
+                action,
+                immutable_action_args,
+                variables,
+                inventory,
+                hosts,
+                rules_engine_result,
+            )
 
     async def _call_action(
         self,

--- a/ansible_rulebook/shared_job_monitor.py
+++ b/ansible_rulebook/shared_job_monitor.py
@@ -1,0 +1,366 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+
+from ansible_rulebook.conf import settings
+from ansible_rulebook.exception import ControllerApiException
+
+if TYPE_CHECKING:
+    from ansible_rulebook.job_template_runner import JobTemplateRunner
+
+logger = logging.getLogger(__name__)
+
+
+class SharedJobMonitor:
+    """Shared monitor that polls multiple jobs in batches.
+
+    Created as an instance variable on JobTemplateRunner so its lifecycle
+    is tied to the runner.  All calls to monitor_job on the same runner
+    share one polling loop, reducing API calls to the controller.
+
+    Benefits:
+    - Centralized polling logic
+    - Batch API support via id__in
+    - Better error handling across all jobs
+    - Reduced overhead from multiple asyncio tasks
+    - Natural cleanup when the runner is destroyed
+    """
+
+    def __init__(self, runner: "JobTemplateRunner"):
+        self._runner = runner
+        self._jobs: Dict[str, Dict[str, Any]] = {}
+        self._monitor_task = None
+        self._jobs_lock = asyncio.Lock()
+        self._total_jobs_monitored = 0
+        self._monitor_start_count = 0
+
+    @staticmethod
+    def _job_key(job_url: str) -> str:
+        """Derive a unique key from a job URL.
+
+        Uses the last two path segments (e.g. "jobs/123") so that
+        /jobs/123 and /workflow_jobs/123 are tracked separately.
+        """
+        parts = job_url.rstrip("/").split("/")
+        return "/".join(parts[-2:])
+
+    async def register_job(self, job_url: str) -> asyncio.Future:
+        """Register a job for monitoring and return a future.
+
+        Args:
+            job_url: The job URL to monitor
+
+        Returns:
+            asyncio.Future that resolves to the final job status dict
+        """
+        key = self._job_key(job_url)
+
+        async with self._jobs_lock:
+            if key in self._jobs:
+                logger.debug("Job %s already registered, reusing future", key)
+                return self._jobs[key]["future"]
+
+            future = asyncio.Future()
+            numeric_id = job_url.rstrip("/").split("/")[-1]
+            self._jobs[key] = {
+                "url": job_url,
+                "numeric_id": numeric_id,
+                "future": future,
+            }
+            self._total_jobs_monitored += 1
+
+            monitor_was_stopped = (
+                self._monitor_task is None or self._monitor_task.done()
+            )
+            if monitor_was_stopped:
+                self._monitor_start_count += 1
+                self._monitor_task = asyncio.create_task(self._monitor_loop())
+                logger.info(
+                    "Started shared job monitor loop (cycle #%d) - "
+                    "monitoring %d job(s)",
+                    self._monitor_start_count,
+                    len(self._jobs),
+                )
+            else:
+                logger.debug(
+                    "Registered job %s for batch monitoring (%d active jobs)",
+                    key,
+                    len(self._jobs),
+                )
+
+        return future
+
+    async def _monitor_loop(self):
+        """Main monitoring loop that polls all registered jobs."""
+        logger.info("Starting shared job monitor loop")
+
+        while True:
+            try:
+                await self._cleanup_stale_jobs()
+
+                async with self._jobs_lock:
+                    if not self._jobs:
+                        logger.info(
+                            "No more jobs to monitor, "
+                            "stopping monitor loop. "
+                            "Total monitored this cycle: %d",
+                            self._total_jobs_monitored,
+                        )
+                        self._monitor_task = None
+                        break
+
+                    jobs_to_check = list(self._jobs.items())
+
+                await self._poll_all_jobs(jobs_to_check)
+
+                if jobs_to_check:
+                    await asyncio.sleep(self._runner.refresh_delay)
+
+            except (
+                ControllerApiException,
+                OSError,
+                asyncio.TimeoutError,
+            ) as e:
+                logger.error(  # NOSONAR
+                    "Transient error in shared job monitor loop: %s",
+                    str(e),
+                )
+                await asyncio.sleep(5)
+            except Exception as e:
+                logger.error(  # NOSONAR
+                    "Non-transient error in shared job monitor loop: %s",
+                    str(e),
+                )
+                await self._fail_all_jobs(e)
+                break
+
+    async def _poll_all_jobs(
+        self, jobs_to_check: List[Tuple[str, Dict[str, Any]]]
+    ):
+        """Group jobs by type and poll each group."""
+        regular_jobs = {}
+        workflow_jobs = {}
+
+        for job_id, job_info in jobs_to_check:
+            if job_info["future"].done():
+                continue
+            if "workflow_jobs" in job_info["url"]:
+                workflow_jobs[job_id] = job_info
+            else:
+                regular_jobs[job_id] = job_info
+
+        api_prefix = self._runner._api_slug_prefix()
+
+        if regular_jobs:
+            await self._batch_poll_jobs(
+                regular_jobs, f"{api_prefix}jobs/", "jobs"
+            )
+
+        if workflow_jobs:
+            await self._batch_poll_jobs(
+                workflow_jobs,
+                f"{api_prefix}workflow_jobs/",
+                "workflow_jobs",
+            )
+
+    async def _batch_poll_jobs(
+        self, jobs: Dict[str, Dict[str, Any]], api_path: str, job_type: str
+    ):
+        """Poll multiple jobs in chunked batch API calls."""
+        if not jobs:
+            return
+
+        job_ids = list(jobs.keys())
+        chunk_size = settings.max_batch_job_polling_size
+        chunks = [
+            job_ids[i : i + chunk_size]
+            for i in range(0, len(job_ids), chunk_size)
+        ]
+
+        logger.debug(
+            "Batch polling %d %s in %d chunk(s) of up to %d",
+            len(job_ids),
+            job_type,
+            len(chunks),
+            chunk_size,
+        )
+
+        for chunk in chunks:
+            chunk_jobs = {jid: jobs[jid] for jid in chunk}
+            await self._poll_job_chunk(chunk_jobs, api_path, job_type)
+
+    async def _poll_job_chunk(
+        self, jobs: Dict[str, Dict[str, Any]], api_path: str, job_type: str
+    ):
+        """Poll a single chunk of jobs with one API call."""
+        numeric_ids = []
+        id_to_key = {}
+        for key, info in jobs.items():
+            nid = info["numeric_id"]
+            numeric_ids.append(nid)
+            id_to_key[nid] = key
+
+        # Include page_size to ensure all results come back in one page
+        # and avoid silent truncation if controller's default page size
+        # is smaller than our chunk size
+        params = {
+            "id__in": ",".join(numeric_ids),
+            "page_size": len(numeric_ids),
+        }
+        result = await self._runner._get_page_no_retry(api_path, params)
+
+        processed = 0
+        for job_data in result.get("results", []):
+            nid = str(job_data["id"])
+            key = id_to_key.get(nid)
+            if key and key in jobs:
+                processed += await self._process_poll_result(
+                    key, jobs[key], job_data
+                )
+
+        logger.debug(
+            "Batch poll chunk processed %d/%d %s",
+            processed,
+            len(numeric_ids),
+            job_type,
+        )
+
+    async def _process_poll_result(
+        self,
+        key: str,
+        job_info: Dict[str, Any],
+        job_data: dict,
+    ) -> int:
+        """Process a single job result from a poll response.
+
+        Returns 1 if the job was processed, 0 otherwise.
+        """
+        nid = str(job_data["id"])
+        status = job_data["status"]
+
+        if status not in self._runner.JOB_COMPLETION_STATUSES:
+            logger.debug("Job %s still running (status: %s)", nid, status)
+            return 1
+
+        async with self._jobs_lock:
+            if key in self._jobs and not job_info["future"].done():
+                job_info["future"].set_result(job_data)
+                del self._jobs[key]
+                self._log_completion(nid, status)
+                return 1
+        return 0
+
+    def _log_completion(self, job_id: str, status: str) -> None:
+        """Log job completion at the appropriate level."""
+        remaining = len(self._jobs)
+        if status == "successful":
+            logger.debug(
+                "Job %s completed successfully (%d jobs remaining)",
+                job_id,
+                remaining,
+            )
+        elif status in ["failed", "error"]:
+            logger.error(
+                "Job %s completed with status: %s (%d jobs remaining)",
+                job_id,
+                status,
+                remaining,
+            )
+        elif status == "canceled":
+            logger.warning(
+                "Job %s was canceled (%d jobs remaining)",
+                job_id,
+                remaining,
+            )
+
+    async def _cleanup_stale_jobs(self):
+        """Remove jobs with cancelled or errored futures."""
+        async with self._jobs_lock:
+            stale_jobs = [
+                job_id
+                for job_id, job_info in self._jobs.items()
+                if job_info["future"].done()
+                and (
+                    job_info["future"].cancelled()
+                    or job_info["future"].exception() is not None
+                )
+            ]
+
+            for job_id in stale_jobs:
+                job_info = self._jobs[job_id]
+                if job_info["future"].cancelled():
+                    logger.debug(
+                        "Removing cancelled job %s from monitor", job_id
+                    )
+                else:
+                    logger.warning(
+                        "Removing job %s with error from monitor: %s",
+                        job_id,
+                        job_info["future"].exception(),
+                    )
+                del self._jobs[job_id]
+
+    async def _fail_all_jobs(self, exc: Exception):
+        """Resolve all pending job futures with the exception."""
+        async with self._jobs_lock:
+            for _key, job_info in self._jobs.items():
+                if not job_info["future"].done():
+                    job_info["future"].set_exception(
+                        ControllerApiException(str(exc))
+                    )
+            self._jobs.clear()
+            self._monitor_task = None
+
+    async def unregister_job(self, job_url: str):
+        """Manually unregister a job (e.g., if cancelled)."""
+        key = self._job_key(job_url)
+        async with self._jobs_lock:
+            if key in self._jobs:
+                del self._jobs[key]
+                logger.debug(
+                    "Unregistered job %s (%d jobs remaining)",
+                    key,
+                    len(self._jobs),
+                )
+
+    def get_monitored_job_count(self) -> int:
+        return len(self._jobs)
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {
+            "active_jobs": len(self._jobs),
+            "total_jobs_monitored": self._total_jobs_monitored,
+            "monitor_cycles": self._monitor_start_count,
+            "monitor_running": self._monitor_task is not None
+            and not self._monitor_task.done(),
+        }
+
+    def is_healthy(self) -> bool:
+        has_jobs = len(self._jobs) > 0
+        monitor_running = (
+            self._monitor_task is not None and not self._monitor_task.done()
+        )
+
+        if has_jobs and not monitor_running:
+            logger.error(
+                "Monitor unhealthy: %d jobs registered "
+                "but monitor not running",
+                len(self._jobs),
+            )
+            return False
+
+        return True

--- a/ansible_rulebook/util.py
+++ b/ansible_rulebook/util.py
@@ -25,6 +25,7 @@ import sys
 import tempfile
 import typing
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from urllib.parse import urlparse
 
@@ -420,6 +421,54 @@ def validate_url(url: str, url_type: str) -> bool:
     if url_type == "controller":
         return res.scheme in ["http", "https"] and bool(res.netloc)
     return res.scheme in ["ws", "wss"] and bool(res.netloc)
+
+
+def validate_file_path(file_path: str, file_description: str = "File") -> str:
+    """Validate file path to prevent path traversal attacks.
+
+    This function validates user-provided file paths to ensure they are safe
+    to open. It prevents path traversal attacks and validates that the file
+    exists and is readable.
+
+    Args:
+        file_path: The file path to validate
+        file_description: Description of the file type for error messages
+
+    Returns:
+        The resolved absolute path if valid
+
+    Raises:
+        ValueError: If the path is invalid, doesn't exist, or attempts
+                   path traversal
+    """
+    if not file_path:
+        raise ValueError(f"{file_description} path cannot be empty")
+
+    # Check for null bytes (path injection attempt) before Path.resolve()
+    if "\x00" in file_path:
+        raise ValueError(f"{file_description} path contains null bytes")
+
+    try:
+        # Resolve to absolute path and resolve any symlinks
+        resolved_path = Path(file_path).resolve()
+
+        # Check if path exists
+        if not resolved_path.exists():
+            raise ValueError(f"{file_description} does not exist: {file_path}")
+
+        # Check if it's a file (not a directory)
+        if not resolved_path.is_file():
+            raise ValueError(
+                f"{file_description} path is not a file: {file_path}"
+            )
+
+        return str(resolved_path)
+
+    except (OSError, RuntimeError) as e:
+        raise ValueError(
+            f"Invalid {file_description.lower()} path: {file_path}. "
+            f"Error: {e}"
+        )
 
 
 # If the following values exist in a key,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -21,6 +21,9 @@ The `ansible-rulebook` CLI supports the following options:
                         [--persistence-id PERSISTENCE_ID]
                         [--controller-retry-max-timeout CONTROLLER_RETRY_MAX_TIMEOUT]
                         [--controller-retry-attempts CONTROLLER_RETRY_ATTEMPTS]
+                        [-m MAX_CONCURRENT_ACTIONS] [--max-back-pressure-timeout MAX_BACK_PRESSURE_TIMEOUT]
+                        [--max-reporting-queue-size MAX_REPORTING_QUEUE_SIZE]
+                        [--max-batch-job-polling-size MAX_BATCH_JOB_POLLING_SIZE]
 
     optional arguments:
     -h, --help            show this help message and exit
@@ -81,6 +84,14 @@ The `ansible-rulebook` CLI supports the following options:
                             Maximum backoff time in seconds for controller API retries on transient errors (429/502/503/504). Default is 60. Can also be passed via env var EDA_CONTROLLER_RETRY_MAX_TIMEOUT
     --controller-retry-attempts CONTROLLER_RETRY_ATTEMPTS
                             Number of retry attempts for controller API calls on transient errors. Default is 5. Can also be passed via env var EDA_CONTROLLER_RETRY_ATTEMPTS
+    -m MAX_CONCURRENT_ACTIONS, --max-concurrent-actions MAX_CONCURRENT_ACTIONS
+                            Maximum number of concurrent actions for parallel execution strategy. Default is 25. Can also be passed via env var EDA_MAX_CONCURRENT_ACTIONS
+    --max-back-pressure-timeout MAX_BACK_PRESSURE_TIMEOUT
+                            Seconds to wait for actions or reporting queue to drain before aborting. Default is 3600. Can also be passed via env var EDA_MAX_BACK_PRESSURE_TIMEOUT
+    --max-reporting-queue-size MAX_REPORTING_QUEUE_SIZE
+                            Maximum backlog of reporting objects to flush to EDA Server. Default is 50. Can also be passed via env var EDA_MAX_REPORTING_QUEUE_SIZE
+    --max-batch-job-polling-size MAX_BATCH_JOB_POLLING_SIZE
+                            Maximum number of jobs per batch polling request to the controller. Default is 25. Can also be passed via env var EDA_MAX_BATCH_JOB_POLLING_SIZE
 
 To get help from `ansible-rulebook` run the following:
 

--- a/tests/data/awx_test_data.py
+++ b/tests/data/awx_test_data.py
@@ -112,12 +112,14 @@ JOB_TEMPLATE_POST_RESPONSE = {
 }
 
 JOB_1_RUNNING = dict(
+    id=JOB_ID_1,
     job=JOB_ID_1,
     url=JOB_1_SLUG,
     status=JOB_STATUS_RUNNING,
 )
 
 JOB_1_SUCCESSFUL = dict(
+    id=JOB_ID_1,
     job=JOB_ID_1,
     url=JOB_1_SLUG,
     status=JOB_STATUS_SUCCESSFUL,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import json
+import re
 
 import pytest
 import pytest_asyncio
@@ -55,6 +56,24 @@ from .data.awx_test_data import (
 )
 
 CONFIG_SLUG = "api/v2/config/"
+BATCH_JOBS_SLUG = "api/v2/jobs/"
+
+
+def add_batch_job_monitor_responses(mocked, host, *job_responses):
+    """Mock the batch polling endpoint used by SharedJobMonitor.
+
+    Each job_response is a dict (e.g. JOB_1_RUNNING, JOB_1_SUCCESSFUL)
+    that will be returned as a single-item batch result per poll cycle.
+    Uses regex to match the URL with any query params (id__in=...).
+    """
+    base = re.escape(f"{host}{BATCH_JOBS_SLUG}")
+    pattern = re.compile(base + r"\?.*\bid__in=")
+    for job_data in job_responses:
+        mocked.get(
+            pattern,
+            status=200,
+            body=json.dumps({"count": 1, "results": [job_data]}),
+        )
 
 
 @pytest_asyncio.fixture
@@ -258,15 +277,11 @@ async def test_run_job_template(
             status=200,
             body=json.dumps(JOB_TEMPLATE_POST_RESPONSE),
         )
-        mocked.get(
-            f"{new_job_template_runner.host}{JOB_1_SLUG}",
-            status=200,
-            body=json.dumps(JOB_1_RUNNING),
-        )
-        mocked.get(
-            f"{new_job_template_runner.host}{JOB_1_SLUG}",
-            status=200,
-            body=json.dumps(JOB_1_SUCCESSFUL),
+        add_batch_job_monitor_responses(
+            mocked,
+            new_job_template_runner.host,
+            JOB_1_RUNNING,
+            JOB_1_SUCCESSFUL,
         )
         if "exception" in fail_label:
             with pytest.raises(ControllerApiException):
@@ -324,15 +339,11 @@ async def test_run_workflow_template(
             status=200,
             body=json.dumps(JOB_TEMPLATE_POST_RESPONSE),
         )
-        mocked.get(
-            f"{new_job_template_runner.host}{JOB_1_SLUG}",
-            status=200,
-            body=json.dumps(JOB_1_RUNNING),
-        )
-        mocked.get(
-            f"{new_job_template_runner.host}{JOB_1_SLUG}",
-            status=200,
-            body=json.dumps(JOB_1_SUCCESSFUL),
+        add_batch_job_monitor_responses(
+            mocked,
+            new_job_template_runner.host,
+            JOB_1_RUNNING,
+            JOB_1_SUCCESSFUL,
         )
 
         data = await new_job_template_runner.run_workflow_job_template(
@@ -782,15 +793,26 @@ async def test_get_job_url_from_label_invalid_type(new_job_template_runner):
 async def test_monitor_job_retries_on_502(
     new_job_template_runner, monkeypatch
 ):
-    """Verify monitor_job retries on 502 and succeeds after recovery."""
+    """Verify monitor_job retries on 502 and succeeds after recovery.
+
+    The SharedJobMonitor polls the batch endpoint (api/v2/jobs/?id__in=...).
+    When a poll fails, the monitor retries on the next cycle.
+    """
     monkeypatch.setattr(settings, "controller_retry_attempts", 3)
     monkeypatch.setattr(settings, "controller_retry_max_timeout", 0.0)
+    batch_pattern = re.compile(
+        re.escape(f"{new_job_template_runner.host}{BATCH_JOBS_SLUG}")
+        + r"\?.*\bid__in="
+    )
     with aioresponses() as mocked:
-        url = f"{new_job_template_runner.host}{JOB_1_SLUG}"
-        mocked.get(url, status=502)
-        mocked.get(url, status=502)
-        mocked.get(url, status=200, body=json.dumps(JOB_1_RUNNING))
-        mocked.get(url, status=200, body=json.dumps(JOB_1_SUCCESSFUL))
+        mocked.get(batch_pattern, status=502)
+        mocked.get(batch_pattern, status=502)
+        add_batch_job_monitor_responses(
+            mocked,
+            new_job_template_runner.host,
+            JOB_1_RUNNING,
+            JOB_1_SUCCESSFUL,
+        )
 
         result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
         assert result["status"] == "successful"
@@ -800,16 +822,28 @@ async def test_monitor_job_retries_on_502(
 async def test_monitor_job_raises_after_max_retries(
     new_job_template_runner, monkeypatch
 ):
-    """Verify monitor_job raises ControllerApiException after retries."""
+    """Verify monitor_job eventually completes even after transient errors.
+
+    The SharedJobMonitor catches polling errors and retries on the next
+    cycle rather than raising immediately, so we verify it recovers.
+    """
     monkeypatch.setattr(settings, "controller_retry_attempts", 3)
     monkeypatch.setattr(settings, "controller_retry_max_timeout", 0.0)
+    batch_pattern = re.compile(
+        re.escape(f"{new_job_template_runner.host}{BATCH_JOBS_SLUG}")
+        + r"\?.*\bid__in="
+    )
     with aioresponses() as mocked:
-        url = f"{new_job_template_runner.host}{JOB_1_SLUG}"
-        for _ in range(5):
-            mocked.get(url, status=502)
+        for _ in range(3):
+            mocked.get(batch_pattern, status=502)
+        add_batch_job_monitor_responses(
+            mocked,
+            new_job_template_runner.host,
+            JOB_1_SUCCESSFUL,
+        )
 
-        with pytest.raises(ControllerApiException):
-            await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        assert result["status"] == "successful"
 
 
 @pytest.mark.asyncio
@@ -910,3 +944,233 @@ async def test_create_obj_already_exists_returns_retry(
         )
         assert result is None
         assert retry is True
+
+
+# Shared monitor and back pressure tests
+
+
+@pytest.mark.asyncio
+async def test_retry_on_503_service_unavailable(new_job_template_runner):
+    """Test that 503 errors are retried and eventually succeed."""
+    text_success = json.dumps(dict(version="4.4.1"))
+
+    with aioresponses() as mocked:
+        # First attempt: 503 Service Unavailable
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=503,
+            body="Service Unavailable",
+        )
+        # Second attempt: Success
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=200,
+            body=text_success,
+        )
+
+        data = await new_job_template_runner.get_config()
+        assert data["version"] == "4.4.1"
+
+
+@pytest.mark.asyncio
+async def test_retry_on_429_rate_limit(new_job_template_runner):
+    """Test that 429 rate limit errors are retried and eventually succeed."""
+    text_success = json.dumps(dict(version="4.4.1"))
+
+    with aioresponses() as mocked:
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=429,
+            body="Too Many Requests",
+        )
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=200,
+            body=text_success,
+        )
+
+        data = await new_job_template_runner.get_config()
+        assert data["version"] == "4.4.1"
+
+
+@pytest.mark.asyncio
+async def test_retry_on_502_bad_gateway(new_job_template_runner):
+    """Test that 502 Bad Gateway errors are retried and eventually succeed."""
+    text_success = json.dumps(dict(version="4.4.1"))
+
+    with aioresponses() as mocked:
+        # First attempt: 502 Bad Gateway
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=502,
+            body="Bad Gateway",
+        )
+        # Second attempt: Success
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=200,
+            body=text_success,
+        )
+
+        data = await new_job_template_runner.get_config()
+        assert data["version"] == "4.4.1"
+
+
+@pytest.mark.asyncio
+async def test_retry_on_504_gateway_timeout(new_job_template_runner):
+    """Test that 504 errors are retried and succeed."""
+    text_success = json.dumps(dict(version="4.4.1"))
+
+    with aioresponses() as mocked:
+        # First attempt: 504 Gateway Timeout
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=504,
+            body="Gateway Timeout",
+        )
+        # Second attempt: Success
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=200,
+            body=text_success,
+        )
+
+        data = await new_job_template_runner.get_config()
+        assert data["version"] == "4.4.1"
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_raises_exception(
+    new_job_template_runner, monkeypatch
+):
+    """Test that after max retries are exhausted, exception is raised."""
+    monkeypatch.setattr(settings, "controller_retry_attempts", 3)
+    with aioresponses() as mocked:
+        # Mock consecutive 503 errors (more than 3 attempts)
+        for _ in range(5):
+            mocked.get(
+                f"{new_job_template_runner.host}{CONFIG_SLUG}",
+                status=503,
+                body="Service Unavailable",
+            )
+
+        with pytest.raises(ControllerApiException):
+            await new_job_template_runner.get_config()
+
+
+@pytest.mark.asyncio
+async def test_retry_on_post_request_launch(new_job_template_runner):
+    """Test that POST requests (job launch) also retry on 503 errors."""
+    with aioresponses() as mocked:
+        add_job_templates_pages(
+            mocked,
+            new_job_template_runner.host,
+            UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE_NO_LABELS,
+            UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE_NO_LABELS,
+        )
+
+        # First POST attempt: 503 Service Unavailable
+        mocked.post(
+            f"{new_job_template_runner.host}{JOB_TEMPLATE_1_LAUNCH_SLUG}",
+            status=503,
+            body="Service Unavailable",
+        )
+        # Second POST attempt: Success
+        mocked.post(
+            f"{new_job_template_runner.host}{JOB_TEMPLATE_1_LAUNCH_SLUG}",
+            status=200,
+            body=json.dumps(JOB_TEMPLATE_POST_RESPONSE),
+        )
+
+        # Mock job monitoring via batch endpoint
+        add_batch_job_monitor_responses(
+            mocked,
+            new_job_template_runner.host,
+            JOB_1_SUCCESSFUL,
+        )
+
+        data = await new_job_template_runner.run_job_template(
+            JOB_TEMPLATE_NAME_1, ORGANIZATION_NAME, {"a": 1}
+        )
+        assert data["status"] == "successful"
+
+
+@pytest.mark.asyncio
+async def test_multiple_retries_before_success(new_job_template_runner):
+    """Test that multiple retries work before eventual success."""
+    text_success = json.dumps(dict(version="4.4.1"))
+
+    with aioresponses() as mocked:
+        # First attempt: 503
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=503,
+            body="Service Unavailable",
+        )
+        # Second attempt: 502
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=502,
+            body="Bad Gateway",
+        )
+        # Third attempt: Success
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=200,
+            body=text_success,
+        )
+
+        data = await new_job_template_runner.get_config()
+        assert data["version"] == "4.4.1"
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_error_fails_immediately(new_job_template_runner):
+    """Test that non-retryable errors fail immediately."""
+    with aioresponses() as mocked:
+        # 400 Bad Request should not be retried
+        mocked.get(
+            f"{new_job_template_runner.host}{CONFIG_SLUG}",
+            status=400,
+            body="Bad Request",
+        )
+
+        with pytest.raises(ControllerApiException):
+            await new_job_template_runner.get_config()
+
+
+@pytest.mark.asyncio
+async def test_retry_on_workflow_launch(new_job_template_runner):
+    """Test that workflow launches also retry on 503 errors."""
+    with aioresponses() as mocked:
+        add_job_templates_pages(
+            mocked,
+            new_job_template_runner.host,
+            UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE_NO_LABELS,
+            UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE_NO_LABELS,
+        )
+
+        # First POST attempt: 503 Service Unavailable
+        mocked.post(
+            f"{new_job_template_runner.host}{JOB_TEMPLATE_2_LAUNCH_SLUG}",
+            status=503,
+            body="Service Unavailable",
+        )
+        # Second POST attempt: Success
+        mocked.post(
+            f"{new_job_template_runner.host}{JOB_TEMPLATE_2_LAUNCH_SLUG}",
+            status=200,
+            body=json.dumps(JOB_TEMPLATE_POST_RESPONSE),
+        )
+
+        # Mock job monitoring via batch endpoint
+        add_batch_job_monitor_responses(
+            mocked,
+            new_job_template_runner.host,
+            JOB_1_SUCCESSFUL,
+        )
+
+        data = await new_job_template_runner.run_workflow_job_template(
+            JOB_TEMPLATE_NAME_1, ORGANIZATION_NAME, {"a": 1}, []
+        )
+        assert data["status"] == "successful"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -913,10 +913,11 @@ async def test_30_run_module_missing():
 
     event = event_log.get_nowait()
     assert event["type"] == "Job", "0"
-    for i in range(10):
-        assert event_log.get_nowait()["type"] == "AnsibleEvent", f"0.{i}"
+    while True:
+        event = event_log.get_nowait()
+        if event["type"] != "AnsibleEvent":
+            break
 
-    event = event_log.get_nowait()
     assert event["type"] == "Action", "1"
     assert event["action"] == "run_module", "2"
 

--- a/tests/test_shared_job_monitor.py
+++ b/tests/test_shared_job_monitor.py
@@ -1,0 +1,719 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for SharedJobMonitor - centralized batch job monitoring."""
+
+import asyncio
+import json
+import re
+
+import pytest
+import pytest_asyncio
+from aioresponses import aioresponses
+
+from .data.awx_test_data import JOB_1_RUNNING, JOB_1_SLUG, JOB_1_SUCCESSFUL
+
+POLL_INTERVAL = 0.01
+POLL_TIMEOUT = 5.0
+
+
+async def _wait_for(predicate, timeout=POLL_TIMEOUT):
+    """Poll predicate until truthy or timeout."""
+
+    async def _poll():
+        while not predicate():
+            await asyncio.sleep(POLL_INTERVAL)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+def batch_url(host, path="api/v2/jobs/"):
+    """Regex pattern matching a batch polling URL with id__in param."""
+    base = re.escape(f"{host}{path}")
+    return re.compile(base + r"\?.*\bid__in=")
+
+
+@pytest_asyncio.fixture
+async def new_job_template_runner(monkeypatch):
+    from ansible_rulebook.conf import settings
+    from ansible_rulebook.job_template_runner import JobTemplateRunner
+
+    monkeypatch.setattr(settings, "controller_retry_max_timeout", 0.0)
+    obj = JobTemplateRunner(
+        host="https://example.com",
+        token="DUMMY",
+    )
+    obj.refresh_delay = 0.0
+    yield obj
+    await obj.close_session()
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_single_job(new_job_template_runner):
+    """Test that shared monitor works for a single job."""
+    with aioresponses() as mocked:
+        # Job is running initially
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_RUNNING]}),
+        )
+        # Job completes
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_SUCCESSFUL]}),
+        )
+
+        result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        assert result["status"] == "successful"
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_multiple_jobs_concurrently(
+    new_job_template_runner,
+):
+    """Test shared monitor with multiple concurrent jobs."""
+    job_2_slug = "api/v2/jobs/124/"
+    job_3_slug = "api/v2/jobs/125/"
+
+    with aioresponses() as mocked:
+        # First batch poll: all running
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps(
+                {
+                    "count": 3,
+                    "results": [
+                        {**JOB_1_RUNNING, "id": 909},
+                        {**JOB_1_RUNNING, "id": 124},
+                        {**JOB_1_RUNNING, "id": 125},
+                    ],
+                }
+            ),
+        )
+        # Second batch poll: all successful
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps(
+                {
+                    "count": 3,
+                    "results": [
+                        {**JOB_1_SUCCESSFUL, "id": 909},
+                        {**JOB_1_SUCCESSFUL, "id": 124},
+                        {**JOB_1_SUCCESSFUL, "id": 125},
+                    ],
+                }
+            ),
+        )
+
+        results = await asyncio.gather(
+            new_job_template_runner.monitor_job(JOB_1_SLUG),
+            new_job_template_runner.monitor_job(job_2_slug),
+            new_job_template_runner.monitor_job(job_3_slug),
+        )
+
+        assert all(r["status"] == "successful" for r in results)
+        assert results[0]["id"] == 909
+        assert results[1]["id"] == 124
+        assert results[2]["id"] == 125
+
+        # Verify all jobs were cleaned up from monitor
+        assert (
+            new_job_template_runner._job_monitor.get_monitored_job_count() == 0
+        )
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_handles_duplicate_registration(
+    new_job_template_runner,
+):
+    """Test that registering the same job twice returns the same future."""
+    monitor = new_job_template_runner._job_monitor
+
+    with aioresponses() as mocked:
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_SUCCESSFUL]}),
+        )
+
+        # Register the same job twice
+        future1 = await monitor.register_job(JOB_1_SLUG)
+        future2 = await monitor.register_job(JOB_1_SLUG)
+
+        # Should be the same future
+        assert future1 is future2
+
+        # Both should resolve to the same result
+        result = await future1
+        assert result["status"] == "successful"
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_batch_polling(new_job_template_runner):
+    """Test that batch polling uses correct API path for multiple jobs."""
+
+    job_2_slug = "api/v2/jobs/124/"
+    job_3_slug = "api/v2/jobs/125/"
+
+    # Expected batch API response
+    batch_response = {
+        "count": 3,
+        "results": [
+            {**JOB_1_RUNNING, "id": 909},
+            {**JOB_1_RUNNING, "id": 124},
+            {**JOB_1_SUCCESSFUL, "id": 125},
+        ],
+    }
+
+    with aioresponses() as mocked:
+        # Mock batch polling endpoint
+        # Should use api/v2/jobs/ with id__in parameter
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps(batch_response),
+        )
+
+        # Second poll - remaining jobs
+        batch_response_2 = {
+            "count": 2,
+            "results": [
+                {**JOB_1_SUCCESSFUL, "id": 909},
+                {**JOB_1_SUCCESSFUL, "id": 124},
+            ],
+        }
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps(batch_response_2),
+        )
+
+        # Monitor all 3 jobs concurrently
+        results = await asyncio.gather(
+            new_job_template_runner.monitor_job(JOB_1_SLUG),
+            new_job_template_runner.monitor_job(job_2_slug),
+            new_job_template_runner.monitor_job(job_3_slug),
+        )
+
+        assert all(r["status"] == "successful" for r in results)
+        assert results[0]["id"] == 909
+        assert results[1]["id"] == 124
+        assert results[2]["id"] == 125
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_batch_polling_gateway_path(
+    new_job_template_runner,
+):
+    """Test that batch polling works with gateway URL format."""
+
+    # Simulate gateway setup
+    new_job_template_runner.host = "https://example.com/api/controller/"
+    job_1_slug = "v2/jobs/123/"
+    job_2_slug = "v2/jobs/124/"
+
+    batch_response = {
+        "count": 2,
+        "results": [
+            {**JOB_1_SUCCESSFUL, "id": 123, "url": job_1_slug},
+            {**JOB_1_SUCCESSFUL, "id": 124, "url": job_2_slug},
+        ],
+    }
+
+    with aioresponses() as mocked:
+        # Should use v2/jobs/ (not api/v2/jobs/) for gateway
+        mocked.get(
+            batch_url(new_job_template_runner.host, "v2/jobs/"),
+            status=200,
+            body=json.dumps(batch_response),
+        )
+
+        # Monitor both jobs
+        results = await asyncio.gather(
+            new_job_template_runner.monitor_job(job_1_slug),
+            new_job_template_runner.monitor_job(job_2_slug),
+        )
+
+        assert all(r["status"] == "successful" for r in results)
+        assert results[0]["id"] == 123
+        assert results[1]["id"] == 124
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_stats(new_job_template_runner):
+    """Test that SharedJobMonitor.get_stats() returns accurate statistics."""
+
+    with aioresponses() as mocked:
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_SUCCESSFUL]}),
+        )
+
+        # Get initial stats
+        initial_stats = new_job_template_runner._job_monitor.get_stats()
+
+        # Register and monitor a job
+        result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        assert result["status"] == "successful"
+
+        # Check final stats
+        final_stats = new_job_template_runner._job_monitor.get_stats()
+        assert final_stats["active_jobs"] == 0  # Job completed
+        assert (
+            final_stats["total_jobs_monitored"]
+            >= initial_stats["total_jobs_monitored"]
+        )
+        assert final_stats["monitor_cycles"] >= initial_stats["monitor_cycles"]
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_get_monitored_job_count(new_job_template_runner):
+    """Test that get_monitored_job_count returns correct count."""
+
+    job_2_slug = "api/v2/jobs/124/"
+
+    with aioresponses() as mocked:
+        # Jobs that stay running for this test
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps(
+                {
+                    "count": 2,
+                    "results": [
+                        {**JOB_1_RUNNING, "id": 909},
+                        {**JOB_1_RUNNING, "id": 124},
+                    ],
+                }
+            ),
+            repeat=True,
+        )
+
+        # Start monitoring (don't await - let them run in background)
+        task1 = asyncio.create_task(
+            new_job_template_runner.monitor_job(JOB_1_SLUG)
+        )
+        task2 = asyncio.create_task(
+            new_job_template_runner.monitor_job(job_2_slug)
+        )
+
+        # Wait for monitor to register both jobs
+        monitor = new_job_template_runner._job_monitor
+        await _wait_for(lambda: monitor.get_monitored_job_count() >= 2)
+        assert monitor.get_monitored_job_count() == 2
+
+        # Cancel tasks to cleanup
+        task1.cancel()
+        task2.cancel()
+        try:
+            await task1
+        except asyncio.CancelledError:
+            pass
+        try:
+            await task2
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_unregister_job(new_job_template_runner):
+    """Test manual unregistration of a job."""
+
+    with aioresponses() as mocked:
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_RUNNING]}),
+            repeat=True,
+        )
+
+        # Register job
+        monitor = new_job_template_runner._job_monitor
+        await monitor.register_job(JOB_1_SLUG)
+        assert monitor.get_monitored_job_count() == 1
+
+        # Unregister job
+        await monitor.unregister_job(JOB_1_SLUG)
+        assert monitor.get_monitored_job_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_is_healthy(new_job_template_runner):
+    """Test health check in various states."""
+
+    # Initially healthy (no jobs, no monitor)
+    assert new_job_template_runner._job_monitor.is_healthy()
+
+    with aioresponses() as mocked:
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_SUCCESSFUL]}),
+        )
+
+        # Monitor a job
+        result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        assert result["status"] == "successful"
+
+        # Still healthy after job completes
+        assert new_job_template_runner._job_monitor.is_healthy()
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_cleanup_cancelled_jobs(new_job_template_runner):
+    """Test that cancelled futures are cleaned up properly."""
+
+    with aioresponses() as mocked:
+        # Job stays running
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_RUNNING]}),
+            repeat=True,
+        )
+
+        # Start monitoring but cancel immediately
+        task = asyncio.create_task(
+            new_job_template_runner.monitor_job(JOB_1_SLUG)
+        )
+        monitor = new_job_template_runner._job_monitor
+        await _wait_for(lambda: monitor.get_monitored_job_count() >= 1)
+        initial_count = monitor.get_monitored_job_count()
+        assert initial_count >= 1
+
+        # Cancel the task
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # Wait for cleanup to run
+        await _wait_for(
+            lambda: monitor.get_monitored_job_count() < initial_count
+        )
+        assert (
+            new_job_template_runner._job_monitor.get_monitored_job_count()
+            < initial_count
+        )
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_batch_polling_mixed_job_types(
+    new_job_template_runner,
+):
+    """Test batch polling with both regular jobs and workflow jobs."""
+    regular_job_slug = "api/v2/jobs/123/"
+    workflow_job_slug = "api/v2/workflow_jobs/456/"
+
+    workflow_job_successful = {
+        "id": 456,
+        "status": "successful",
+        "url": workflow_job_slug,
+        "artifacts": {"result": "ok"},
+    }
+
+    with aioresponses() as mocked:
+        # Batch response for regular jobs
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps(
+                {"count": 1, "results": [{**JOB_1_SUCCESSFUL, "id": 123}]}
+            ),
+        )
+
+        # Batch response for workflow jobs
+        mocked.get(
+            batch_url(new_job_template_runner.host, "api/v2/workflow_jobs/"),
+            status=200,
+            body=json.dumps(
+                {"count": 1, "results": [workflow_job_successful]}
+            ),
+        )
+
+        # Monitor both types concurrently
+        results = await asyncio.gather(
+            new_job_template_runner.monitor_job(regular_job_slug),
+            new_job_template_runner.monitor_job(workflow_job_slug),
+        )
+
+        assert results[0]["id"] == 123
+        assert results[0]["status"] == "successful"
+        assert results[1]["id"] == 456
+        assert results[1]["status"] == "successful"
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_batch_polling_retries_on_error(
+    new_job_template_runner,
+):
+    """Test that batch polling retries via the monitor loop on error."""
+    with aioresponses() as mocked:
+        # First batch poll fails (transient error)
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=500,
+            body="Internal Server Error",
+        )
+
+        # Second batch poll succeeds
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_SUCCESSFUL]}),
+        )
+
+        result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        assert result["status"] == "successful"
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_empty_batch_results(new_job_template_runner):
+    """Test handling of empty batch results (jobs not in response)."""
+    with aioresponses() as mocked:
+        # First poll: empty results
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 0, "results": []}),
+        )
+
+        # Second poll: job appears and completes
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [JOB_1_SUCCESSFUL]}),
+        )
+
+        # Should eventually complete
+        result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        assert result["status"] == "successful"
+
+
+@pytest.mark.asyncio
+async def test_monitor_job_with_failed_status_logged(
+    new_job_template_runner, caplog
+):
+    """Test that failed jobs are properly logged at ERROR level."""
+    job_failed = {
+        "id": 909,
+        "status": "failed",
+        "url": JOB_1_SLUG,
+        "artifacts": {},
+        "created": "2024-01-01T00:00:00Z",
+    }
+
+    with aioresponses() as mocked:
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [job_failed]}),
+        )
+
+        result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        assert result["status"] == "failed"
+
+    error_msgs = [
+        r
+        for r in caplog.records
+        if r.levelname == "ERROR" and "failed" in r.message
+    ]
+    assert len(error_msgs) >= 1
+
+
+@pytest.mark.asyncio
+async def test_monitor_job_with_canceled_status_logged(
+    new_job_template_runner, caplog
+):
+    """Test that canceled jobs are properly logged at WARNING level."""
+    job_canceled = {
+        "id": 909,
+        "status": "canceled",
+        "url": JOB_1_SLUG,
+        "artifacts": {},
+        "created": "2024-01-01T00:00:00Z",
+    }
+
+    with aioresponses() as mocked:
+        mocked.get(
+            batch_url(new_job_template_runner.host),
+            status=200,
+            body=json.dumps({"count": 1, "results": [job_canceled]}),
+        )
+
+        result = await new_job_template_runner.monitor_job(JOB_1_SLUG)
+        assert result["status"] == "canceled"
+
+    warning_msgs = [
+        r
+        for r in caplog.records
+        if r.levelname == "WARNING" and "canceled" in r.message
+    ]
+    assert len(warning_msgs) >= 1
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_chunked_batch_polling(new_job_template_runner):
+    """Test that batch polling chunks jobs by max_batch_job_polling_size.
+
+    With 4 jobs and a batch size of 2, the monitor should make 2 API calls
+    per poll cycle, each with 2 job IDs in the id__in parameter.
+    """
+    from unittest.mock import patch
+
+    job_slugs = [f"api/v2/jobs/{i}/" for i in range(123, 127)]
+
+    with patch(
+        "ansible_rulebook.shared_job_monitor.settings"
+    ) as mock_settings:
+        mock_settings.max_batch_job_polling_size = 2
+
+        with aioresponses() as mocked:
+            # Chunk 1: jobs 123, 124
+            mocked.get(
+                batch_url(new_job_template_runner.host),
+                status=200,
+                body=json.dumps(
+                    {
+                        "count": 2,
+                        "results": [
+                            {**JOB_1_SUCCESSFUL, "id": 123},
+                            {**JOB_1_SUCCESSFUL, "id": 124},
+                        ],
+                    }
+                ),
+            )
+            # Chunk 2: jobs 125, 126
+            mocked.get(
+                batch_url(new_job_template_runner.host),
+                status=200,
+                body=json.dumps(
+                    {
+                        "count": 2,
+                        "results": [
+                            {**JOB_1_SUCCESSFUL, "id": 125},
+                            {**JOB_1_SUCCESSFUL, "id": 126},
+                        ],
+                    }
+                ),
+            )
+
+            results = await asyncio.gather(
+                *[
+                    new_job_template_runner.monitor_job(slug)
+                    for slug in job_slugs
+                ]
+            )
+
+            assert len(results) == 4
+            assert all(r["status"] == "successful" for r in results)
+            for i, result in enumerate(results):
+                assert result["id"] == 123 + i
+
+
+@pytest.mark.asyncio
+async def test_batch_poll_includes_page_size(new_job_template_runner):
+    """Test that batch polling includes page_size parameter."""
+    # Create a mock monitor
+    monitor = new_job_template_runner._job_monitor
+
+    # Mock the _get_page_no_retry to capture params
+    captured_params = []
+
+    original_get_page = new_job_template_runner._get_page_no_retry
+
+    async def mock_get_page(href_slug, params):
+        captured_params.append(params)
+        return {"count": 0, "results": []}
+
+    new_job_template_runner._get_page_no_retry = mock_get_page
+
+    try:
+        # Create fake jobs
+        jobs = {
+            f"jobs/{i}": {
+                "url": f"https://example.com/api/v2/jobs/{i}/",  # noqa
+                "numeric_id": str(i),
+                "future": asyncio.Future(),
+            }
+            for i in range(10, 15)  # 5 jobs
+        }
+
+        # Call _poll_job_chunk
+        await monitor._poll_job_chunk(jobs, "api/v2/jobs/", "jobs")
+
+        # Verify page_size was included in params
+        assert len(captured_params) == 1
+        params = captured_params[0]
+
+        assert "page_size" in params
+        assert params["page_size"] == 5  # Same as number of jobs
+        assert "id__in" in params
+
+    finally:
+        new_job_template_runner._get_page_no_retry = original_get_page
+
+
+@pytest.mark.asyncio
+async def test_batch_poll_page_size_matches_chunk_size(
+    new_job_template_runner,
+):
+    """Test that page_size matches the number of IDs being queried."""
+    monitor = new_job_template_runner._job_monitor
+
+    captured_params = []
+
+    async def mock_get_page(href_slug, params):
+        captured_params.append(params)
+        return {"count": 0, "results": []}
+
+    new_job_template_runner._get_page_no_retry = mock_get_page
+
+    try:
+        # Test with different chunk sizes
+        for num_jobs in [1, 5, 25, 50]:
+            captured_params.clear()
+
+            jobs = {
+                f"jobs/{i}": {
+                    "url": f"https://example.com/api/v2/jobs/{i}/",  # noqa
+                    "numeric_id": str(i),
+                    "future": asyncio.Future(),
+                }
+                for i in range(num_jobs)
+            }
+
+            await monitor._poll_job_chunk(jobs, "api/v2/jobs/", "jobs")
+
+            # Verify page_size matches number of jobs
+            assert len(captured_params) == 1
+            params = captured_params[0]
+            assert params["page_size"] == num_jobs
+
+            # Verify id__in contains correct number of IDs
+            id_list = params["id__in"].split(",")
+            assert len(id_list) == num_jobs
+
+    finally:
+        # Clean up futures
+        for jobs_dict in [jobs]:
+            for job_info in jobs_dict.values():
+                if not job_info["future"].done():
+                    job_info["future"].cancel()

--- a/tests/unit/action/test_helper.py
+++ b/tests/unit/action/test_helper.py
@@ -587,3 +587,143 @@ async def test_get_old_job_url_failed_status(metadata, control):
     )
 
     assert result is None
+
+
+def test_log_completion_successful(metadata, control, caplog):
+    """Test log_completion logs successful status at INFO level."""
+    import logging
+
+    caplog.set_level(logging.INFO)
+    helper = Helper(metadata, control, "test_action")
+
+    controller_job = {
+        "status": "successful",
+        "id": 123,
+    }
+
+    helper.log_completion("Job template", "test-job", controller_job)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "INFO"
+    assert "Job template 'test-job' completed successfully" in caplog.text
+    assert "job_id: 123" in caplog.text
+
+
+def test_log_completion_failed(metadata, control, caplog):
+    """Test log_completion logs failed status at ERROR level."""
+    import logging
+
+    caplog.set_level(logging.ERROR)
+    helper = Helper(metadata, control, "test_action")
+
+    controller_job = {
+        "status": "failed",
+        "id": 456,
+    }
+
+    helper.log_completion("Job template", "test-job", controller_job)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "ERROR"
+    assert "Job template 'test-job' failed" in caplog.text
+    assert "job_id: 456" in caplog.text
+
+
+def test_log_completion_error(metadata, control, caplog):
+    """Test log_completion logs error status at ERROR level."""
+    import logging
+
+    caplog.set_level(logging.ERROR)
+    helper = Helper(metadata, control, "test_action")
+
+    controller_job = {
+        "status": "error",
+        "id": 789,
+    }
+
+    helper.log_completion("Workflow template", "test-workflow", controller_job)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "ERROR"
+    assert "Workflow template 'test-workflow' error" in caplog.text
+    assert "job_id: 789" in caplog.text
+
+
+def test_log_completion_canceled(metadata, control, caplog):
+    """Test log_completion logs canceled status at WARNING level."""
+    import logging
+
+    caplog.set_level(logging.WARNING)
+    helper = Helper(metadata, control, "test_action")
+
+    controller_job = {
+        "status": "canceled",
+        "id": 101,
+    }
+
+    helper.log_completion("Job template", "test-job", controller_job)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert "Job template 'test-job' was canceled" in caplog.text
+    assert "job_id: 101" in caplog.text
+
+
+def test_log_completion_unexpected_status(metadata, control, caplog):
+    """Test log_completion logs unexpected status at DEBUG level."""
+    import logging
+
+    caplog.set_level(logging.DEBUG)
+    helper = Helper(metadata, control, "test_action")
+
+    controller_job = {
+        "status": "pending",  # Unexpected status
+        "id": 202,
+    }
+
+    helper.log_completion("Job template", "test-job", controller_job)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "DEBUG"
+    assert "completed with unexpected status: pending" in caplog.text
+    assert "job_id: 202" in caplog.text
+
+
+def test_log_completion_no_job_id(metadata, control, caplog):
+    """Test log_completion handles missing job_id gracefully."""
+    import logging
+
+    caplog.set_level(logging.INFO)
+    helper = Helper(metadata, control, "test_action")
+
+    controller_job = {
+        "status": "successful",
+        # No "id" field
+    }
+
+    helper.log_completion("Job template", "test-job", controller_job)
+
+    assert len(caplog.records) == 1
+    assert "job_id: None" in caplog.text
+
+
+def test_log_completion_different_template_types(metadata, control, caplog):
+    """Test log_completion works with different template types."""
+    import logging
+
+    caplog.set_level(logging.INFO)
+    helper = Helper(metadata, control, "test_action")
+
+    # Test with Job template
+    helper.log_completion(
+        "Job template", "my-job", {"status": "successful", "id": 1}
+    )
+    assert "Job template 'my-job'" in caplog.text
+
+    caplog.clear()
+
+    # Test with Workflow template
+    helper.log_completion(
+        "Workflow template", "my-workflow", {"status": "successful", "id": 2}
+    )
+    assert "Workflow template 'my-workflow'" in caplog.text

--- a/tests/unit/action/test_run_job_template.py
+++ b/tests/unit/action/test_run_job_template.py
@@ -348,3 +348,52 @@ async def test_run_job_template_with_null_labels():
                 await RunJobTemplate(metadata, control, **action_args)()
 
         _validate(queue, True)
+
+
+@pytest.mark.asyncio
+async def test_run_job_template_negative_retries():
+    """Test that negative retries are clamped to 0 to prevent TypeError."""
+    queue = asyncio.Queue()
+    metadata = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid="u1",
+        rule_set_uuid="u2",
+        rule_run_at="abc",
+    )
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"a": 1},
+        project_data_file="",
+    )
+    # Negative retries value (from malformed rulebook)
+    action_args = {
+        "name": "fred",
+        "organization": "Default",
+        "retries": -5,  # Negative value
+        "retry": False,
+        "delay": 0,
+    }
+    controller_job = {
+        "status": "successful",
+        "rc": 0,
+        "artifacts": dict(b=1),
+        "created": "abc",
+        "id": 10,
+    }
+    with patch(
+        "ansible_rulebook.action.run_job_template."
+        "job_template_runner.launch_job_template",
+        return_value="https://www.example.com",
+    ):
+        with patch(
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            # Should not raise TypeError from range() with negative number
+            await RunJobTemplate(metadata, control, **action_args)()
+
+            _validate(queue, True)

--- a/tests/unit/action/test_run_workflow_template.py
+++ b/tests/unit/action/test_run_workflow_template.py
@@ -361,3 +361,52 @@ async def test_run_workflow_template_with_null_labels():
                 await RunWorkflowTemplate(metadata, control, **action_args)()
 
         _validate(queue, True)
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_template_negative_retries():
+    """Test that negative retries are clamped to 0 to prevent TypeError."""
+    queue = asyncio.Queue()
+    metadata = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid="u1",
+        rule_set_uuid="u2",
+        rule_run_at="abc",
+    )
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"a": 1},
+        project_data_file="",
+    )
+    # Negative retries value (from malformed rulebook)
+    action_args = {
+        "name": "fred",
+        "organization": "Default",
+        "retries": -5,  # Negative value
+        "retry": False,
+        "delay": 0,
+    }
+    controller_job = {
+        "status": "successful",
+        "rc": 0,
+        "artifacts": dict(b=1),
+        "created": "abc",
+        "id": 10,
+    }
+    with patch(
+        "ansible_rulebook.action.run_workflow_template."
+        "job_template_runner.launch_workflow_job_template",
+        return_value="https://www.example.com",
+    ):
+        with patch(
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            # Should not raise TypeError from range() with negative number
+            await RunWorkflowTemplate(metadata, control, **action_args)()
+
+            _validate(queue, True)

--- a/tests/unit/test_back_pressure.py
+++ b/tests/unit/test_back_pressure.py
@@ -1,0 +1,568 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ansible_rulebook.app import NullQueue
+from ansible_rulebook.back_pressure import BackPressureManager
+from ansible_rulebook.exception import (
+    TimedOutActionsException,
+    TimedOutReportingException,
+)
+
+
+class TestBackPressureManager:
+    """Test suite for BackPressureManager class."""
+
+    # ========================================================================
+    # Reporting Back Pressure Tests
+    # ========================================================================
+
+    @pytest.mark.asyncio
+    async def test_reporting_back_pressure_no_event_log(self):
+        """Test that reporting back pressure is skipped when no event_log."""
+        manager = BackPressureManager(event_log=None)
+        # Should return immediately without error
+        await manager.apply_reporting_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_reporting_back_pressure_null_queue(self):
+        """Test that reporting back pressure is skipped with NullQueue."""
+        null_queue = NullQueue()
+        manager = BackPressureManager(event_log=null_queue)
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 10
+
+            # Should return immediately since NullQueue has maxsize=0
+            await manager.apply_reporting_back_pressure()
+
+            # Verify NullQueue has expected interface
+            assert hasattr(null_queue, "maxsize")
+            assert hasattr(null_queue, "full")
+            assert hasattr(null_queue, "qsize")
+            assert null_queue.maxsize == 0
+            assert null_queue.full() is False
+            assert null_queue.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_reporting_back_pressure_skip_audit_events(self):
+        """Test reporting back pressure skipped when audit disabled."""
+        event_log = asyncio.Queue(maxsize=10)
+        manager = BackPressureManager(event_log=event_log)
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.skip_audit_events = True
+            # Should return immediately without checking queue
+            await manager.apply_reporting_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_reporting_back_pressure_queue_not_full(self):
+        """Test that back pressure returns immediately when queue has space."""
+        event_log = asyncio.Queue(maxsize=10)
+        manager = BackPressureManager(event_log=event_log)
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 10
+
+            # Queue is empty, should return immediately
+            await manager.apply_reporting_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_reporting_back_pressure_queue_full_then_drains(self):
+        """Test back pressure waits when queue full, releases on drain."""
+        event_log = asyncio.Queue(maxsize=2)
+        manager = BackPressureManager(event_log=event_log)
+
+        # Fill the queue
+        await event_log.put("item1")
+        await event_log.put("item2")
+        assert event_log.full()
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 10
+
+            # Simulate queue draining after 1 second
+            async def drain_queue():
+                await asyncio.sleep(0.1)
+                await event_log.get()  # Remove one item
+
+            drain_task = asyncio.create_task(drain_queue())
+
+            # Should wait briefly then return when space available
+            await manager.apply_reporting_back_pressure()
+            await drain_task
+
+            # Verify queue now has space
+            assert not event_log.full()
+
+    @pytest.mark.asyncio
+    async def test_reporting_back_pressure_timeout(self):
+        """Test that timeout exception is raised when queue stays full."""
+        event_log = asyncio.Queue(maxsize=2)
+        manager = BackPressureManager(event_log=event_log)
+
+        # Fill the queue
+        await event_log.put("item1")
+        await event_log.put("item2")
+        assert event_log.full()
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 2  # Short timeout
+
+            # Should raise exception after timeout
+            with pytest.raises(TimedOutReportingException) as exc_info:
+                await manager.apply_reporting_back_pressure()
+
+            assert "did not drain" in str(exc_info.value)
+            assert "2 seconds" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_reporting_back_pressure_drains_just_before_timeout(self):
+        """Test back pressure succeeds if queue drains before timeout."""
+        event_log = asyncio.Queue(maxsize=2)
+        manager = BackPressureManager(event_log=event_log)
+
+        # Fill the queue
+        await event_log.put("item1")
+        await event_log.put("item2")
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 3
+
+            # Drain queue just before timeout
+            async def drain_queue():
+                await asyncio.sleep(
+                    1.5
+                )  # Drain after 1.5s (before 3s timeout)
+                await event_log.get()
+
+            drain_task = asyncio.create_task(drain_queue())
+
+            # Should succeed without raising exception
+            await manager.apply_reporting_back_pressure()
+            await drain_task
+
+    # ========================================================================
+    # Actions Back Pressure Tests
+    # ========================================================================
+
+    @pytest.mark.asyncio
+    async def test_actions_back_pressure_no_semaphore(self):
+        """Test actions back pressure skipped when semaphore not set."""
+        manager = BackPressureManager()
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = None
+            # Should return immediately without error
+            await manager.apply_actions_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_actions_back_pressure_semaphore_available(self):
+        """Test back pressure returns immediately when slots available."""
+        manager = BackPressureManager()
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 5  # 5 slots available
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.max_back_pressure_timeout = 10
+
+            # Should return immediately
+            await manager.apply_actions_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_actions_back_pressure_semaphore_full_then_releases(self):
+        """Test back pressure waits when full, releases when available."""
+        manager = BackPressureManager()
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0  # No slots available
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.max_back_pressure_timeout = 10
+            mock_settings.max_concurrent_actions = 10
+
+            # Simulate slot becoming available after delay
+            async def release_slot():
+                await asyncio.sleep(0.1)
+                mock_semaphore._value = 1  # One slot becomes available
+
+            release_task = asyncio.create_task(release_slot())
+
+            # Should wait briefly then return
+            await manager.apply_actions_back_pressure()
+            await release_task
+
+            assert mock_semaphore._value > 0
+
+    @pytest.mark.asyncio
+    async def test_actions_back_pressure_timeout(self):
+        """Test timeout exception raised when actions don't complete."""
+        manager = BackPressureManager()
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0  # No slots available
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.max_back_pressure_timeout = 2  # Short timeout
+            mock_settings.max_concurrent_actions = 10
+
+            # Should raise exception after timeout
+            with pytest.raises(TimedOutActionsException) as exc_info:
+                await manager.apply_actions_back_pressure()
+
+            assert "failed to end" in str(exc_info.value)
+            assert "2 seconds" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_actions_back_pressure_releases_just_before_timeout(self):
+        """Test back pressure succeeds if actions complete before timeout."""
+        manager = BackPressureManager()
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0  # No slots available
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.max_back_pressure_timeout = 3
+            mock_settings.max_concurrent_actions = 10
+
+            # Release slot just before timeout
+            async def release_slot():
+                await asyncio.sleep(
+                    1.5
+                )  # Release after 1.5s (before 3s timeout)
+                mock_semaphore._value = 1
+
+            release_task = asyncio.create_task(release_slot())
+
+            # Should succeed without raising exception
+            await manager.apply_actions_back_pressure()
+            await release_task
+
+    # ========================================================================
+    # Combined Back Pressure Tests
+    # ========================================================================
+
+    @pytest.mark.asyncio
+    async def test_apply_all_back_pressure_both_available(self):
+        """Test apply_all works when both actions and reporting available."""
+        event_log = asyncio.Queue(maxsize=10)
+        manager = BackPressureManager(event_log=event_log)
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 5
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 10
+
+            # Should return immediately when both have capacity
+            await manager.apply_all_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_apply_all_back_pressure_actions_blocks(self):
+        """Test apply_all propagates actions timeout exception."""
+        event_log = asyncio.Queue(maxsize=10)
+        manager = BackPressureManager(event_log=event_log)
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0  # Actions blocked
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 1
+            mock_settings.max_concurrent_actions = 10
+
+            # Should raise actions timeout exception
+            with pytest.raises(TimedOutActionsException):
+                await manager.apply_all_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_apply_all_back_pressure_reporting_blocks(self):
+        """Test that apply_all propagates reporting timeout exception."""
+        event_log = asyncio.Queue(maxsize=2)
+        manager = BackPressureManager(event_log=event_log)
+
+        # Fill reporting queue
+        await event_log.put("item1")
+        await event_log.put("item2")
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 5  # Actions available
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 1
+
+            # Should raise reporting timeout exception
+            with pytest.raises(TimedOutReportingException):
+                await manager.apply_all_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_apply_all_back_pressure_sequential_release(self):
+        """Test that both back pressures are checked sequentially."""
+        event_log = asyncio.Queue(maxsize=2)
+        manager = BackPressureManager(event_log=event_log)
+
+        # Fill reporting queue
+        await event_log.put("item1")
+        await event_log.put("item2")
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0  # Actions blocked initially
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 10
+            mock_settings.max_concurrent_actions = 10
+
+            async def release_both():
+                await asyncio.sleep(0.1)
+                mock_semaphore._value = 1  # Release actions
+                await asyncio.sleep(0.1)
+                await event_log.get()  # Release reporting
+
+            release_task = asyncio.create_task(release_both())
+
+            # Should succeed when both release
+            await manager.apply_all_back_pressure()
+            await release_task
+
+    # ========================================================================
+    # Edge Cases and Logging Tests
+    # ========================================================================
+
+    @pytest.mark.asyncio
+    async def test_reporting_back_pressure_logs_waiting(self, caplog):
+        """Test waiting message logged when back pressure applied."""
+        event_log = asyncio.Queue(maxsize=2)
+        manager = BackPressureManager(event_log=event_log)
+
+        # Fill queue
+        await event_log.put("item1")
+        await event_log.put("item2")
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 10
+
+            async def drain_quickly():
+                await asyncio.sleep(0.05)
+                await event_log.get()
+
+            drain_task = asyncio.create_task(drain_quickly())
+
+            await manager.apply_reporting_back_pressure()
+            await drain_task
+
+            # Check that appropriate log message was generated
+            # Note: Actual logging verification depends on caplog fixture
+
+    @pytest.mark.asyncio
+    async def test_actions_back_pressure_logs_waiting(self):
+        """Test waiting message logged when actions back pressure applied."""
+        manager = BackPressureManager()
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.max_back_pressure_timeout = 10
+            mock_settings.max_concurrent_actions = 10
+
+            async def release_quickly():
+                await asyncio.sleep(0.05)
+                mock_semaphore._value = 1
+
+            release_task = asyncio.create_task(release_quickly())
+
+            await manager.apply_actions_back_pressure()
+            await release_task
+
+    @pytest.mark.asyncio
+    async def test_multiple_back_pressure_cycles(self):
+        """Test back pressure can be applied multiple times in sequence."""
+        event_log = asyncio.Queue(maxsize=2)
+        manager = BackPressureManager(event_log=event_log)
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 10
+
+            # First call - queue empty
+            await manager.apply_reporting_back_pressure()
+
+            # Fill queue
+            await event_log.put("item1")
+            await event_log.put("item2")
+
+            # Second call - queue full, but drain it
+            async def drain():
+                await asyncio.sleep(0.05)
+                await event_log.get()
+
+            drain_task = asyncio.create_task(drain())
+            await manager.apply_reporting_back_pressure()
+            await drain_task
+
+            # Third call - queue not full again
+            await manager.apply_reporting_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_apply_all_back_pressure_shares_timeout_budget(self):
+        """Test that apply_all shares timeout budget between phases."""
+        event_log = asyncio.Queue(maxsize=10)
+        manager = BackPressureManager(event_log=event_log)
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0  # Actions blocked initially
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 5
+
+            # Fill the reporting queue
+            for _ in range(10):
+                await event_log.put("item")
+
+            # Release actions after 2 seconds, leaving 3 seconds for reporting
+            async def release_actions():
+                await asyncio.sleep(2)
+                mock_semaphore._value = 1
+
+            # Drain queue after another 2 seconds (total 4s, within budget)
+            async def drain_queue():
+                await asyncio.sleep(2.5)
+                while not event_log.empty():
+                    await event_log.get()
+
+            release_task = asyncio.create_task(release_actions())
+            drain_task = asyncio.create_task(drain_queue())
+
+            # Should succeed because total time < 5s
+            await manager.apply_all_back_pressure()
+            await release_task
+            await drain_task
+
+    @pytest.mark.asyncio
+    async def test_apply_all_back_pressure_timeout_from_actions_phase(self):
+        """Test that actions phase timeout leaves less time for reporting."""
+        event_log = asyncio.Queue(maxsize=10)
+        manager = BackPressureManager(event_log=event_log)
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0  # Actions blocked
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = (
+                3  # 3 second total budget
+            )
+
+            # Fill the reporting queue
+            for _ in range(10):
+                await event_log.put("item")
+
+            # Actions phase blocks for the full timeout
+            # Reporting phase will have 0 seconds left and should timeout
+
+            # Should raise TimedOutActionsException after 3 seconds
+            with pytest.raises(TimedOutActionsException) as exc_info:
+                await manager.apply_all_back_pressure()
+
+            assert "3 seconds" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_back_pressure_uses_asyncio_wait_for(self):
+        """Test that back pressure uses asyncio.wait_for() correctly."""
+        event_log = asyncio.Queue(maxsize=10)
+        manager = BackPressureManager(event_log=event_log)
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 1  # Available
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 10
+
+            # Should return immediately since semaphore has capacity
+            await manager.apply_actions_back_pressure()
+
+            # Should return immediately since queue is not full
+            await manager.apply_reporting_back_pressure()
+
+    @pytest.mark.asyncio
+    async def test_back_pressure_timeout_with_time_tracking(self):
+        """Test that apply_all tracks time correctly between phases."""
+        import time
+
+        event_log = asyncio.Queue(maxsize=10)
+        manager = BackPressureManager(event_log=event_log)
+
+        mock_semaphore = Mock()
+        mock_semaphore._value = 0  # Blocked initially
+
+        with patch("ansible_rulebook.back_pressure.settings") as mock_settings:
+            mock_settings.max_actions_semaphore = mock_semaphore
+            mock_settings.skip_audit_events = False
+            mock_settings.max_back_pressure_timeout = 5
+
+            # Fill the reporting queue
+            for _ in range(10):
+                await event_log.put("item")
+
+            # Release after 1 second
+            async def release():
+                await asyncio.sleep(1)
+                mock_semaphore._value = 1
+
+            # Drain queue quickly
+            async def drain():
+                await asyncio.sleep(1.2)
+                while not event_log.empty():
+                    await event_log.get()
+
+            release_task = asyncio.create_task(release())
+            drain_task = asyncio.create_task(drain())
+
+            start = time.monotonic()
+            await manager.apply_all_back_pressure()
+            elapsed = time.monotonic() - start
+
+            await release_task
+            await drain_task
+
+            # Should complete in ~2 seconds (1s for actions + 1s for reporting)
+            assert 1.5 <= elapsed <= 3

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,11 +1,18 @@
 import re
 import sys
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from ansible_rulebook.cli import main
-from ansible_rulebook.util import check_jvm, get_version, validate_url
+from ansible_rulebook.util import (
+    check_jvm,
+    get_version,
+    validate_file_path,
+    validate_url,
+)
 
 
 def test_get_version():
@@ -139,3 +146,197 @@ def test_main_invalid_args(args):
 def test_validate_url(url, url_type, expected_bool):
     res = validate_url(url, url_type)
     assert res == expected_bool
+
+
+class TestVaultFilePathValidation:
+    """Tests for vault password file path validation."""
+
+    def test_validate_vault_file_path_valid(self):
+        """Test validation with a valid vault password file."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("test_password")
+            temp_path = f.name
+
+        try:
+            result = validate_file_path(temp_path, "Vault password file")
+            # Should return the resolved absolute path
+            assert result is not None
+            assert Path(result).exists()
+            assert Path(result).is_file()
+        finally:
+            Path(temp_path).unlink()
+
+    def test_validate_vault_file_path_empty_string(self):
+        """Test validation rejects empty string."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_file_path("", "Vault password file")
+
+        assert "cannot be empty" in str(exc_info.value)
+
+    def test_validate_vault_file_path_nonexistent(self):
+        """Test validation rejects nonexistent file."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_file_path(
+                "/tmp/nonexistent_vault_file_xyz123", "Vault password file"
+            )
+
+        assert "does not exist" in str(exc_info.value)
+
+    def test_validate_vault_file_path_directory(self):
+        """Test validation rejects directory paths."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with pytest.raises(ValueError) as exc_info:
+                validate_file_path(temp_dir, "Vault password file")
+
+            assert "not a file" in str(exc_info.value)
+
+    def test_validate_vault_file_path_null_byte(self):
+        """Test validation rejects paths with null bytes."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_file_path("/tmp/file\x00injected", "Vault password file")
+
+        # OS raises ValueError with "null character" or our custom check
+        assert "null" in str(exc_info.value).lower()
+
+    def test_validate_vault_file_path_resolves_symlinks(self):
+        """Test that validation resolves symlinks to canonical path."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("test_password")
+            real_path = f.name
+
+        try:
+            # Create a symlink to the real file
+            symlink_path = f"{real_path}_link"
+            Path(symlink_path).symlink_to(real_path)
+
+            try:
+                result = validate_file_path(
+                    symlink_path, "Vault password file"
+                )
+                # Should resolve to the real file path
+                assert Path(result).resolve() == Path(real_path).resolve()
+            finally:
+                Path(symlink_path).unlink()
+        finally:
+            Path(real_path).unlink()
+
+    def test_validate_vault_file_path_relative_path(self):
+        """Test validation handles relative paths."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, dir=".") as f:
+            f.write("test_password")
+            temp_path = Path(f.name).name  # Just the filename
+
+        try:
+            # Change to the directory containing the file
+            result = validate_file_path(temp_path, "Vault password file")
+            # Should resolve to absolute path
+            assert Path(result).is_absolute()
+            assert Path(result).exists()
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
+
+class TestParseVaultPasswords:
+    """Tests for vault password parsing with file validation."""
+
+    def test_parse_vault_password_file_valid(self, tmp_path):
+        """Test parsing with valid vault password file."""
+        from argparse import Namespace
+
+        from ansible_rulebook.cli import parse_vault_passwords
+
+        # Create a temporary vault password file
+        vault_file = tmp_path / "vault_password"
+        vault_file.write_text("my_secret_password")
+
+        args = Namespace(
+            vault_password_file=str(vault_file),
+            vault_id=[],
+            ask_vault_pass=False,
+        )
+
+        # Should not raise any exception
+        parse_vault_passwords(args)
+
+    def test_parse_vault_password_file_invalid(self, capsys):
+        """Test parsing with invalid vault password file."""
+        from argparse import Namespace
+
+        from ansible_rulebook.cli import parse_vault_passwords
+
+        args = Namespace(
+            vault_password_file="/nonexistent/vault_file",
+            vault_id=[],
+            ask_vault_pass=False,
+        )
+
+        # Should exit with error
+        with pytest.raises(SystemExit) as exc_info:
+            parse_vault_passwords(args)
+
+        assert exc_info.value.code == 1
+
+    def test_parse_vault_id_with_file_valid(self, tmp_path):
+        """Test parsing with valid vault ID file."""
+        from argparse import Namespace
+
+        from ansible_rulebook.cli import parse_vault_passwords
+
+        # Create a temporary vault ID file
+        vault_id_file = tmp_path / "vault_id_file"
+        vault_id_file.write_text("vault_secret")
+
+        args = Namespace(
+            vault_password_file=None,
+            vault_id=[f"prod@{vault_id_file}"],
+            ask_vault_pass=False,
+        )
+
+        # Should not raise any exception
+        parse_vault_passwords(args)
+
+    def test_parse_vault_id_with_file_invalid(self):
+        """Test parsing with invalid vault ID file."""
+        from argparse import Namespace
+
+        from ansible_rulebook.cli import parse_vault_passwords
+
+        args = Namespace(
+            vault_password_file=None,
+            vault_id=["prod@/nonexistent/vault_id_file"],
+            ask_vault_pass=False,
+        )
+
+        # Should exit with error
+        with pytest.raises(SystemExit) as exc_info:
+            parse_vault_passwords(args)
+
+        assert exc_info.value.code == 1
+
+    def test_parse_vault_id_without_file(self):
+        """Test parsing vault ID without file (prompt case)."""
+        from argparse import Namespace
+
+        from ansible_rulebook.cli import parse_vault_passwords
+
+        args = Namespace(
+            vault_password_file=None,
+            vault_id=["prod"],  # No @ means it's a prompt ID
+            ask_vault_pass=False,
+        )
+
+        # Should not raise any exception
+        parse_vault_passwords(args)
+
+    def test_parse_vault_no_options(self):
+        """Test parsing with no vault options."""
+        from argparse import Namespace
+
+        from ansible_rulebook.cli import parse_vault_passwords
+
+        args = Namespace(
+            vault_password_file=None, vault_id=[], ask_vault_pass=False
+        )
+
+        # Should return early without error
+        parse_vault_passwords(args)

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -1,0 +1,469 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Unit tests for ansible_rulebook.conf module."""
+
+import uuid
+from unittest.mock import patch
+
+from ansible_rulebook.conf import (
+    DEFAULT_EDA_LABEL,
+    DEFAULT_MAX_CONCURRENT_ACTIONS,
+    _Settings,
+    settings,
+)
+
+
+class TestSettings:
+    """Tests for _Settings class."""
+
+    def test_settings_initialization(self):
+        """Test that _Settings initializes with correct default values."""
+        test_settings = _Settings()
+
+        # UUID should be generated
+        assert isinstance(uuid.UUID(test_settings.identifier), uuid.UUID)
+
+        # Check default values
+        assert test_settings.gc_after == 1000
+        assert test_settings.default_execution_strategy == "sequential"
+        assert test_settings.max_feedback_timeout == 5
+        assert test_settings.print_events is False
+        assert test_settings.websocket_url is None
+        assert test_settings.websocket_ssl_verify == "yes"
+        assert test_settings.websocket_token_url is None
+        assert test_settings.websocket_access_token is None
+        assert test_settings.websocket_refresh_token is None
+        assert test_settings.skip_audit_events is False
+        assert test_settings.vault is not None
+        assert test_settings.eda_labels == [DEFAULT_EDA_LABEL]
+        assert test_settings.persistence_enabled is False
+
+    def test_settings_ansible_galaxy_path(self):
+        """Test that ansible-galaxy path is set if available."""
+        with patch("shutil.which", return_value="/usr/bin/ansible-galaxy"):
+            test_settings = _Settings()
+            assert (
+                test_settings.ansible_galaxy_path == "/usr/bin/ansible-galaxy"
+            )
+
+    def test_settings_ansible_galaxy_path_not_found(self):
+        """Test that ansible-galaxy path is None if not found."""
+        with patch("shutil.which", return_value=None):
+            test_settings = _Settings()
+            assert test_settings.ansible_galaxy_path is None
+
+    def test_settings_unique_identifier(self):
+        """Test that each _Settings instance gets a unique identifier."""
+        settings1 = _Settings()
+        settings2 = _Settings()
+
+        assert settings1.identifier != settings2.identifier
+
+    def test_settings_vault_initialization(self):
+        """Test that Vault instance is created."""
+        test_settings = _Settings()
+        from ansible_rulebook.vault import Vault
+
+        assert isinstance(test_settings.vault, Vault)
+
+    def test_settings_modification(self):
+        """Test that settings values can be modified."""
+        test_settings = _Settings()
+
+        # Modify values
+        test_settings.print_events = True
+        test_settings.skip_audit_events = True
+        test_settings.persistence_enabled = True
+        test_settings.gc_after = 2000
+        test_settings.default_execution_strategy = "parallel"
+
+        # Verify modifications
+        assert test_settings.print_events is True
+        assert test_settings.skip_audit_events is True
+        assert test_settings.persistence_enabled is True
+        assert test_settings.gc_after == 2000
+        assert test_settings.default_execution_strategy == "parallel"
+
+    def test_settings_websocket_configuration(self):
+        """Test setting websocket configuration."""
+        test_settings = _Settings()
+
+        test_settings.websocket_url = "wss://example.com"
+        test_settings.websocket_ssl_verify = "no"
+        test_settings.websocket_token_url = "https://example.com/token"
+        test_settings.websocket_access_token = "access_token_123"
+        test_settings.websocket_refresh_token = "refresh_token_456"
+
+        assert test_settings.websocket_url == "wss://example.com"
+        assert test_settings.websocket_ssl_verify == "no"
+        assert test_settings.websocket_token_url == "https://example.com/token"
+        assert test_settings.websocket_access_token == "access_token_123"
+        assert test_settings.websocket_refresh_token == "refresh_token_456"
+
+    def test_settings_eda_labels_default(self):
+        """Test that eda_labels contains default label."""
+        test_settings = _Settings()
+
+        assert DEFAULT_EDA_LABEL in test_settings.eda_labels
+        assert len(test_settings.eda_labels) == 1
+
+    def test_settings_eda_labels_modification(self):
+        """Test modifying eda_labels list."""
+        test_settings = _Settings()
+
+        test_settings.eda_labels.append("custom_label")
+
+        assert DEFAULT_EDA_LABEL in test_settings.eda_labels
+        assert "custom_label" in test_settings.eda_labels
+        assert len(test_settings.eda_labels) == 2
+
+    def test_settings_new_attributes(self):
+        """Test concurrency and timeout attributes."""
+        test_settings = _Settings()
+
+        assert test_settings.max_concurrent_actions == 0
+        assert test_settings.max_actions_semaphore is None
+        assert test_settings.max_actions_timeout == 3600
+        assert test_settings.max_batch_job_polling_size == 25
+
+
+class TestConvertType:
+    """Tests for _Settings._convert_type static method."""
+
+    def test_convert_type_bool_from_string_true(self):
+        """Test converting various true string values to bool."""
+        assert _Settings._convert_type("true", bool) is True
+        assert _Settings._convert_type("True", bool) is True
+        assert _Settings._convert_type("TRUE", bool) is True
+        assert _Settings._convert_type("1", bool) is True
+        assert _Settings._convert_type("yes", bool) is True
+        assert _Settings._convert_type("YES", bool) is True
+        assert _Settings._convert_type("on", bool) is True
+        assert _Settings._convert_type("ON", bool) is True
+
+    def test_convert_type_bool_from_string_false(self):
+        """Test converting various false string values to bool."""
+        assert _Settings._convert_type("false", bool) is False
+        assert _Settings._convert_type("False", bool) is False
+        assert _Settings._convert_type("FALSE", bool) is False
+        assert _Settings._convert_type("0", bool) is False
+        assert _Settings._convert_type("no", bool) is False
+        assert _Settings._convert_type("NO", bool) is False
+        assert _Settings._convert_type("off", bool) is False
+        assert _Settings._convert_type("", bool) is False
+
+    def test_convert_type_bool_already_bool(self):
+        """Test that bool values are returned as-is."""
+        assert _Settings._convert_type(True, bool) is True
+        assert _Settings._convert_type(False, bool) is False
+
+    def test_convert_type_int_from_string(self):
+        """Test converting string to int."""
+        assert _Settings._convert_type("42", int) == 42
+        assert _Settings._convert_type("0", int) == 0
+        assert _Settings._convert_type("-10", int) == -10
+
+    def test_convert_type_int_already_int(self):
+        """Test that int values are returned as-is."""
+        assert _Settings._convert_type(42, int) == 42
+        assert _Settings._convert_type(0, int) == 0
+
+    def test_convert_type_str_from_various(self):
+        """Test converting various types to string."""
+        assert _Settings._convert_type("hello", str) == "hello"
+        assert _Settings._convert_type(42, str) == "42"
+        assert _Settings._convert_type(True, str) == "True"
+
+    def test_convert_type_str_already_str(self):
+        """Test that string values are returned as-is."""
+        assert _Settings._convert_type("hello", str) == "hello"
+
+    def test_convert_type_list_from_json_string(self):
+        """Test converting JSON string to list."""
+        assert _Settings._convert_type('["a", "b", "c"]', list) == [
+            "a",
+            "b",
+            "c",
+        ]
+        assert _Settings._convert_type("[1, 2, 3]", list) == [1, 2, 3]
+        assert _Settings._convert_type("[]", list) == []
+
+    def test_convert_type_list_from_non_json_string(self):
+        """Test converting non-JSON string to list."""
+        result = _Settings._convert_type("simple_string", list)
+        assert result == ["simple_string"]
+
+    def test_convert_type_list_already_list(self):
+        """Test that list values are returned as-is."""
+        test_list = ["a", "b", "c"]
+        assert _Settings._convert_type(test_list, list) == test_list
+
+    def test_convert_type_list_from_non_list_non_string(self):
+        """Test converting non-list, non-string to list."""
+        assert _Settings._convert_type(42, list) == [42]
+
+
+class TestUpdateFromEnv:
+    """Tests for _Settings.update_from_env method."""
+
+    def test_update_from_env_int_values(self, monkeypatch):
+        """Test updating int settings from environment variables."""
+        monkeypatch.setenv("EDA_GC_AFTER", "2000")
+        monkeypatch.setenv("EDA_MAX_FEEDBACK_TIMEOUT", "10")
+        monkeypatch.setenv("EDA_MAX_CONCURRENT_ACTIONS", "5")
+        monkeypatch.setenv("EDA_MAX_ACTIONS_TIMEOUT", "7200")
+
+        test_settings = _Settings()
+
+        assert test_settings.gc_after == 2000
+        assert test_settings.max_feedback_timeout == 10
+        assert test_settings.max_concurrent_actions == 5
+        assert test_settings.max_actions_timeout == 7200
+
+    def test_update_from_env_batch_polling_size(self, monkeypatch):
+        """Test updating max_batch_job_polling_size from env var."""
+        monkeypatch.setenv("EDA_MAX_BATCH_JOB_POLLING_SIZE", "50")
+
+        test_settings = _Settings()
+
+        assert test_settings.max_batch_job_polling_size == 50
+
+    def test_update_from_env_bool_values(self, monkeypatch):
+        """Test updating bool settings from environment variables."""
+        monkeypatch.setenv("EDA_PRINT_EVENTS", "true")
+        monkeypatch.setenv("EDA_SKIP_AUDIT_EVENTS", "1")
+        monkeypatch.setenv("EDA_PERSISTENCE_ENABLED", "yes")
+
+        test_settings = _Settings()
+
+        assert test_settings.print_events is True
+        assert test_settings.skip_audit_events is True
+        assert test_settings.persistence_enabled is True
+
+    def test_update_from_env_bool_false_values(self, monkeypatch):
+        """Test updating bool settings with false values from env."""
+        monkeypatch.setenv("EDA_PRINT_EVENTS", "false")
+        monkeypatch.setenv("EDA_SKIP_AUDIT_EVENTS", "0")
+
+        test_settings = _Settings()
+
+        assert test_settings.print_events is False
+        assert test_settings.skip_audit_events is False
+
+    def test_update_from_env_string_values(self, monkeypatch):
+        """Test updating string settings from environment variables."""
+        monkeypatch.setenv("EDA_EXECUTION_STRATEGY", "parallel")
+        monkeypatch.setenv("EDA_WEBSOCKET_URL", "wss://example.com")
+        monkeypatch.setenv("EDA_WEBSOCKET_SSL_VERIFY", "no")
+        monkeypatch.setenv(
+            "EDA_WEBSOCKET_TOKEN_URL", "https://example.com/token"
+        )
+        monkeypatch.setenv("EDA_WEBSOCKET_ACCESS_TOKEN", "token123")
+        monkeypatch.setenv("EDA_WEBSOCKET_REFRESH_TOKEN", "refresh123")
+        monkeypatch.setenv("EDA_PERSISTENCE_ID", "unique-id-123")
+
+        test_settings = _Settings()
+
+        assert test_settings.default_execution_strategy == "parallel"
+        assert test_settings.websocket_url == "wss://example.com"
+        assert test_settings.websocket_ssl_verify == "no"
+        assert test_settings.websocket_token_url == "https://example.com/token"
+        assert test_settings.websocket_access_token == "token123"
+        assert test_settings.websocket_refresh_token == "refresh123"
+        assert test_settings.persistence_id == "unique-id-123"
+
+    def test_update_from_env_list_values_json(self, monkeypatch):
+        """Test updating list settings from JSON environment variable."""
+        monkeypatch.setenv("EDA_LABELS", '["label1", "label2", "label3"]')
+
+        test_settings = _Settings()
+
+        assert test_settings.eda_labels == ["label1", "label2", "label3"]
+
+    def test_update_from_env_list_values_non_json(self, monkeypatch):
+        """Test updating list settings from non-JSON string."""
+        monkeypatch.setenv("EDA_LABELS", "single_label")
+
+        test_settings = _Settings()
+
+        assert test_settings.eda_labels == ["single_label"]
+
+    def test_update_from_env_no_env_vars(self, monkeypatch):
+        """Test that defaults are used when no env vars are set."""
+        # Clear any existing env vars
+        for env_key in [
+            "EDA_GC_AFTER",
+            "EDA_EXECUTION_STRATEGY",
+            "EDA_MAX_FEEDBACK_TIMEOUT",
+            "EDA_PRINT_EVENTS",
+        ]:
+            monkeypatch.delenv(env_key, raising=False)
+
+        test_settings = _Settings()
+
+        # Should use defaults
+        assert test_settings.gc_after == 1000
+        assert test_settings.default_execution_strategy == "sequential"
+        assert test_settings.max_feedback_timeout == 5
+        assert test_settings.print_events is False
+
+    def test_update_from_env_invalid_int(self, monkeypatch, caplog):
+        """Test handling of invalid int value in env var."""
+        monkeypatch.setenv("EDA_GC_AFTER", "not_a_number")
+
+        test_settings = _Settings()
+
+        # Should keep default value and log warning
+        assert test_settings.gc_after == 1000
+        assert "Failed to convert env var EDA_GC_AFTER" in caplog.text
+
+    def test_update_from_env_invalid_json_list(self, monkeypatch, caplog):
+        """Test handling of invalid JSON in list env var."""
+        monkeypatch.setenv("EDA_LABELS", '["unclosed array')
+
+        test_settings = _Settings()
+
+        # Should fall back to treating it as a single-item list
+        assert test_settings.eda_labels == ['["unclosed array']
+
+    def test_update_from_env_called_multiple_times(self, monkeypatch):
+        """Test that update_from_env can be called multiple times."""
+        monkeypatch.setenv("EDA_GC_AFTER", "1500")
+
+        test_settings = _Settings()
+        assert test_settings.gc_after == 1500
+
+        # Update env var and call update_from_env again
+        monkeypatch.setenv("EDA_GC_AFTER", "2500")
+        test_settings.update_from_env()
+
+        assert test_settings.gc_after == 2500
+
+    def test_update_from_env_partial_update(self, monkeypatch):
+        """Test that only env vars that are set get updated."""
+        # Set only some env vars
+        monkeypatch.setenv("EDA_GC_AFTER", "3000")
+        monkeypatch.setenv("EDA_PRINT_EVENTS", "true")
+
+        test_settings = _Settings()
+
+        # Updated values
+        assert test_settings.gc_after == 3000
+        assert test_settings.print_events is True
+
+        # Default values for others
+        assert test_settings.default_execution_strategy == "sequential"
+        assert test_settings.max_feedback_timeout == 5
+
+    def test_env_map_completeness(self):
+        """Test that ENV_MAP is properly defined."""
+        assert hasattr(_Settings, "ENV_MAP")
+        assert isinstance(_Settings.ENV_MAP, dict)
+
+        # Check that all expected keys are present
+        expected_keys = {
+            "gc_after",
+            "default_execution_strategy",
+            "max_feedback_timeout",
+            "print_events",
+            "websocket_url",
+            "websocket_ssl_verify",
+            "websocket_token_url",
+            "websocket_access_token",
+            "websocket_refresh_token",
+            "skip_audit_events",
+            "persistence_enabled",
+            "persistence_id",
+            "max_concurrent_actions",
+            "max_actions_timeout",
+            "max_back_pressure_timeout",
+            "max_reporting_queue_size",
+            "max_batch_job_polling_size",
+            "eda_labels",
+        }
+
+        assert set(_Settings.ENV_MAP.keys()) == expected_keys
+
+        # Check that each value is a tuple of (env_var_name, type)
+        for _key, value in _Settings.ENV_MAP.items():
+            assert isinstance(value, tuple)
+            assert len(value) == 2
+            assert isinstance(value[0], str)
+            assert isinstance(value[1], type)
+
+
+class TestGlobalSettings:
+    """Tests for the global settings instance."""
+
+    def test_global_settings_instance(self):
+        """Test that global settings instance exists."""
+        assert settings is not None
+        assert isinstance(settings, _Settings)
+
+    def test_default_eda_label_constant(self):
+        """Test DEFAULT_EDA_LABEL constant value."""
+        assert DEFAULT_EDA_LABEL == "Activated by Event-Driven Ansible"
+
+    def test_default_max_concurrent_actions_constant(self):
+        """Test DEFAULT_MAX_CONCURRENT_ACTIONS constant value."""
+        assert DEFAULT_MAX_CONCURRENT_ACTIONS == 25
+
+
+class TestMaxConcurrentActionsValidation:
+    """Tests for max_concurrent_actions special validation."""
+
+    def test_max_concurrent_actions_accepts_zero(self):
+        """Test that max_concurrent_actions accepts 0 as sentinel value."""
+        with patch.dict("os.environ", {"EDA_MAX_CONCURRENT_ACTIONS": "0"}):
+            test_settings = _Settings()
+            # 0 should be accepted (sentinel for "use default")
+            assert test_settings.max_concurrent_actions == 0
+
+    def test_max_concurrent_actions_accepts_positive(self):
+        """Test that max_concurrent_actions accepts positive values."""
+        with patch.dict("os.environ", {"EDA_MAX_CONCURRENT_ACTIONS": "50"}):
+            test_settings = _Settings()
+            assert test_settings.max_concurrent_actions == 50
+
+    def test_max_concurrent_actions_rejects_negative(self):
+        """Test that negative max_concurrent_actions is rejected."""
+        with patch.dict("os.environ", {"EDA_MAX_CONCURRENT_ACTIONS": "-5"}):
+            test_settings = _Settings()
+            # Negative should be rejected, falls back to default 0
+            assert test_settings.max_concurrent_actions == 0
+
+    def test_max_concurrent_actions_not_in_positive_int_settings(self):
+        """Test that max_concurrent_actions is not in POSITIVE_INT_SETTINGS."""
+        # max_concurrent_actions should NOT be in POSITIVE_INT_SETTINGS
+        # because 0 is a valid sentinel value
+        assert "max_concurrent_actions" not in _Settings.POSITIVE_INT_SETTINGS
+
+    def test_positive_int_settings_still_reject_zero(self):
+        """Test that other POSITIVE_INT_SETTINGS still reject 0."""
+        # Test that other settings in POSITIVE_INT_SETTINGS still reject 0
+        with patch.dict("os.environ", {"EDA_MAX_ACTIONS_TIMEOUT": "0"}):
+            test_settings = _Settings()
+            # Should reject 0 and use default
+            assert test_settings.max_actions_timeout == 3600  # default
+
+        with patch.dict("os.environ", {"EDA_MAX_BACK_PRESSURE_TIMEOUT": "0"}):
+            test_settings = _Settings()
+            # Should reject 0 and use default
+            assert test_settings.max_back_pressure_timeout == 3600  # default
+
+    def test_max_concurrent_actions_default_is_zero(self):
+        """Test that default max_concurrent_actions is 0 (sentinel)."""
+        test_settings = _Settings()
+        assert test_settings.max_concurrent_actions == 0

--- a/tests/unit/test_job_template_runner.py
+++ b/tests/unit/test_job_template_runner.py
@@ -1,0 +1,146 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Unit tests for ansible_rulebook.job_template_runner module."""
+
+from unittest.mock import AsyncMock, Mock
+
+import aiohttp
+import pytest
+
+from ansible_rulebook.job_template_runner import JobTemplateRunner
+
+
+class TestJobTemplateRunnerSessions:
+    """Tests for JobTemplateRunner session management."""
+
+    @pytest.mark.asyncio
+    async def test_init_creates_no_sessions(self):
+        """Test that __init__ doesn't create sessions immediately."""
+        runner = JobTemplateRunner(
+            host="https://controller.example.com",
+            token="test-token",
+        )
+
+        assert runner._session is None
+        assert runner._raw_session is None
+
+    @pytest.mark.asyncio
+    async def test_create_session_stores_both_sessions(self):
+        """Test that _create_session stores both raw and retry sessions."""
+        runner = JobTemplateRunner(
+            host="https://controller.example.com",
+            token="test-token",
+        )
+
+        try:
+            runner._create_session()
+
+            # Both sessions should be created
+            assert runner._session is not None
+            assert runner._raw_session is not None
+
+            # _session should be a RetryClient
+            from aiohttp_retry import RetryClient
+
+            assert isinstance(runner._session, RetryClient)
+
+            # _raw_session should be the underlying aiohttp.ClientSession
+            assert isinstance(runner._raw_session, aiohttp.ClientSession)
+        finally:
+            # Clean up
+            await runner.close_session()
+
+    @pytest.mark.asyncio
+    async def test_close_session_closes_both(self):
+        """Test that close_session closes both sessions."""
+        runner = JobTemplateRunner(
+            host="https://controller.example.com",
+            token="test-token",
+        )
+
+        runner._create_session()
+
+        # Store references to verify they exist before closing
+        assert runner._session is not None
+        assert runner._raw_session is not None
+
+        # Close both sessions
+        await runner.close_session()
+
+        # Both should be set to None
+        assert runner._session is None
+        assert runner._raw_session is None
+
+    @pytest.mark.asyncio
+    async def test_get_page_no_retry_uses_raw_session(self):
+        """Test that _get_page_no_retry uses raw session directly."""
+        runner = JobTemplateRunner(
+            host="https://controller.example.com",
+            token="test-token",
+        )
+
+        try:
+            runner._create_session()
+
+            # Mock the raw session's get method
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.text = AsyncMock(
+                return_value='{"result": "success"}'
+            )
+            mock_response.raise_for_status = Mock()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock()
+
+            runner._raw_session.get = Mock(return_value=mock_response)
+
+            # Call _get_page_no_retry
+            result = await runner._get_page_no_retry("api/v2/jobs/", {})
+
+            # Verify raw session was used (not RetryClient)
+            runner._raw_session.get.assert_called_once()
+            assert result == {"result": "success"}
+        finally:
+            # Clean up
+            await runner.close_session()
+
+    @pytest.mark.asyncio
+    async def test_raw_session_no_internal_attribute_access(self):
+        """Test that we don't access RetryClient internal attributes."""
+        runner = JobTemplateRunner(
+            host="https://controller.example.com",
+            token="test-token",
+        )
+
+        try:
+            runner._create_session()
+
+            # Verify we can access _raw_session without accessing
+            # _session._client
+            assert hasattr(runner, "_raw_session")
+            assert runner._raw_session is not None
+
+            # The _raw_session should be the same object that
+            # RetryClient wraps
+            # But we're accessing it directly, not via RetryClient._client
+            assert isinstance(runner._raw_session, aiohttp.ClientSession)
+
+            # Verify we're NOT accessing internal _client attribute
+            # This test passes if _raw_session exists and we can use it
+            # without needing _session._client
+            assert runner._raw_session is not None
+        finally:
+            # Clean up
+            await runner.close_session()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -33,6 +33,7 @@ from ansible_rulebook.util import (
     mask_sensitive_variable_values,
     startup_logging,
     strtobool,
+    validate_file_path,
 )
 from ansible_rulebook.vault import Vault
 
@@ -381,3 +382,81 @@ def test_mask_sensitive_variable_values(extra_vars, expected):
 )
 def test_strtobool(value: str, expected: bool):
     assert strtobool(value) == expected
+
+
+def test_validate_file_path_valid(tmp_path):
+    """Test validate_file_path with a valid file."""
+    test_file = tmp_path / "test_file.txt"
+    test_file.write_text("test content")
+
+    result = validate_file_path(str(test_file), "Test file")
+    assert result == str(test_file.resolve())
+
+
+def test_validate_file_path_empty():
+    """Test validate_file_path with empty path."""
+    with pytest.raises(ValueError, match="path cannot be empty"):
+        validate_file_path("", "Test file")
+
+
+def test_validate_file_path_nonexistent():
+    """Test validate_file_path with non-existent file."""
+    with pytest.raises(ValueError, match="does not exist"):
+        validate_file_path("/nonexistent/file.txt", "Test file")
+
+
+def test_validate_file_path_directory(tmp_path):
+    """Test validate_file_path with a directory instead of file."""
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    with pytest.raises(ValueError, match="is not a file"):
+        validate_file_path(str(test_dir), "Test file")
+
+
+def test_validate_file_path_null_byte():
+    """Test validate_file_path with null byte in path."""
+    with pytest.raises(ValueError, match="contains null bytes"):
+        validate_file_path("/tmp/test\x00file.txt", "Test file")
+
+
+def test_validate_file_path_with_symlink(tmp_path):
+    """Test validate_file_path resolves symlinks correctly."""
+    # Create a real file
+    real_file = tmp_path / "real_file.txt"
+    real_file.write_text("test content")
+
+    # Create a symlink to it
+    symlink = tmp_path / "symlink.txt"
+    symlink.symlink_to(real_file)
+
+    # Validate should resolve to the real file
+    result = validate_file_path(str(symlink), "Test file")
+    assert result == str(real_file.resolve())
+
+
+def test_validate_file_path_custom_description():
+    """Test validate_file_path with custom file description."""
+    with pytest.raises(ValueError, match="Rulebook file does not exist"):
+        validate_file_path("/nonexistent/rulebook.yml", "Rulebook file")
+
+
+def test_validate_file_path_oserror(tmp_path, monkeypatch):
+    """Test validate_file_path handles OSError during path resolution."""
+    test_file = tmp_path / "test_file.txt"
+    test_file.write_text("test content")
+
+    # Mock Path.resolve to raise OSError
+    from pathlib import Path
+
+    original_resolve = Path.resolve
+
+    def mock_resolve(self, strict=False):
+        if str(self) == str(test_file):
+            raise OSError("Permission denied")
+        return original_resolve(self, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", mock_resolve)
+
+    with pytest.raises(ValueError, match="Invalid test file path"):
+        validate_file_path(str(test_file), "Test file")


### PR DESCRIPTION
## Summary
- Introduces back pressure management (`BackPressureManager`) to prevent system overload when actions or reporting queues reach capacity
- Adds `SharedJobMonitor` as an instance on `JobTemplateRunner` that batches controller API polling via `id__in` queries, with configurable chunk size (`max_batch_job_polling_size`, default 25)
- Concurrent actions are capped with a configurable semaphore (`DEFAULT_MAX_CONCURRENT_ACTIONS=50`) that is always created since per-ruleset `execution_strategy: parallel` can override the global default
- Adds `_get_page_no_retry` for polling operations to avoid thundering herd on transient controller errors
- Fixes `RetryClient.closed` AttributeError in `close_session()`
- All settings support CLI args and env var overrides (`EDA_MAX_CONCURRENT_ACTIONS`, `EDA_MAX_BACK_PRESSURE_TIMEOUT`, `EDA_MAX_REPORTING_QUEUE_SIZE`, `EDA_MAX_BATCH_JOB_POLLING_SIZE`, `EDA_MAX_ACTIONS_TIMEOUT`)

## New settings
| CLI arg | Env var | Default | Description |
|---------|---------|---------|-------------|
| `--max-concurrent-actions` | `EDA_MAX_CONCURRENT_ACTIONS` | 25 (parallel) | Max concurrent actions for parallel strategy |
| `--max-back-pressure-timeout` | `EDA_MAX_BACK_PRESSURE_TIMEOUT` | 3600 | Seconds to wait before aborting |
| `--max-reporting-queue-size` | `EDA_MAX_REPORTING_QUEUE_SIZE` | 50 | Max audit event backlog |
| `--max-batch-job-polling-size` | `EDA_MAX_BATCH_JOB_POLLING_SIZE` | 25 | Max jobs per batch poll API call |

## Test plan
- [ ] Run `pytest tests/test_controller.py` — all tests pass with batch polling mocks
- [ ] Run `pytest tests/test_shared_job_monitor.py` — shared monitor tests with chunking, fallback, gateway paths
- [ ] Run `pytest tests/unit/test_back_pressure.py` — back pressure timeout and release scenarios
- [ ] Run `pytest tests/unit/test_conf.py` — settings initialization, env var overrides, type conversion
- [ ] Run `pytest tests/test_examples.py` — existing tests unaffected (monitor_job is patched)
- [ ] Manual test with `execution_strategy: parallel` in rulebook and concurrent job templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment variable configuration for operational limits: concurrent actions, back pressure timeouts, reporting queue sizes, and batch job polling.
  * Introduced back pressure management to automatically throttle event processing based on system capacity.
  * Implemented batch job polling for more efficient concurrent job monitoring.

* **Improvements**
  * Enhanced controller API resilience with configurable retry logic and exponential backoff.
  * Improved job/workflow completion logging with status-specific message levels.
  * Refined WebSocket shutdown handling with timeout protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->