### PR TITLE
feat: add OAuth2 token validation support to webhook event source

### DIFF
--- a/ansible_rulebook/collection.py
+++ b/ansible_rulebook/collection.py
@@ -60,6 +60,7 @@ LEGACY_SOURCE_MAPPING = {
     "ansible.eda.pg_listener": "eda.builtin.pg_listener",
     "ansible.eda.generic": "eda.builtin.generic",
     "ansible.eda.range": "eda.builtin.range",
+    "ansible.eda.webhook": "eda.builtin.webhook",
 }
 
 logger = logging.getLogger(__name__)

--- a/ansible_rulebook/event_source/webhook.py
+++ b/ansible_rulebook/event_source/webhook.py
@@ -7,9 +7,13 @@ import hmac
 import json
 import logging
 import ssl
+import time
 import typing
+from dataclasses import dataclass, field
 from typing import Any
 
+import aiohttp
+import jwt
 from aiohttp import web
 
 DOCUMENTATION = r"""
@@ -83,6 +87,28 @@ options:
     type: str
     default: "hex"
     choices: ["hex", "base64"]
+  oauth_introspection_url:
+    description:
+      - The token introspection endpoint (RFC 7662) for validating
+        OAuth2 access tokens using the client credentials grant type.
+    type: str
+  oauth_client_id:
+    description:
+      - The client id for the OAuth2 client credentials grant type.
+    type: str
+  oauth_client_secret:
+    description:
+      - The client secret for the OAuth2 client credentials grant type.
+    type: str
+  oauth_jwks_url:
+    description:
+      - The JWKS endpoint (RFC 9068, RFC 7517) for validating
+        OAuth2 JWT access tokens using local signature verification.
+    type: str
+  oauth_audience:
+    description:
+      - The audience for OAuth2 JWT, if present the audience will be checked
+    type: str
 """
 
 EXAMPLES = r"""
@@ -93,7 +119,23 @@ EXAMPLES = r"""
     hmac_algo: "sha256"
     hmac_header: "x-hub-signature-256"
     hmac_format: "base64"
