### PR TITLE
fix: catch TimeoutError before OSError in websocket connect retry loop

### DIFF
--- a/ansible_rulebook/websocket.py
+++ b/ansible_rulebook/websocket.py
@@ -121,6 +121,15 @@ async def _connect_websocket(
             else:
                 logger.warning(f"websocket aborted by InvalidStatus: {e}")
                 raise  # abort
+        except asyncio.exceptions.TimeoutError as e:
+            # TimeoutError is a subclass of OSError; catch it first so the
+            # OSError handler below does not swallow handshake timeouts and
+            # prevent the retry logic from running.
+            if retry_on_close:
+                backoff_delay = await _wait_before_retry(backoff_delay)
+            else:
+                logger.warning(f"websocket aborted by {type(e)}: {e}")
+                raise
         except OSError as e:
             if "[Errno 61]" in str(e):
                 # if connection cannot be established, retry later
@@ -149,10 +158,7 @@ async def _connect_websocket(
             else:
                 logger.warning(f"websocket closed by ConnectionClosedOK: {e}")
                 raise
-        except (
-            websockets.exceptions.InvalidMessage,
-            asyncio.exceptions.TimeoutError,
-        ) as e:
+        except websockets.exceptions.InvalidMessage as e:
             if retry_on_close:
                 backoff_delay = await _wait_before_retry(backoff_delay)
             else:


### PR DESCRIPTION
TimeoutError is a subclass of OSError in Python's exception hierarchy. The OSError handler was catching handshake timeouts first and re-raising them (no [Errno 61] match), making the TimeoutError retry branch unreachable. This caused a single transient handshake timeout to abort an activation instead of retrying with backoff.

Fix by catching asyncio.exceptions.TimeoutError explicitly before OSError. InvalidMessage is also split out of the combined tuple for clarity.

https://redhat.atlassian.net/browse/AAP-82022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved websocket connection handling so timeouts are treated separately from other connection errors.
  * Retry and backoff behavior now works more reliably when websocket connections take too long to establish.
  * Prevented timeout errors from being misclassified, which helps avoid unexpected connection handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->