### PR TITLE
chore: add fastavro python package for kafka

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN "${PIP_BIN}" install -U pip \
     azure-servicebus \
     jmespath \
     watchdog \
+    fastavro \
     && ansible-galaxy collection install ansible.eda
 
 RUN bash -c "if [ $DEVEL_COLLECTION_LIBRARY -ne 0 ]; then \


### PR DESCRIPTION
Now that we support AVRO we need to add fastavro when building an image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to include an additional Python package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->