+- eda.builtin.webhook:
+    port: 6666
+    host: 0.0.0.0
+    oauth_introspection_url: https://your_oauth_server/
+    oauth_client_id: my_client_id
+    oauth_client_secret: "secret"
+- eda.builtin.webhook:
+    port: 6666
+    host: 0.0.0.0
+    oauth_jwks_url: https://your_oauth_server/
+    oauth_audience: "my_audience"
 """
+
+
+class AuthenticationFailed(Exception):
+    pass
+
 
 if typing.TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -105,9 +147,151 @@ routes = web.RouteTableDef()
 queue_key = web.AppKey("queue", asyncio.Queue[Any])
 token_key = web.AppKey("token", str)
 hmac_secret_key = web.AppKey("hmac_secret", bytes)
+oauth_instance_key = web.AppKey("oauth_instance", Any)
 hmac_algo_key = web.AppKey("hmac_algo", str)
 hmac_header_key = web.AppKey("hmac_header", str)
 hmac_format_key = web.AppKey("hmac_format", str)
+
+
+JWKS_CACHE_TTL = 300
+JWKS_MIN_REFRESH_INTERVAL = 5
+
+
+@dataclass
+class Oauth2JwtAuthentication:
+    """OAuth2 JWT Authentication."""
+
+    jwks_url: str
+    audience: typing.Optional[str]
+    _jwks_cache: dict | None = field(default=None, repr=False)
+    _jwks_cache_time: float = field(default=0.0, repr=False)
+    _jwks_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+
+    def _cache_expired(self) -> bool:
+        return (
+            self._jwks_cache is None
+            or (time.monotonic() - self._jwks_cache_time) >= JWKS_CACHE_TTL
+        )
+
+    async def _get_signing_key_async(self, kid: str):
+        if self._cache_expired():
+            await self._locked_refresh()
+
+        key = self._find_key(kid)
+        if key is not None:
+            return key
+
+        await self._locked_refresh()
+        key = self._find_key(kid)
+        if key is not None:
+            return key
+
+        raise AuthenticationFailed(f"Unable to find key with kid: {kid}")
+
+    def _find_key(self, kid: str):
+        for key_data in (self._jwks_cache or {}).get("keys", []):
+            if key_data.get("kid") == kid:
+                return jwt.PyJWK.from_dict(key_data).key
+        return None
+
+    async def _locked_refresh(self):
+        async with self._jwks_lock:
+            if (
+                not self._cache_expired()
+                and (time.monotonic() - self._jwks_cache_time)
+                < JWKS_MIN_REFRESH_INTERVAL
+            ):
+                return
+            await self._refresh_jwks()
+
+    async def _refresh_jwks(self):
+        timeout = aiohttp.ClientTimeout(total=10)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(self.jwks_url) as response:
+                    response.raise_for_status()
+                    self._jwks_cache = await response.json()
+                    self._jwks_cache_time = time.monotonic()
+        except aiohttp.ClientResponseError as err:
+            logger.error(
+                "JWKS fetch HTTP error %s: %s", err.status, err.message
+            )
+            raise AuthenticationFailed(err.message) from err
+        except aiohttp.ClientError as err:
+            logger.error("JWKS fetch failed: %s", err)
+            raise AuthenticationFailed(str(err)) from err
+
+    async def authenticate(self, token: str):
+        """Handle OAuth2 JWT authentication."""
+        try:
+            header = jwt.get_unverified_header(token)
+            kid = header.get("kid")
+            if not kid:
+                raise AuthenticationFailed("JWT header missing kid")
+
+            signing_key = await self._get_signing_key_async(kid)
+
+            options = {
+                "verify_signature": True,
+                "verify_exp": True,
+                "verify_nbf": True,
+                "verify_iat": True,
+                "verify_aud": bool(self.audience),
+            }
+
+            jwt.decode(
+                token,
+                signing_key,
+                algorithms=["RS256"],
+                audience=self.audience,
+                options=options,
+            )
+        except AuthenticationFailed:
+            raise
+        except jwt.exceptions.PyJWTError as err:
+            message = f"JWT error: {err}"
+            logger.warning(message)
+            raise AuthenticationFailed(message) from err
+
+
+@dataclass
+class Oauth2Authentication:
+    """OAuth2 Authentication."""
+
+    introspection_url: str
+    client_id: str
+    client_secret: str
+
+    async def authenticate(self, token: str):
+        """Handle OAuth2 authentication."""
+        data = {
+            "token": token,
+            "token_type_hint": "access_token",
+        }
+        credentials = base64.b64encode(
+            (self.client_id + ":" + self.client_secret).encode()
+        ).decode()
+        timeout = aiohttp.ClientTimeout(total=120)
+        headers = {"Authorization": f"Basic {credentials}"}
+        async with aiohttp.ClientSession(
+            headers=headers, timeout=timeout
+        ) as session:
+            try:
+                async with session.post(
+                    self.introspection_url, data=data
+                ) as response:
+                    response.raise_for_status()
+                    response_data = await response.json()
+                    if not response_data.get("active", False):
+                        message = "User is not active"
+                        logger.warning(message)
+                        raise AuthenticationFailed(message)
+            except aiohttp.ClientResponseError as err:
+                logger.error(f"HTTP Error {err.status}: {err.message}")
+                raise AuthenticationFailed(err.message)
+            except aiohttp.ClientError as err:
+                logger.error(f"Network Failure {err}")
+                raise AuthenticationFailed(str(err))
 
 
 @routes.post(r"/{endpoint:.*}")
@@ -206,6 +390,28 @@ async def hmac_verify(
     return await handler(request)
 
 
+@web.middleware
+async def verify_oauth(
+    request: web.Request,
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+) -> web.StreamResponse:
+    """Verify event's OAuth signature."""
+
+    if "Authorization" not in request.headers:
+        raise web.HTTPUnauthorized()
+
+    parts = request.headers["Authorization"].strip().split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise web.HTTPUnauthorized()
+
+    try:
+        await request.app[oauth_instance_key].authenticate(parts[1])
+    except AuthenticationFailed:
+        raise web.HTTPUnauthorized() from None
+
+    return await handler(request)
+
+
 def _get_ssl_context(args: dict[str, Any]) -> ssl.SSLContext | None:
     context = None
     if "certfile" in args:
