### PR TITLE
chore: add additional azure packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ psycopg
 psycopg-c
 watchdog>=5.0.0
 xxhash
+azure-eventhub-checkpointstoreblob-aio
+azure-identity
 EOF
 
 # Build the wheels for the collection


### PR DESCRIPTION
For Azure Service Bus and Azure Event Hub we need extra packages

* azure-eventhub-checkpointstoreblob-aio
* azure-identity

Related to
https://github.com/ansible-collections/azure/pull/2313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure Event Hub checkpoint storage and identity authentication dependencies during application builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->