### PR TITLE
[AAP-82418] chore: update ansible-core version t0 2.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG SETUPTOOLS_SCM_PRETEND_VERSION
 # git repositories:
 # https://docs.ansible.com/projects/ansible/latest/collections_guide/collections_installing.html
 ARG DEVEL_COLLECTION_REPO=ansible.eda
-ARG ANSIBLE_CORE_VER=${ANSIBLE_CORE_VER:-2.16.14}
+ARG ANSIBLE_CORE_VER=${ANSIBLE_CORE_VER:-2.20.7}
 
 ENV PIP_BUILD_OPTS="--use-pep517 --disable-pip-version-check --wheel-dir /output/wheels"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG SETUPTOOLS_SCM_PRETEND_VERSION
 # git repositories:
 # https://docs.ansible.com/projects/ansible/latest/collections_guide/collections_installing.html
 ARG DEVEL_COLLECTION_REPO=ansible.eda
-ARG ANSIBLE_CORE_VER=${ANSIBLE_CORE_VER:-2.20.7}
+ARG ANSIBLE_CORE_VER=2.20.7
 
 ENV PIP_BUILD_OPTS="--use-pep517 --disable-pip-version-check --wheel-dir /output/wheels"
 

--- a/minimal-decision-environment.yml
+++ b/minimal-decision-environment.yml
@@ -17,7 +17,7 @@ dependencies:
   python:
     - ansible-rulebook
   ansible_core:
-    package_pip: ansible-core~=2.16.0
+    package_pip: ansible-core~=2.20.7
   ansible_runner:
     package_pip: ansible-runner
   system:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,8 +3,9 @@ docopt
 psutil
 requests
 ansible
-ansible-core~=2.16.0; python_version >= "3.11"
+ansible-core~=2.16.0; python_version >= "3.11" and python_version < "3.12"
 ansible-core~=2.15.0; python_version < "3.11"
+ansible-core~=2.20.0; python_version >= "3.12"
 ansible-runner
 pexpect
 jmespath

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import inspect
+import re
+import subprocess
 from unittest.mock import Mock
 
 import aiohttp
 import pytest
+from packaging.version import Version
 
 from ansible_rulebook.condition_types import Condition as Conditions
 from ansible_rulebook.rule_types import (
@@ -114,3 +117,13 @@ def create_ruleset(create_event_source, create_rule, **kwargs):
         )
 
     return _ruleset
+
+
+@pytest.fixture(scope="session")
+def ansible_core_version():
+    output = subprocess.check_output(
+        ["ansible-playbook", "--version"], text=True
+    )
+    match = re.search(r"ansible-playbook\s+(?:\[core\s+)?([0-9.]+)", output)
+    assert match, f"Could not parse ansible-core version from: {output}"
+    return Version(match.group(1))

--- a/tests/playbooks/compare_value_core_220.yml
+++ b/tests/playbooks/compare_value_core_220.yml
@@ -1,0 +1,9 @@
+---
+- name: Retrieve expected value
+  ansible.builtin.set_fact:
+    expected_value: "{{ vars_json | from_json | community.general.json_query(item.key) }}"
+
+- name: Fail the task if mismatch
+  ansible.builtin.fail:
+    msg: "{{ item.key }} mismatch {{ expected_value }} != {{ item.value }}"
+  when: expected_value != item.value

--- a/tests/playbooks/validate_args_playbook.yml
+++ b/tests/playbooks/validate_args_playbook.yml
@@ -15,6 +15,12 @@
       ansible.builtin.set_fact:
         vars_json: "{{ ansible_eda | to_json }}"
 
-    - name: Compare value
+    - name: Compare value ansible-core < 2.19
       ansible.builtin.include_tasks: compare_value.yml
       loop: "{{ my_vars | dict2items }}"
+      when: ansible_version.full is version('2.19', '<')
+
+    - name: Compare value ansible-core 2.19+
+      ansible.builtin.include_tasks: compare_value_core_220.yml
+      loop: "{{ my_vars | dict2items }}"
+      when: ansible_version.full is version('2.19', '>=')

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -541,7 +541,7 @@ async def test_run_assert_facts():
         assert event_log.get_nowait()["type"] == "EmptyEvent", "0"
         assert event_log.get_nowait()["type"] == "Action", "0.1"
         assert event_log.get_nowait()["type"] == "Job", "1.0"
-        for i in range(47):
+        for i in range(46):
             assert event_log.get_nowait()["type"] == "AnsibleEvent", f"1.{i}"
 
         event = event_log.get_nowait()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -22,6 +22,7 @@ import pytest
 import yaml
 from freezegun import freeze_time
 from jsonschema.exceptions import ValidationError
+from packaging.version import Version
 
 from ansible_rulebook.engine import run_rulesets, start_source
 from ansible_rulebook.exception import (
@@ -519,7 +520,7 @@ async def test_run_rulesets_on_hosts():
 
 
 @pytest.mark.asyncio
-async def test_run_assert_facts():
+async def test_run_assert_facts(ansible_core_version):
     ruleset_queues, event_log = load_rulebook("rules/test_set_facts.yml")
     inventory = dict(
         all=dict(hosts=dict(localhost=dict(ansible_connection="local")))
@@ -541,12 +542,21 @@ async def test_run_assert_facts():
         assert event_log.get_nowait()["type"] == "EmptyEvent", "0"
         assert event_log.get_nowait()["type"] == "Action", "0.1"
         assert event_log.get_nowait()["type"] == "Job", "1.0"
-        for i in range(46):
-            assert event_log.get_nowait()["type"] == "AnsibleEvent", f"1.{i}"
 
-        event = event_log.get_nowait()
-        assert event["type"] == "Action", "2.1"
-        assert event["action"] == "run_playbook", "2.2"
+        native_types = ansible_core_version >= Version("2.19")
+        allowed_types = (
+            ("AnsibleEvent", "Action") if native_types else ("AnsibleEvent",)
+        )
+        while True:
+            event = event_log.get_nowait()
+            if (
+                event["type"] == "Action"
+                and event.get("action") == "run_playbook"
+            ):
+                break
+            assert (
+                event["type"] in allowed_types
+            ), f"unexpected event type: {event['type']}"
         assert event["rc"] == 0, "2.3"
         assert event["status"] == "successful", "2.4"
         assert event_log.get_nowait()["type"] == "Shutdown", "4"


### PR DESCRIPTION
Bumps ansible-core version to 2.20.  This is needed because after https://github.com/ansible-automation-platform/de-minimal-container/pull/2791 merges tests will likely start the fail without this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded the bundled Ansible Core version used in builds to **2.20.7**.
  * Updated the minimal decision environment to use **Ansible Core 2.20.7**.
  * Refined Ansible Core version selection for tests so **2.20.7** is chosen for **Python 3.12+**, with non-overlapping constraints for other Python versions.
* **Tests**
  * Updated an engine test to expect **“Action”** event types in the event log.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->