@@ -250,6 +456,37 @@ async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:
         middlewares.append(bearer_auth)
         app_attrs["token"] = args["token"]
 
+    if args.get("oauth_introspection_url") and args.get("oauth_jwks_url"):
+        raise ValueError(
+            "oauth_introspection_url and oauth_jwks_url are mutually "
+            "exclusive; configure only one OAuth2 mode"
+        )
+
+    if args.get("oauth_introspection_url"):
+        middlewares.append(verify_oauth)
+        missing = [
+            name
+            for name in ("oauth_client_id", "oauth_client_secret")
+            if not args.get(name)
+        ]
+        if missing:
+            raise ValueError(
+                "Unsupported OAuth2 configuration missing "
+                + " and ".join(missing)
+            )
+        app_attrs["oauth_instance"] = Oauth2Authentication(
+            introspection_url=args["oauth_introspection_url"],
+            client_id=args["oauth_client_id"],
+            client_secret=args["oauth_client_secret"],
+        )
+
+    elif args.get("oauth_jwks_url"):
+        middlewares.append(verify_oauth)
+        app_attrs["oauth_instance"] = Oauth2JwtAuthentication(
+            jwks_url=args["oauth_jwks_url"],
+            audience=args.get("oauth_audience"),
+        )
+
     if "hmac_secret" in args:
         middlewares.append(hmac_verify)
 
@@ -279,6 +516,8 @@ async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:
         app[hmac_header_key] = app_attrs["hmac_header"]
     if "hmac_format" in app_attrs:
         app[hmac_format_key] = app_attrs["hmac_format"]
+    if "oauth_instance" in app_attrs:
+        app[oauth_instance_key] = app_attrs["oauth_instance"]
 
     app[queue_key] = queue
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
 	drools_jpy == 0.4.1
 	watchdog >=3,<7
 	xxhash >=3,<4
+	PyJWT[crypto] >=2,<3
     pyyaml >=6,<7
     psycopg[binary] >=3,<4
 

