### PR TITLE
chore: group github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
       - "/.github/actions/*/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        group-by: dependency-name


### PR DESCRIPTION
This should hopefully avoid many PRs for the same dependency update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Grouped GitHub Actions dependency updates to simplify update management and make related changes easier to review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->