### PR TITLE
fix: add ENV HOME=/app for OCP arbitrary UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,7 @@ RUN microdnf update --setopt=install_weak_deps=0 -y && \
 # support random uid number and gid 0 for openshift
 RUN useradd --uid "$USER_ID" --gid 0 --create-home --key HOME_MODE=0770 --home-dir /app appuser && \
     chmod -R g+w /app
+ENV HOME=/app
 
 # Copy all the artifacts from the build phase
 COPY --from=builder /output /tmp/output


### PR DESCRIPTION
When CRI-O injects an arbitrary UID into /etc/passwd with HOME set to /, it causes permission denied because the collections dir fall back to /.ansible which is not writable. We need to explicitly set HOME to /app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime environment consistency by setting the application home directory explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->