--- a/tests/event_source/test_webhook_oauth.py
+++ b/tests/event_source/test_webhook_oauth.py
@@ -1,0 +1,892 @@
+import asyncio
+import json
+import time
+from http import HTTPStatus
+from typing import Any, Optional
+from unittest.mock import patch
+
+import aiohttp
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from ansible_rulebook.event_source.webhook import (
+    AuthenticationFailed,
+    Oauth2Authentication,
+    Oauth2JwtAuthentication,
+    main as webhook_main,
+)
+
+
+async def wait_for_server(
+    host: str,
+    port: int,
+    timeout: float = 5.0,
+    check_interval: float = 0.1,
+) -> None:
+    start_time = asyncio.get_event_loop().time()
+    while True:
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(host, port), timeout=0.5
+            )
+            writer.close()
+            await writer.wait_closed()
+            return
+        except (OSError, asyncio.TimeoutError):
+            pass
+
+        elapsed = asyncio.get_event_loop().time() - start_time
+        if elapsed >= timeout:
+            raise TimeoutError(
+                "Server at "
+                + host
+                + ":"
+                + str(port)
+                + " did not become ready within "
+                + str(timeout)
+                + "s"
+            )
+        await asyncio.sleep(check_interval)
+
+
+async def start_server(
+    queue: asyncio.Queue[Any], args: dict[str, Any]
+) -> None:
+    await webhook_main(queue, args)
+
+
+async def assert_post(
+    server_task: asyncio.Task[None],
+    info: dict[str, Any],
+    expected_status: HTTPStatus = HTTPStatus.OK,
+    expected_text: Optional[str] = None,
+) -> None:
+    host = info["host"]
+    endpoint = info["endpoint"]
+    url = "http://" + host + "/" + endpoint
+    payload = info["payload"]
+    headers = {}
+
+    if "token" in info:
+        headers["Authorization"] = f"Bearer {info['token']}"
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=payload, headers=headers) as resp:
+            server_task.cancel()
+            assert resp.status == expected_status
+            if expected_text:
+                assert expected_text in await resp.text()
+
+
+# ---------------------------------------------------------------------------
+# RSA key helpers for JWT tests
+# ---------------------------------------------------------------------------
+
+
+def _generate_rsa_keypair():
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048
+    )
+    return private_key
+
+
+def _jwk_from_public_key(public_key, kid="test-key-1"):
+    from jwt.algorithms import RSAAlgorithm
+
+    jwk_dict = json.loads(RSAAlgorithm.to_jwk(public_key))
+    jwk_dict["kid"] = kid
+    jwk_dict["use"] = "sig"
+    jwk_dict["alg"] = "RS256"
+    return jwk_dict
+
+
+def _make_jwt(private_key, kid="test-key-1", claims=None, headers=None):
+    payload = {"sub": "testuser", "exp": 9999999999, "iat": 1000000000}
+    if claims:
+        payload.update(claims)
+    extra_headers = {"kid": kid}
+    if headers:
+        extra_headers.update(headers)
+    return jwt.encode(
+        payload, private_key, algorithm="RS256", headers=extra_headers
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mock OAuth2 introspection server
+# ---------------------------------------------------------------------------
+
+
+async def _run_mock_introspection_server(port, responses):
+    from aiohttp import web
+
+    async def introspect(request):
+        data = await request.post()
+        token = data.get("token", "")
+        if token in responses:
+            return web.json_response(responses[token])
+        return web.json_response({"active": False})
+
+    app = web.Application()
+    app.router.add_post("/introspect", introspect)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", port)
+    await site.start()
+    try:
+        await asyncio.Future()
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await runner.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Mock JWKS server
+# ---------------------------------------------------------------------------
+
+
+async def _run_mock_jwks_server(port, jwks_data):
+    from aiohttp import web
+
+    async def jwks_endpoint(request):
+        return web.json_response(jwks_data)
+
+    app = web.Application()
+    app.router.add_get("/jwks", jwks_endpoint)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", port)
+    await site.start()
+    try:
+        await asyncio.Future()
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await runner.cleanup()
+
+
+# ===================================================================
+# OAuth2 Introspection tests
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_valid_token() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9100
+    webhook_port = 8200
+
+    mock_task = asyncio.create_task(
+        _run_mock_introspection_server(
+            mock_port,
+            {"valid-token-123": {"active": True, "username": "testuser"}},
+        )
+    )
+    await wait_for_server("localhost", mock_port)
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_introspection_url": (
+            "http://localhost:" + str(mock_port) + "/introspect"
+        ),
+        "oauth_client_id": "my_client",
+        "oauth_client_secret": "my_secret",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    task_info = {
+        "payload": {"src_path": "https://example.com/payload"},
+        "endpoint": "test",
+        "host": "localhost:" + str(webhook_port),
+        "token": "valid-token-123",
+    }
+    post_task = asyncio.create_task(assert_post(plugin_task, task_info))
+    await post_task
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+    data = await queue.get()
+    assert data["payload"] == task_info["payload"]
+    assert data["meta"]["endpoint"] == task_info["endpoint"]
+    assert "Authorization" not in data["meta"]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_inactive_token() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9101
+    webhook_port = 8201
+
+    mock_task = asyncio.create_task(
+        _run_mock_introspection_server(
+            mock_port,
+            {"valid-token-123": {"active": True}},
+        )
+    )
+    await wait_for_server("localhost", mock_port)
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_introspection_url": (
+            "http://localhost:" + str(mock_port) + "/introspect"
+        ),
+        "oauth_client_id": "my_client",
+        "oauth_client_secret": "my_secret",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    task_info = {
+        "payload": {"src_path": "https://example.com/payload"},
+        "endpoint": "test",
+        "host": "localhost:" + str(webhook_port),
+        "token": "unknown-token",
+    }
+    post_task = asyncio.create_task(
+        assert_post(plugin_task, task_info, HTTPStatus.UNAUTHORIZED)
+    )
+    await post_task
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_missing_auth_header() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9102
+    webhook_port = 8202
+
+    mock_task = asyncio.create_task(
+        _run_mock_introspection_server(mock_port, {})
+    )
+    await wait_for_server("localhost", mock_port)
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_introspection_url": (
+            "http://localhost:" + str(mock_port) + "/introspect"
+        ),
+        "oauth_client_id": "my_client",
+        "oauth_client_secret": "my_secret",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    url = "http://localhost:" + str(webhook_port) + "/test"
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json={"test": 1}) as resp:
+            plugin_task.cancel()
+            assert resp.status == HTTPStatus.UNAUTHORIZED
+
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_non_bearer_scheme() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9103
+    webhook_port = 8203
+
+    mock_task = asyncio.create_task(
+        _run_mock_introspection_server(mock_port, {})
+    )
+    await wait_for_server("localhost", mock_port)
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_introspection_url": (
+            "http://localhost:" + str(mock_port) + "/introspect"
+        ),
+        "oauth_client_id": "my_client",
+        "oauth_client_secret": "my_secret",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    url = "http://localhost:" + str(webhook_port) + "/test"
+    headers = {"Authorization": "Basic dXNlcjpwYXNz"}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            url, json={"test": 1}, headers=headers
+        ) as resp:
+            plugin_task.cancel()
+            assert resp.status == HTTPStatus.UNAUTHORIZED
+
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+
+# ===================================================================
+# OAuth2 Introspection config validation tests
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_missing_client_id() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args = {
+        "host": "localhost",
+        "port": 8204,
+        "oauth_introspection_url": "http://localhost:9999/introspect",
+        "oauth_client_secret": "my_secret",
+    }
+    with pytest.raises(ValueError, match="oauth_client_id"):
+        await webhook_main(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_missing_client_secret() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args = {
+        "host": "localhost",
+        "port": 8205,
+        "oauth_introspection_url": "http://localhost:9999/introspect",
+        "oauth_client_id": "my_client",
+    }
+    with pytest.raises(ValueError, match="oauth_client_secret"):
+        await webhook_main(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_missing_both_credentials() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args = {
+        "host": "localhost",
+        "port": 8206,
+        "oauth_introspection_url": "http://localhost:9999/introspect",
+    }
+    with pytest.raises(ValueError, match="oauth_client_id"):
+        await webhook_main(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_empty_client_id() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args = {
+        "host": "localhost",
+        "port": 8207,
+        "oauth_introspection_url": "http://localhost:9999/introspect",
+        "oauth_client_id": "",
+        "oauth_client_secret": "my_secret",
+    }
+    with pytest.raises(ValueError, match="oauth_client_id"):
+        await webhook_main(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_oauth_introspection_and_jwks_mutually_exclusive() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args = {
+        "host": "localhost",
+        "port": 8208,
+        "oauth_introspection_url": "http://localhost:9999/introspect",
+        "oauth_client_id": "my_client",
+        "oauth_client_secret": "my_secret",
+        "oauth_jwks_url": "http://localhost:9999/jwks",
+    }
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        await webhook_main(queue, args)
+
+
+# ===================================================================
+# OAuth2 JWT / JWKS tests
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_oauth_jwt_valid_token() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9110
+    webhook_port = 8210
+
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="key-1")
+    jwks_data = {"keys": [jwk]}
+
+    mock_task = asyncio.create_task(
+        _run_mock_jwks_server(mock_port, jwks_data)
+    )
+    await wait_for_server("localhost", mock_port)
+
+    token = _make_jwt(private_key, kid="key-1")
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_jwks_url": "http://localhost:" + str(mock_port) + "/jwks",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    task_info = {
+        "payload": {"src_path": "https://example.com/payload"},
+        "endpoint": "test",
+        "host": "localhost:" + str(webhook_port),
+        "token": token,
+    }
+    post_task = asyncio.create_task(assert_post(plugin_task, task_info))
+    await post_task
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+    data = await queue.get()
+    assert data["payload"] == task_info["payload"]
+    assert data["meta"]["endpoint"] == task_info["endpoint"]
+    assert "Authorization" not in data["meta"]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_oauth_jwt_valid_token_with_audience() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9111
+    webhook_port = 8211
+
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="key-1")
+    jwks_data = {"keys": [jwk]}
+
+    mock_task = asyncio.create_task(
+        _run_mock_jwks_server(mock_port, jwks_data)
+    )
+    await wait_for_server("localhost", mock_port)
+
+    token = _make_jwt(private_key, kid="key-1", claims={"aud": "my_audience"})
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_jwks_url": "http://localhost:" + str(mock_port) + "/jwks",
+        "oauth_audience": "my_audience",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    task_info = {
+        "payload": {"src_path": "https://example.com/payload"},
+        "endpoint": "test",
+        "host": "localhost:" + str(webhook_port),
+        "token": token,
+    }
+    post_task = asyncio.create_task(assert_post(plugin_task, task_info))
+    await post_task
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+    data = await queue.get()
+    assert data["payload"] == task_info["payload"]
+
+
+@pytest.mark.asyncio
+async def test_oauth_jwt_wrong_audience() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9112
+    webhook_port = 8212
+
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="key-1")
+    jwks_data = {"keys": [jwk]}
+
+    mock_task = asyncio.create_task(
+        _run_mock_jwks_server(mock_port, jwks_data)
+    )
+    await wait_for_server("localhost", mock_port)
+
+    token = _make_jwt(
+        private_key, kid="key-1", claims={"aud": "wrong_audience"}
+    )
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_jwks_url": "http://localhost:" + str(mock_port) + "/jwks",
+        "oauth_audience": "my_audience",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    task_info = {
+        "payload": {"src_path": "https://example.com/payload"},
+        "endpoint": "test",
+        "host": "localhost:" + str(webhook_port),
+        "token": token,
+    }
+    post_task = asyncio.create_task(
+        assert_post(plugin_task, task_info, HTTPStatus.UNAUTHORIZED)
+    )
+    await post_task
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_oauth_jwt_expired_token() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9113
+    webhook_port = 8213
+
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="key-1")
+    jwks_data = {"keys": [jwk]}
+
+    mock_task = asyncio.create_task(
+        _run_mock_jwks_server(mock_port, jwks_data)
+    )
+    await wait_for_server("localhost", mock_port)
+
+    token = _make_jwt(private_key, kid="key-1", claims={"exp": 1000000000})
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_jwks_url": "http://localhost:" + str(mock_port) + "/jwks",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    task_info = {
+        "payload": {"test": 1},
+        "endpoint": "test",
+        "host": "localhost:" + str(webhook_port),
+        "token": token,
+    }
+    post_task = asyncio.create_task(
+        assert_post(plugin_task, task_info, HTTPStatus.UNAUTHORIZED)
+    )
+    await post_task
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_oauth_jwt_unknown_kid() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9114
+    webhook_port = 8214
+
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="key-1")
+    jwks_data = {"keys": [jwk]}
+
+    mock_task = asyncio.create_task(
+        _run_mock_jwks_server(mock_port, jwks_data)
+    )
+    await wait_for_server("localhost", mock_port)
+
+    token = _make_jwt(private_key, kid="unknown-key")
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_jwks_url": "http://localhost:" + str(mock_port) + "/jwks",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    task_info = {
+        "payload": {"test": 1},
+        "endpoint": "test",
+        "host": "localhost:" + str(webhook_port),
+        "token": token,
+    }
+    post_task = asyncio.create_task(
+        assert_post(plugin_task, task_info, HTTPStatus.UNAUTHORIZED)
+    )
+    await post_task
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_oauth_jwt_tampered_token() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    mock_port = 9115
+    webhook_port = 8215
+
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="key-1")
+    jwks_data = {"keys": [jwk]}
+
+    mock_task = asyncio.create_task(
+        _run_mock_jwks_server(mock_port, jwks_data)
+    )
+    await wait_for_server("localhost", mock_port)
+
+    other_key = _generate_rsa_keypair()
+    token = _make_jwt(other_key, kid="key-1")
+
+    args = {
+        "host": "localhost",
+        "port": webhook_port,
+        "oauth_jwks_url": "http://localhost:" + str(mock_port) + "/jwks",
+    }
+    plugin_task = asyncio.create_task(start_server(queue, args))
+    await wait_for_server("localhost", webhook_port)
+
+    task_info = {
+        "payload": {"test": 1},
+        "endpoint": "test",
+        "host": "localhost:" + str(webhook_port),
+        "token": token,
+    }
+    post_task = asyncio.create_task(
+        assert_post(plugin_task, task_info, HTTPStatus.UNAUTHORIZED)
+    )
+    await post_task
+    await asyncio.gather(plugin_task, return_exceptions=True)
+    mock_task.cancel()
+    await asyncio.gather(mock_task, return_exceptions=True)
+
+
+# ===================================================================
+# Unit tests for Oauth2JwtAuthentication
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_jwt_auth_missing_kid_in_header() -> None:
+    auth = Oauth2JwtAuthentication(
+        jwks_url="http://localhost:1/jwks", audience=None
+    )
+    private_key = _generate_rsa_keypair()
+    token = jwt.encode(
+        {"sub": "user", "exp": 9999999999, "iat": 1000000000},
+        private_key,
+        algorithm="RS256",
+    )
+    with pytest.raises(AuthenticationFailed, match="missing kid"):
+        await auth.authenticate(token)
+
+
+# ===================================================================
+# Unit tests for Oauth2Authentication
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_introspection_auth_network_failure() -> None:
+    auth = Oauth2Authentication(
+        introspection_url="http://localhost:1/introspect",
+        client_id="client",
+        client_secret="secret",
+    )
+    with pytest.raises(AuthenticationFailed):
+        await auth.authenticate("some-token")
+
+
+# ===================================================================
+# JWKS cache tests
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_jwks_cache_is_reused() -> None:
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="cached-key")
+    jwks_data = {"keys": [jwk]}
+
+    fetch_count = 0
+
+    async def counting_refresh(self):
+        nonlocal fetch_count
+        fetch_count += 1
+        self._jwks_cache = jwks_data
+        self._jwks_cache_time = time.monotonic()
+
+    auth = Oauth2JwtAuthentication(
+        jwks_url="http://localhost:1/jwks", audience=None
+    )
+
+    with patch.object(
+        Oauth2JwtAuthentication, "_refresh_jwks", counting_refresh
+    ):
+        token1 = _make_jwt(private_key, kid="cached-key")
+        await auth.authenticate(token1)
+        assert fetch_count == 1
+
+        token2 = _make_jwt(private_key, kid="cached-key")
+        await auth.authenticate(token2)
+        assert fetch_count == 1
+
+
+@pytest.mark.asyncio
+async def test_jwks_cache_refresh_on_kid_miss() -> None:
+    private_key1 = _generate_rsa_keypair()
+    public_key1 = private_key1.public_key()
+    jwk1 = _jwk_from_public_key(public_key1, kid="key-1")
+
+    private_key2 = _generate_rsa_keypair()
+    public_key2 = private_key2.public_key()
+    jwk2 = _jwk_from_public_key(public_key2, kid="key-2")
+
+    call_count = 0
+    jwks_versions = [{"keys": [jwk1]}, {"keys": [jwk1, jwk2]}]
+
+    async def staged_refresh(self):
+        nonlocal call_count
+        self._jwks_cache = jwks_versions[min(call_count, 1)]
+        self._jwks_cache_time = time.monotonic()
+        call_count += 1
+
+    auth = Oauth2JwtAuthentication(
+        jwks_url="http://localhost:1/jwks", audience=None
+    )
+
+    with patch.object(
+        Oauth2JwtAuthentication, "_refresh_jwks", staged_refresh
+    ):
+        token1 = _make_jwt(private_key1, kid="key-1")
+        await auth.authenticate(token1)
+        assert call_count == 1
+
+        from ansible_rulebook.event_source.webhook import (
+            JWKS_MIN_REFRESH_INTERVAL,
+        )
+
+        auth._jwks_cache_time -= JWKS_MIN_REFRESH_INTERVAL + 1
+
+        token2 = _make_jwt(private_key2, kid="key-2")
+        await auth.authenticate(token2)
+        assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_jwks_cache_expires_after_ttl() -> None:
+    from ansible_rulebook.event_source.webhook import JWKS_CACHE_TTL
+
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="ttl-key")
+    jwks_data = {"keys": [jwk]}
+
+    fetch_count = 0
+
+    async def counting_refresh(self):
+        nonlocal fetch_count
+        fetch_count += 1
+        self._jwks_cache = jwks_data
+        self._jwks_cache_time = time.monotonic()
+
+    auth = Oauth2JwtAuthentication(
+        jwks_url="http://localhost:1/jwks", audience=None
+    )
+
+    with patch.object(
+        Oauth2JwtAuthentication, "_refresh_jwks", counting_refresh
+    ):
+        token1 = _make_jwt(private_key, kid="ttl-key")
+        await auth.authenticate(token1)
+        assert fetch_count == 1
+
+        auth._jwks_cache_time -= JWKS_CACHE_TTL + 1
+
+        token2 = _make_jwt(private_key, kid="ttl-key")
+        await auth.authenticate(token2)
+        assert fetch_count == 2
+
+
+@pytest.mark.asyncio
+async def test_jwks_forced_refresh_is_throttled() -> None:
+    from ansible_rulebook.event_source.webhook import JWKS_MIN_REFRESH_INTERVAL
+
+    private_key = _generate_rsa_keypair()
+    public_key = private_key.public_key()
+    jwk = _jwk_from_public_key(public_key, kid="known-key")
+    jwks_data: dict = {"keys": [jwk]}
+
+    fetch_count = 0
+
+    async def counting_refresh(self):
+        nonlocal fetch_count
+        fetch_count += 1
+        self._jwks_cache = jwks_data
+        self._jwks_cache_time = time.monotonic()
+
+    auth = Oauth2JwtAuthentication(
+        jwks_url="http://localhost:1/jwks", audience=None
+    )
+
+    with patch.object(
+        Oauth2JwtAuthentication, "_refresh_jwks", counting_refresh
+    ):
+        token = _make_jwt(private_key, kid="known-key")
+        await auth.authenticate(token)
+        assert fetch_count == 1
+
+        for _ in range(5):
+            with pytest.raises(AuthenticationFailed, match="Unable to find"):
+                bad_token = _make_jwt(private_key, kid="bogus")
+                await auth.authenticate(bad_token)
+
+        assert fetch_count == 1
+
+        auth._jwks_cache_time -= JWKS_MIN_REFRESH_INTERVAL + 1
+
+        with pytest.raises(AuthenticationFailed, match="Unable to find"):
+            bad_token = _make_jwt(private_key, kid="bogus")
+            await auth.authenticate(bad_token)
+
+        assert fetch_count == 2
+
+
+@pytest.mark.asyncio
+async def test_jwks_fetch_network_error() -> None:
+    auth = Oauth2JwtAuthentication(
+        jwks_url="http://localhost:1/jwks", audience=None
+    )
+    private_key = _generate_rsa_keypair()
+    token = _make_jwt(private_key, kid="net-err")
+    with pytest.raises(AuthenticationFailed):
+        await auth.authenticate(token)
+
+
+@pytest.mark.asyncio
+async def test_jwks_fetch_http_error() -> None:
+    from aiohttp import web as aio_web
+
+    app = aio_web.Application()
+
+    async def jwks_handler(request):
+        return aio_web.Response(status=500, text="internal error")
+
+    app.router.add_get("/jwks", jwks_handler)
+
+    runner = aio_web.AppRunner(app)
+    await runner.setup()
+    site = aio_web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+
+    jwks_url = "http://127.0.0.1:" + str(port) + "/jwks"
+    auth = Oauth2JwtAuthentication(jwks_url=jwks_url, audience=None)
+
+    try:
+        private_key = _generate_rsa_keypair()
+        token = _make_jwt(private_key, kid="http-err")
+        with pytest.raises(AuthenticationFailed):
+            await auth.authenticate(token)
+    finally:
+        await runner.cleanup()


### PR DESCRIPTION
  Add two OAuth2 authentication modes for the webhook plugin:
  - Classic OAuth2 via token introspection (RFC 7662)
  - OAuth2 with JWT validation using JWKS key discovery (RFC 9068, RFC 7517)

  Includes JWKS key caching with automatic refresh on kid miss,
  robust Authorization header parsing, and PyJWT[crypto] as a
  hard dependency. Adds comprehensive tests covering both auth
  flows, config validation, token expiry, audience checks,
  tampered tokens, and cache behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth2 authentication for webhook requests through token introspection or JWT validation.
  * Added JWKS-based key validation with caching and automatic refresh.
  * Added configuration documentation and usage examples.

* **Bug Fixes**
  * Unauthorized requests now return HTTP 401 responses.
  * Improved handling of invalid, expired, or tampered tokens and invalid OAuth settings.

* **Compatibility**
  * Preserved support for the legacy webhook source name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->